### PR TITLE
feat: add custom dropdown picker for bar modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,43 @@ Scroll events are debounced (50ms) so rapid scrolling doesn't fire dozens of
 commands. Set `interval-ms = 0` if you only want updates from `on-action` (no
 polling at all).
 
+Click actions can also open dropdowns. Use `"dropdown:<name>"` for built-in
+dropdowns (audio, battery, etc.) or `"dropdown:custom:<name>"` for custom
+dropdowns defined in `[dropdowns.custom.<name>]`:
+
+```toml
+[[modules.custom]]
+id = "scale"
+command = "hypr-scale.sh get"
+interval-ms = 5000
+format = "{{ text }}"
+icon-name = "ld-monitor-symbolic"
+left-click = "dropdown:custom:scale"
+on-action = "hypr-scale.sh get"
+
+[dropdowns.custom.scale]
+title = "Display Scale"
+icon = "ld-monitor-symbolic"
+width = 340
+
+[[dropdowns.custom.scale.sections]]
+type = "picker"
+list-command = "hypr-scale.sh list --json"
+select-command = 'hypr-scale.sh set "$WAYLE_SELECTED"'
+```
+
+The `list-command` outputs one item per line — either plain text or JSON:
+
+```json
+{"value": "1.5", "label": "1.5x", "subtitle": "140 DPI", "active": true}
+```
+
+JSON fields: `value` (selection key), `label`, `subtitle`, `icon`, `active`
+(shows checkmark). Plain text lines use the text as both value and label.
+
+The `select-command` receives the chosen value via `$WAYLE_SELECTED`. After
+selection the dropdown closes and `on-action` runs to refresh the bar label.
+
 ### JSON Reserved Fields
 
 When outputting JSON, these fields have special meaning:
@@ -387,14 +424,14 @@ All other fields are available in `format` and `tooltip-format` templates.
 
 #### Actions
 
-| Field          | Type   | Default | Description                                   |
-| -------------- | ------ | ------- | --------------------------------------------- |
-| `left-click`   | string | `""`    | Command on left click                         |
-| `right-click`  | string | `""`    | Command on right click                        |
-| `middle-click` | string | `""`    | Command on middle click                       |
-| `scroll-up`    | string | `""`    | Command on scroll up (50ms debounce)          |
-| `scroll-down`  | string | `""`    | Command on scroll down (50ms debounce)        |
-| `on-action`    | string | none    | Runs after any action, output updates display |
+| Field          | Type   | Default | Description                                                        |
+| -------------- | ------ | ------- | ------------------------------------------------------------------ |
+| `left-click`   | string | `""`    | Shell command, `"dropdown:<name>"`, or `"dropdown:custom:<name>"`  |
+| `right-click`  | string | `""`    | Shell command, `"dropdown:<name>"`, or `"dropdown:custom:<name>"`  |
+| `middle-click` | string | `""`    | Shell command, `"dropdown:<name>"`, or `"dropdown:custom:<name>"`  |
+| `scroll-up`    | string | `""`    | Shell command or dropdown action (50ms debounce)                   |
+| `scroll-down`  | string | `""`    | Shell command or dropdown action (50ms debounce)                   |
+| `on-action`    | string | none    | Runs after shell actions or dropdown close, output updates display |
 
 Color values: `"auto"`, hex (`"#ff0000"`), or theme token (`"red"`, `"primary"`,
 etc.).

--- a/crates/wayle-config/src/lib.rs
+++ b/crates/wayle-config/src/lib.rs
@@ -23,6 +23,8 @@ pub use property::{
 pub mod schemas {
     /// Bar layout configuration.
     pub mod bar;
+    /// Custom dropdown configurations.
+    pub mod dropdowns;
     /// General Wayle configuration.
     pub mod general;
     /// Module-specific configurations.
@@ -69,8 +71,8 @@ pub use infrastructure::{
     watcher::FileWatcher,
 };
 use schemas::{
-    bar::BarConfig, modules::ModulesConfig, osd::OsdConfig, styling::StylingConfig,
-    wallpaper::WallpaperConfig,
+    bar::BarConfig, dropdowns::DropdownsConfig, modules::ModulesConfig, osd::OsdConfig,
+    styling::StylingConfig, wallpaper::WallpaperConfig,
 };
 use wayle_derive::wayle_config;
 
@@ -93,6 +95,10 @@ pub struct Config {
     #[wayle(skip)]
     #[serde(default)]
     pub imports: Vec<String>,
+
+    /// Custom dropdown panel definitions.
+    #[default(DropdownsConfig::default())]
+    pub dropdowns: ConfigProperty<DropdownsConfig>,
 
     /// General Wayle settings.
     pub general: GeneralConfig,

--- a/crates/wayle-config/src/schemas/dropdowns/custom.rs
+++ b/crates/wayle-config/src/schemas/dropdowns/custom.rs
@@ -1,0 +1,90 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Definition of a custom dropdown panel with composable sections.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct CustomDropdownDefinition {
+    /// Optional title displayed in the dropdown header.
+    #[serde(default)]
+    pub title: Option<String>,
+
+    /// Optional icon name for the dropdown header.
+    #[serde(default)]
+    pub icon: Option<String>,
+
+    /// Base width in pixels (scaled by bar scale factor).
+    #[serde(default = "default_width")]
+    pub width: f32,
+
+    /// Composable sections that make up the dropdown content.
+    #[serde(default)]
+    pub sections: Vec<SectionDefinition>,
+}
+
+/// A section within a custom dropdown.
+///
+/// The `section_type` field discriminates which other fields are relevant.
+/// Fields for inactive section types are ignored at runtime.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct SectionDefinition {
+    /// The type of section to render.
+    #[serde(rename = "type")]
+    pub section_type: SectionType,
+
+    /// Shell command that outputs the list of selectable items.
+    /// Used when `type = "picker"`.
+    ///
+    /// The command should output either:
+    /// - Plain text (one item per line)
+    /// - JSON lines: `{"value": "...", "label": "...", "subtitle": "...", "icon": "...", "active": true}`
+    #[serde(default)]
+    pub list_command: Option<String>,
+
+    /// Shell command to run when an item is selected.
+    /// Used when `type = "picker"`.
+    ///
+    /// The selected value is available as `$WAYLE_SELECTED`.
+    #[serde(default)]
+    pub select_command: Option<String>,
+}
+
+/// Available section types for custom dropdowns.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum SectionType {
+    /// List-based item picker driven by shell commands.
+    Picker,
+}
+
+/// Configuration for a picker section (extracted view of picker-specific fields).
+///
+/// This provides a typed view over the flat fields on [`SectionDefinition`]
+/// for convenience when building the picker UI.
+#[derive(Debug, Clone)]
+pub struct PickerSectionConfig {
+    /// Shell command that outputs the list of selectable items.
+    pub list_command: Option<String>,
+
+    /// Shell command to run when an item is selected.
+    pub select_command: Option<String>,
+}
+
+impl SectionDefinition {
+    /// Extract picker-specific configuration from this section.
+    ///
+    /// Returns `Some` only when `section_type` is [`SectionType::Picker`].
+    pub fn as_picker(&self) -> Option<PickerSectionConfig> {
+        match self.section_type {
+            SectionType::Picker => Some(PickerSectionConfig {
+                list_command: self.list_command.clone(),
+                select_command: self.select_command.clone(),
+            }),
+        }
+    }
+}
+
+fn default_width() -> f32 {
+    320.0
+}

--- a/crates/wayle-config/src/schemas/dropdowns/mod.rs
+++ b/crates/wayle-config/src/schemas/dropdowns/mod.rs
@@ -1,0 +1,15 @@
+mod custom;
+
+use std::collections::HashMap;
+
+pub use custom::{CustomDropdownDefinition, PickerSectionConfig, SectionDefinition, SectionType};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Configuration for dropdown panels.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct DropdownsConfig {
+    /// Custom user-defined dropdown panels.
+    #[serde(default)]
+    pub custom: HashMap<String, CustomDropdownDefinition>,
+}

--- a/crates/wayle-config/src/schemas/modules/custom/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/custom/mod.rs
@@ -6,7 +6,10 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 pub use self::types::{ExecutionMode, RestartDelay, RestartPolicy};
-use crate::schemas::styling::{ColorValue, CssToken};
+use crate::{
+    ClickAction,
+    schemas::styling::{ColorValue, CssToken},
+};
 
 /// Custom module definition for user-defined bar modules.
 ///
@@ -363,37 +366,38 @@ pub struct CustomModuleDefinition {
     #[serde(rename = "border-color", default = "default_auto_color")]
     pub border_color: ColorValue,
 
-    /// Shell command executed on left click.
+    /// Action on left click: shell command, `"dropdown:<name>"`, or empty.
     ///
-    /// If `on-action` is set, it runs after this command completes.
+    /// If `on-action` is set, it runs after shell commands complete.
+    /// Dropdown actions are handled by the dropdown registry.
     #[serde(rename = "left-click", default)]
-    pub left_click: String,
+    pub left_click: ClickAction,
 
-    /// Shell command executed on right click.
+    /// Action on right click: shell command, `"dropdown:<name>"`, or empty.
     ///
-    /// If `on-action` is set, it runs after this command completes.
+    /// If `on-action` is set, it runs after shell commands complete.
     #[serde(rename = "right-click", default)]
-    pub right_click: String,
+    pub right_click: ClickAction,
 
-    /// Shell command executed on middle click.
+    /// Action on middle click: shell command, `"dropdown:<name>"`, or empty.
     ///
-    /// If `on-action` is set, it runs after this command completes.
+    /// If `on-action` is set, it runs after shell commands complete.
     #[serde(rename = "middle-click", default)]
-    pub middle_click: String,
+    pub middle_click: ClickAction,
 
-    /// Shell command executed on scroll up.
+    /// Action on scroll up: shell command, `"dropdown:<name>"`, or empty.
     ///
     /// Scroll events are debounced (50ms) to coalesce rapid scrolls.
-    /// If `on-action` is set, it runs after this command completes.
+    /// If `on-action` is set, it runs after shell commands complete.
     #[serde(rename = "scroll-up", default)]
-    pub scroll_up: String,
+    pub scroll_up: ClickAction,
 
-    /// Shell command executed on scroll down.
+    /// Action on scroll down: shell command, `"dropdown:<name>"`, or empty.
     ///
     /// Scroll events are debounced (50ms) to coalesce rapid scrolls.
-    /// If `on-action` is set, it runs after this command completes.
+    /// If `on-action` is set, it runs after shell commands complete.
     #[serde(rename = "scroll-down", default)]
-    pub scroll_down: String,
+    pub scroll_down: ClickAction,
 
     /// Shell command to run after any click/scroll action completes.
     ///

--- a/crates/wayle-shell/src/shell/bar/dropdowns/custom/factory.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/custom/factory.rs
@@ -1,0 +1,25 @@
+use relm4::prelude::*;
+
+use super::{CustomDropdown, CustomDropdownInit};
+use crate::shell::{bar::dropdowns::DropdownInstance, services::ShellServices};
+
+/// Creates a custom dropdown from config, or `None` if the definition is missing.
+pub(crate) fn create(name: &str, services: &ShellServices) -> Option<DropdownInstance> {
+    let config = services.config.config();
+    let dropdowns = config.dropdowns.get();
+    let Some(definition) = dropdowns.custom.get(name).cloned() else {
+        tracing::warn!(name, "custom dropdown definition not found in config");
+        return None;
+    };
+
+    tracing::info!(name, "creating custom dropdown");
+
+    let init = CustomDropdownInit {
+        definition,
+        config: services.config.clone(),
+    };
+    let controller = CustomDropdown::builder().launch(init).detach();
+
+    let popover = controller.widget().clone();
+    Some(DropdownInstance::new(popover, Box::new(controller)))
+}

--- a/crates/wayle-shell/src/shell/bar/dropdowns/custom/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/custom/mod.rs
@@ -1,0 +1,113 @@
+mod factory;
+mod picker;
+
+use std::sync::Arc;
+
+use gtk::prelude::*;
+use relm4::{gtk, prelude::*};
+use wayle_config::{ConfigService, schemas::dropdowns::CustomDropdownDefinition};
+use wayle_widgets::prelude::*;
+
+pub(super) use self::factory::create;
+use self::picker::{PickerSection, PickerSectionInit};
+use super::scaled_dimension;
+
+pub(crate) struct CustomDropdown {
+    scaled_width: i32,
+    title: String,
+    icon: Option<String>,
+    _picker: Option<Controller<PickerSection>>,
+}
+
+pub(crate) struct CustomDropdownInit {
+    pub definition: CustomDropdownDefinition,
+    pub config: Arc<ConfigService>,
+}
+
+#[relm4::component(pub(crate))]
+impl Component for CustomDropdown {
+    type Init = CustomDropdownInit;
+    type Input = ();
+    type Output = ();
+    type CommandOutput = ();
+
+    view! {
+        #[root]
+        gtk::Popover {
+            set_css_classes: &["dropdown", "custom-dropdown"],
+            set_has_arrow: false,
+            #[watch]
+            set_width_request: model.scaled_width,
+
+            #[template]
+            Dropdown {
+                #[template]
+                DropdownHeader {
+                    #[template_child]
+                    icon {
+                        #[watch]
+                        set_visible: model.icon.is_some(),
+                        #[watch]
+                        set_icon_name: model.icon.as_deref(),
+                    },
+                    #[template_child]
+                    label {
+                        #[watch]
+                        set_label: &model.title,
+                    },
+                },
+
+                #[template]
+                DropdownContent {
+                    #[local_ref]
+                    picker_widget -> gtk::Box {},
+                },
+            },
+        }
+    }
+
+    fn init(
+        init: Self::Init,
+        root: Self::Root,
+        _sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let definition = init.definition;
+        let scale = init.config.config().bar.scale.get().value();
+        let scaled_width = scaled_dimension(definition.width, scale);
+
+        // Build picker section from first picker section definition.
+        let picker_config = definition.sections.iter().find_map(|s| s.as_picker());
+
+        let picker = picker_config.map(|config| {
+            PickerSection::builder()
+                .launch(PickerSectionInit { config })
+                .detach()
+        });
+
+        let picker_widget = picker
+            .as_ref()
+            .map(|p| p.widget().clone())
+            .unwrap_or_else(|| gtk::Box::new(gtk::Orientation::Vertical, 0));
+
+        let model = Self {
+            scaled_width,
+            title: definition.title.unwrap_or_default(),
+            icon: definition.icon,
+            _picker: picker,
+        };
+
+        let widgets = view_output!();
+
+        // Reload picker content each time the popover becomes visible.
+        if let Some(picker) = &model._picker {
+            let picker_sender = picker.sender().clone();
+            root.connect_notify(Some("visible"), move |popover, _| {
+                if popover.is_visible() {
+                    picker_sender.send(picker::PickerMsg::Reload).ok();
+                }
+            });
+        }
+
+        ComponentParts { model, widgets }
+    }
+}

--- a/crates/wayle-shell/src/shell/bar/dropdowns/custom/picker.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/custom/picker.rs
@@ -1,0 +1,300 @@
+use gtk::prelude::*;
+use relm4::{factory::FactoryVecDeque, gtk, prelude::*};
+use serde::Deserialize;
+use tokio::process::Command;
+use wayle_config::schemas::dropdowns::PickerSectionConfig;
+use wayle_widgets::primitives::popover::PopoverItem;
+
+/// Parsed item from the list command output.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(super) struct ListItem {
+    #[serde(default)]
+    value: Option<String>,
+    #[serde(default)]
+    label: Option<String>,
+    #[serde(default)]
+    subtitle: Option<String>,
+    #[serde(default)]
+    icon: Option<String>,
+    #[serde(default)]
+    active: bool,
+}
+
+pub(super) struct PickerSection {
+    config: PickerSectionConfig,
+    items: FactoryVecDeque<PopoverItem>,
+    /// Parsed item values, parallel to factory indices, for selection lookup.
+    values: Vec<String>,
+    load_generation: u64,
+}
+
+pub(super) struct PickerSectionInit {
+    pub config: PickerSectionConfig,
+}
+
+#[derive(Debug)]
+pub(super) enum PickerMsg {
+    /// Popover became visible — reload the list.
+    Reload,
+    /// User activated a row.
+    RowActivated(u32),
+}
+
+#[derive(Debug)]
+pub(super) enum PickerCmd {
+    /// List command completed.
+    ListLoaded {
+        items: Vec<ListItem>,
+        generation: u64,
+    },
+    /// Select command completed — refresh the list.
+    SelectDone,
+}
+
+#[relm4::component(pub(super))]
+impl Component for PickerSection {
+    type Init = PickerSectionInit;
+    type Input = PickerMsg;
+    type Output = ();
+    type CommandOutput = PickerCmd;
+
+    view! {
+        #[root]
+        gtk::Box {
+            set_orientation: gtk::Orientation::Vertical,
+            add_css_class: "custom-picker-section",
+
+            #[local_ref]
+            list_box -> gtk::ListBox {
+                add_css_class: "custom-picker-list",
+                set_selection_mode: gtk::SelectionMode::None,
+                set_activate_on_single_click: true,
+                connect_row_activated[sender] => move |_, row: &gtk::ListBoxRow| {
+                    sender.input(PickerMsg::RowActivated(row.index() as u32));
+                },
+            },
+        }
+    }
+
+    fn init(
+        init: Self::Init,
+        root: Self::Root,
+        sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let items = FactoryVecDeque::builder()
+            .launch(gtk::ListBox::default())
+            .detach();
+
+        let model = Self {
+            config: init.config,
+            items,
+            values: Vec::new(),
+            load_generation: 0,
+        };
+
+        let list_box = model.items.widget();
+
+        let widgets = view_output!();
+
+        // Pre-load items so the dropdown has content on first show.
+        sender.input(PickerMsg::Reload);
+
+        ComponentParts { model, widgets }
+    }
+
+    fn update(&mut self, msg: Self::Input, sender: ComponentSender<Self>, _root: &Self::Root) {
+        match msg {
+            PickerMsg::Reload => {
+                self.load_generation += 1;
+                let generation = self.load_generation;
+
+                if let Some(cmd) = &self.config.list_command {
+                    tracing::debug!(command = %cmd, "picker: loading list");
+                    let cmd = cmd.clone();
+                    sender.oneshot_command(async move {
+                        let items = run_list_command(&cmd).await;
+                        tracing::debug!(count = items.len(), "picker: list loaded");
+                        PickerCmd::ListLoaded { items, generation }
+                    });
+                } else {
+                    tracing::warn!("picker: no list-command configured");
+                }
+            }
+            PickerMsg::RowActivated(index) => {
+                let Some(value) = self.values.get(index as usize) else {
+                    return;
+                };
+                let value = value.clone();
+
+                if let Some(cmd) = &self.config.select_command {
+                    let cmd = cmd.clone();
+                    sender.oneshot_command(async move {
+                        run_select_command(&cmd, &value).await;
+                        PickerCmd::SelectDone
+                    });
+                }
+            }
+        }
+    }
+
+    fn update_cmd(
+        &mut self,
+        msg: Self::CommandOutput,
+        _sender: ComponentSender<Self>,
+        root: &Self::Root,
+    ) {
+        match msg {
+            PickerCmd::ListLoaded { items, generation } => {
+                // Discard stale results from previous loads.
+                if generation != self.load_generation {
+                    return;
+                }
+                self.apply_items(items);
+            }
+            PickerCmd::SelectDone => {
+                // Close the parent popover, which triggers on_next_close
+                // in the custom module to refresh the bar label.
+                if let Some(popover) = root
+                    .ancestor(gtk::Popover::static_type())
+                    .and_then(|w| w.downcast::<gtk::Popover>().ok())
+                {
+                    popover.popdown();
+                }
+            }
+        }
+    }
+}
+
+impl PickerSection {
+    fn apply_items(&mut self, items: Vec<ListItem>) {
+        let mut guard = self.items.guard();
+        guard.clear();
+        self.values.clear();
+
+        for item in items {
+            let ListItem {
+                value,
+                label,
+                subtitle,
+                icon,
+                active,
+            } = item;
+
+            let label = label.or_else(|| value.clone()).unwrap_or_default();
+            let value = value.unwrap_or_else(|| label.clone());
+
+            self.values.push(value);
+
+            guard.push_back(PopoverItem {
+                icon,
+                label,
+                subtitle,
+                active_icon: Some("tb-check-symbolic".to_string()),
+                is_active: active,
+            });
+        }
+    }
+}
+
+async fn run_list_command(command: &str) -> Vec<ListItem> {
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .kill_on_drop(true)
+        .output()
+        .await;
+
+    let Ok(output) = output else {
+        tracing::warn!(command, "custom picker list command failed");
+        return Vec::new();
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_list_output(&stdout)
+}
+
+fn parse_list_output(output: &str) -> Vec<ListItem> {
+    output
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            let trimmed = line.trim();
+            // Try JSON first.
+            if trimmed.starts_with('{')
+                && let Ok(item) = serde_json::from_str::<ListItem>(trimmed)
+            {
+                return item;
+            }
+            // Plain text fallback.
+            ListItem {
+                value: Some(trimmed.to_string()),
+                label: Some(trimmed.to_string()),
+                ..Default::default()
+            }
+        })
+        .collect()
+}
+
+async fn run_select_command(command: &str, selected: &str) {
+    let result = Command::new("sh")
+        .arg("-c")
+        .arg(command)
+        .env("WAYLE_SELECTED", selected)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .kill_on_drop(true)
+        .status()
+        .await;
+
+    if let Err(err) = result {
+        tracing::warn!(command, %err, "custom picker select command failed");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_json_lines() {
+        let output = r#"{"value": "1.0", "label": "1.0x", "subtitle": "96 DPI", "active": true}
+{"value": "1.5", "label": "1.5x", "subtitle": "64 DPI", "active": false}
+"#;
+        let items = parse_list_output(output);
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].value.as_deref(), Some("1.0"));
+        assert_eq!(items[0].label.as_deref(), Some("1.0x"));
+        assert!(items[0].active);
+        assert!(!items[1].active);
+    }
+
+    #[test]
+    fn parse_plain_text_lines() {
+        let output = "context-a\ncontext-b\ncontext-c\n";
+        let items = parse_list_output(output);
+        assert_eq!(items.len(), 3);
+        assert_eq!(items[0].value.as_deref(), Some("context-a"));
+        assert_eq!(items[0].label.as_deref(), Some("context-a"));
+        assert!(!items[0].active);
+    }
+
+    #[test]
+    fn parse_skips_empty_lines() {
+        let output = "a\n\n  \nb\n";
+        let items = parse_list_output(output);
+        assert_eq!(items.len(), 2);
+    }
+
+    #[test]
+    fn parse_mixed_json_and_text() {
+        let output = r#"{"value": "x", "label": "X", "active": true}
+plain-text-item
+"#;
+        let items = parse_list_output(output);
+        assert_eq!(items.len(), 2);
+        assert!(items[0].active);
+        assert_eq!(items[1].label.as_deref(), Some("plain-text-item"));
+    }
+}

--- a/crates/wayle-shell/src/shell/bar/dropdowns/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/mod.rs
@@ -2,6 +2,7 @@ mod audio;
 mod battery;
 mod bluetooth;
 mod calendar;
+mod custom;
 mod dashboard;
 mod media;
 mod network;
@@ -29,8 +30,12 @@ macro_rules! register_dropdowns {
             match name {
                 $($name => <$factory as DropdownFactory>::create(services),)+
                 _ => {
-                    tracing::warn!(dropdown = name, "unknown dropdown type");
-                    None
+                    if let Some(custom_name) = name.strip_prefix("custom:") {
+                        custom::create(custom_name, services)
+                    } else {
+                        tracing::warn!(dropdown = name, "unknown dropdown type");
+                        None
+                    }
                 }
             }
         }

--- a/crates/wayle-shell/src/shell/bar/dropdowns/registry.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/registry.rs
@@ -314,6 +314,30 @@ impl DropdownRegistry {
         for name in super::DROPDOWN_NAMES {
             let _ = self.get_or_create(name);
         }
+
+        // Pre-warm custom dropdowns defined in config.
+        let config = self.services.config.config();
+        let dropdowns = config.dropdowns.get();
+        for name in dropdowns.custom.keys() {
+            let key = format!("custom:{name}");
+            let _ = self.get_or_create(&key);
+        }
+    }
+
+    /// Registers a callback to run once the next time a named dropdown closes.
+    ///
+    /// Used by custom modules to refresh their bar label after a dropdown
+    /// selection changes state (e.g., scale picker updates the active scale).
+    pub(crate) fn on_next_close(&self, name: &str, callback: impl FnOnce() + 'static) {
+        let Some(instance) = self.get_or_create(name) else {
+            return;
+        };
+        let callback = Cell::new(Some(callback));
+        instance.popover.connect_closed(move |_| {
+            if let Some(cb) = callback.take() {
+                cb();
+            }
+        });
     }
 
     fn get_or_create(&self, name: &str) -> Option<Rc<DropdownInstance>> {

--- a/crates/wayle-shell/src/shell/bar/modules/custom/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/custom/helpers.rs
@@ -365,9 +365,12 @@ mod tests {
     }
 
     fn default_definition() -> CustomModuleDefinition {
-        use wayle_config::schemas::{
-            modules::{ExecutionMode, RestartDelay, RestartPolicy},
-            styling::ColorValue,
+        use wayle_config::{
+            ClickAction,
+            schemas::{
+                modules::{ExecutionMode, RestartDelay, RestartPolicy},
+                styling::ColorValue,
+            },
         };
 
         CustomModuleDefinition {
@@ -393,11 +396,11 @@ mod tests {
             button_bg_color: ColorValue::Auto,
             border_show: false,
             border_color: ColorValue::Auto,
-            left_click: String::new(),
-            right_click: String::new(),
-            middle_click: String::new(),
-            scroll_up: String::new(),
-            scroll_down: String::new(),
+            left_click: ClickAction::None,
+            right_click: ClickAction::None,
+            middle_click: ClickAction::None,
+            scroll_up: ClickAction::None,
+            scroll_down: ClickAction::None,
             on_action: None,
         }
     }

--- a/crates/wayle-shell/src/shell/bar/modules/custom/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/custom/mod.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 use gtk::prelude::*;
 use relm4::prelude::*;
 use wayle_config::{
-    ConfigProperty,
+    ClickAction, ConfigProperty,
     schemas::{
         modules::{CustomModuleDefinition, ExecutionMode},
         styling::{ColorValue, CssToken},
@@ -166,7 +166,7 @@ impl Component for CustomModule {
     fn update(&mut self, msg: Self::Input, sender: ComponentSender<Self>, _root: &Self::Root) {
         let is_scroll = matches!(msg, CustomMsg::ScrollUp | CustomMsg::ScrollDown);
 
-        let action_cmd = match msg {
+        let action = match msg {
             CustomMsg::LeftClick => &self.definition.left_click,
             CustomMsg::RightClick => &self.definition.right_click,
             CustomMsg::MiddleClick => &self.definition.middle_click,
@@ -174,8 +174,30 @@ impl Component for CustomModule {
             CustomMsg::ScrollDown => &self.definition.scroll_down,
         };
 
-        if !action_cmd.is_empty() {
-            watchers::spawn_action(action_cmd);
+        match action {
+            ClickAction::Dropdown(name) => {
+                crate::shell::bar::dropdowns::dispatch_click(
+                    action,
+                    &self.dropdowns,
+                    &self.bar_button,
+                );
+                // Schedule on_action to run when the dropdown closes,
+                // so the bar label refreshes after a selection.
+                if let Some(on_action) = &self.definition.on_action {
+                    let on_action = on_action.clone();
+                    let module_id = self.definition.id.clone();
+                    let token = self.command_token.reset();
+                    let sender = sender.clone();
+                    self.dropdowns.on_next_close(name, move || {
+                        watchers::run_command_async(&sender, &module_id, on_action, token);
+                    });
+                }
+                return;
+            }
+            ClickAction::Shell(cmd) => {
+                watchers::spawn_action(cmd);
+            }
+            ClickAction::None => return,
         }
 
         let Some(on_action) = &self.definition.on_action else {

--- a/crates/wayle-styling/scss/modules/_index.scss
+++ b/crates/wayle-styling/scss/modules/_index.scss
@@ -12,3 +12,4 @@
 @import "network_dropdown";
 @import "notification_dropdown";
 @import "weather_dropdown";
+@import "custom_dropdown";

--- a/crates/wayle-styling/scss/modules/custom_dropdown/_index.scss
+++ b/crates/wayle-styling/scss/modules/custom_dropdown/_index.scss
@@ -1,0 +1,7 @@
+@import "picker";
+
+.custom-dropdown {
+    .dropdown-content {
+        padding: var(--space-xs) 0;
+    }
+}

--- a/crates/wayle-styling/scss/modules/custom_dropdown/_picker.scss
+++ b/crates/wayle-styling/scss/modules/custom_dropdown/_picker.scss
@@ -1,0 +1,54 @@
+@import "../../primitives/popover/mixins";
+
+.custom-picker-section {
+    .custom-picker-list {
+        background: transparent;
+
+        > row {
+            padding: 0;
+            background: transparent;
+            border-radius: var(--rounding-element);
+            transition: background var(--duration-fast);
+
+            &:hover {
+                background: var(--bg-overlay);
+            }
+
+            &:focus-visible {
+                background: var(--bg-overlay);
+                outline: var(--focus-ring-width) solid var(--accent);
+                outline-offset: calc(-0.125rem * var(--global-scale));
+            }
+        }
+
+        .popover-item {
+            min-height: calc(3rem * var(--global-scale));
+            padding: var(--space-xs) var(--space-sm);
+
+            .icon {
+                @include popover-item-icon;
+            }
+
+            .labels {
+                margin-left: var(--space-sm);
+
+                .label {
+                    font-size: var(--text-md);
+                    font-weight: var(--weight-semibold);
+                    color: var(--fg-default);
+                }
+
+                .subtitle {
+                    font-size: var(--text-base);
+                    font-weight: var(--weight-medium);
+                    color: var(--fg-subtle);
+                }
+            }
+
+            .active-icon {
+                @include popover-item-active-icon;
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
## Objective

Custom modules can execute shell commands and display output in the bar, but they can't open dropdown panels — the only interaction options are fire-and-forget shell commands or opening built-in dropdowns by name. This means use cases like context switchers (display scale, kubectl context, SSH host picker) require external tools like wofi/rofi for selection UI, which breaks visual consistency with the rest of the panel.

This PR adds config-driven custom dropdown panels with composable sections, starting with a `picker` section type for list-based selection.

Related: #71 explores a similar use case. This takes a different approach — registering custom dropdowns in the `DropdownRegistry` rather than managing popovers directly in the custom module, so they get the same lifecycle behavior as built-in dropdowns (positioning, margins, mutual exclusion, freeze/thaw, keyboard mode).

## Solution

New `[dropdowns.custom.<name>]` config section with a `[[sections]]` array. Currently supports `type = "picker"` — a list-based item picker driven by shell commands:

```toml
[[modules.custom]]
id = "scale"
command = "hypr-scale.sh get"
format = "{{ text }}"
icon-name = "ld-monitor-symbolic"
left-click = "dropdown:custom:scale"
on-action = "hypr-scale.sh get"

[dropdowns.custom.scale]
title = "Display Scale"
icon = "ld-monitor-symbolic"
width = 340

[[dropdowns.custom.scale.sections]]
type = "picker"
list-command = "hypr-scale.sh list --json"
select-command = 'hypr-scale.sh set "$WAYLE_SELECTED"'
```

The `list-command` outputs JSON lines matching the `PopoverItem` fields:

```json
{"value": "1.5", "label": "1.5x", "subtitle": "140 DPI  2560×1707", "active": true}
```

Plain text fallback (one item per line) is also supported for simple cases like `kubectl config get-contexts -o name`.

### Key design decisions

- **Registry integration**: Custom dropdowns register as `"custom:<name>"` in the existing `DropdownRegistry`, getting positioning, margins, mutual exclusion, autohide, freeze/thaw, and keyboard mode for free.
- **Composable sections**: The `[[sections]]` array is designed for future section types (slider, toggle, info) without redesigning the config schema. For now, only `picker` is implemented.
- **`ClickAction` on custom modules**: Changed custom module click fields from `String` to `ClickAction` so `left-click = "dropdown:custom:scale"` works through existing dispatch. Backwards-compatible — `"pavucontrol"` still parses as `Shell(...)`.
- **`$WAYLE_SELECTED` env var**: The selected item's value is passed to `select-command` via environment variable, avoiding shell injection.
- **Post-selection refresh**: After selection, the popover closes and the module's `on-action` runs to update the bar label immediately.
- **Pre-warming**: Custom dropdowns are pre-warmed at startup alongside built-in dropdowns.

### Changes

- `wayle-config`: New `schemas::dropdowns` module with `CustomDropdownDefinition`, `SectionDefinition`, `SectionType::Picker`
- `wayle-config`: Custom module click fields changed from `String` to `ClickAction`
- `wayle-shell`: New `dropdowns::custom` module with `CustomDropdown` and `PickerSection` components
- `wayle-shell`: Registry fallback handles `"custom:*"` names, pre-warms custom dropdowns
- `wayle-shell`: `on_next_close` registry method for post-dropdown-close callbacks
- `wayle-styling`: SCSS for custom dropdown picker reusing popover-item mixins
- `README.md`: Documentation for the new config format

<img width="440" height="720" alt="wayle-pr-scale-cropped" src="https://github.com/user-attachments/assets/f5d4f612-3f6d-423f-ad28-4b1cf08a9584" />

## Test Plan

- [x] Configure a custom module with `left-click = "dropdown:custom:<name>"`
- [x] Verify the picker dropdown opens with items from `list-command`
- [x] Verify selecting an item runs `select-command` with `$WAYLE_SELECTED`
- [x] Verify the dropdown closes after selection and bar label refreshes via `on-action`
- [x] Verify plain text fallback (one item per line, no JSON)
- [x] Verify existing custom modules with shell click actions still work
- [x] Verify built-in dropdowns are unaffected
- [x] `cargo +nightly fmt --all --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes