### PR TITLE
feat: add pomodoro module

### DIFF
--- a/crates/wayle-config/src/schemas/bar/types/mod.rs
+++ b/crates/wayle-config/src/schemas/bar/types/mod.rs
@@ -196,6 +196,8 @@ pub enum BarModule {
     Netstat,
     /// Notification center button.
     Notifications,
+    /// Pomodoro timer.
+    Pomodoro,
     /// Power menu button.
     Power,
     /// RAM usage indicator.
@@ -261,6 +263,7 @@ impl BarModule {
             Self::Network => "network",
             Self::Netstat => "netstat",
             Self::Notifications => "notifications",
+            Self::Pomodoro => "pomodoro",
             Self::Power => "power",
             Self::Ram => "ram",
             Self::Separator => "separator",
@@ -293,6 +296,7 @@ impl BarModule {
             "network" => Self::Network,
             "netstat" => Self::Netstat,
             "notifications" => Self::Notifications,
+            "pomodoro" => Self::Pomodoro,
             "power" => Self::Power,
             "ram" => Self::Ram,
             "separator" => Self::Separator,
@@ -376,6 +380,7 @@ const BUILTIN_MODULES: &[&str] = &[
     "netstat",
     "network",
     "notifications",
+    "pomodoro",
     "power",
     "ram",
     "separator",

--- a/crates/wayle-config/src/schemas/modules/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/mod.rs
@@ -18,6 +18,7 @@ mod netstat;
 mod network;
 /// Notification module configuration and popup types.
 pub mod notification;
+mod pomodoro;
 mod power;
 mod ram;
 mod separator;
@@ -53,6 +54,7 @@ pub use notification::{
     IconSource, NotificationConfig, PopupCloseBehavior, PopupMonitor, PopupPosition, StackingOrder,
     UrgencyBarThreshold,
 };
+pub use pomodoro::PomodoroConfig;
 pub use power::PowerConfig;
 pub use ram::RamConfig;
 pub use separator::SeparatorConfig;
@@ -106,6 +108,8 @@ pub struct ModulesConfig {
     pub netstat: NetstatConfig,
     /// Notification center module.
     pub notification: NotificationConfig,
+    /// Pomodoro timer module.
+    pub pomodoro: PomodoroConfig,
     /// Power menu module.
     pub power: PowerConfig,
     /// RAM usage module.

--- a/crates/wayle-config/src/schemas/modules/pomodoro/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/pomodoro/mod.rs
@@ -70,6 +70,21 @@ pub struct PomodoroConfig {
     #[default(ColorValue::Token(CssToken::Blue))]
     pub label_color: ConfigProperty<ColorValue>,
 
+    /// Accent color for work sessions in the bar module.
+    #[serde(rename = "work-color")]
+    #[default(ColorValue::Token(CssToken::Blue))]
+    pub work_color: ConfigProperty<ColorValue>,
+
+    /// Accent color for short breaks in the bar module.
+    #[serde(rename = "short-break-color")]
+    #[default(ColorValue::Token(CssToken::Green))]
+    pub short_break_color: ConfigProperty<ColorValue>,
+
+    /// Accent color for long breaks in the bar module.
+    #[serde(rename = "long-break-color")]
+    #[default(ColorValue::Token(CssToken::Yellow))]
+    pub long_break_color: ConfigProperty<ColorValue>,
+
     /// Max label characters before truncation with ellipsis. Set to 0 to disable.
     #[serde(rename = "label-max-length")]
     #[default(0)]

--- a/crates/wayle-config/src/schemas/modules/pomodoro/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/pomodoro/mod.rs
@@ -70,21 +70,6 @@ pub struct PomodoroConfig {
     #[default(ColorValue::Token(CssToken::Blue))]
     pub label_color: ConfigProperty<ColorValue>,
 
-    /// Accent color for work sessions in the bar module.
-    #[serde(rename = "work-color")]
-    #[default(ColorValue::Token(CssToken::Blue))]
-    pub work_color: ConfigProperty<ColorValue>,
-
-    /// Accent color for short breaks in the bar module.
-    #[serde(rename = "short-break-color")]
-    #[default(ColorValue::Token(CssToken::Green))]
-    pub short_break_color: ConfigProperty<ColorValue>,
-
-    /// Accent color for long breaks in the bar module.
-    #[serde(rename = "long-break-color")]
-    #[default(ColorValue::Token(CssToken::Yellow))]
-    pub long_break_color: ConfigProperty<ColorValue>,
-
     /// Max label characters before truncation with ellipsis. Set to 0 to disable.
     #[serde(rename = "label-max-length")]
     #[default(0)]

--- a/crates/wayle-config/src/schemas/modules/pomodoro/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/pomodoro/mod.rs
@@ -87,7 +87,7 @@ pub struct PomodoroConfig {
 
     /// Action on right click.
     #[serde(rename = "right-click")]
-    #[default(ClickAction::None)]
+    #[default(ClickAction::Shell(String::from(":toggle-running")))]
     pub right_click: ConfigProperty<ClickAction>,
 
     /// Action on middle click.

--- a/crates/wayle-config/src/schemas/modules/pomodoro/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/pomodoro/mod.rs
@@ -1,0 +1,119 @@
+use schemars::schema_for;
+use wayle_derive::wayle_config;
+
+use crate::{
+    ClickAction, ConfigProperty,
+    docs::{ModuleInfo, ModuleInfoProvider},
+    schemas::styling::{ColorValue, CssToken},
+};
+
+/// Pomodoro timer module configuration.
+#[wayle_config(bar_button)]
+pub struct PomodoroConfig {
+    /// Work session duration in minutes.
+    #[serde(rename = "work-duration")]
+    #[default(25)]
+    pub work_duration: ConfigProperty<u32>,
+
+    /// Short break duration in minutes.
+    #[serde(rename = "short-break-duration")]
+    #[default(5)]
+    pub short_break_duration: ConfigProperty<u32>,
+
+    /// Long break duration in minutes.
+    #[serde(rename = "long-break-duration")]
+    #[default(15)]
+    pub long_break_duration: ConfigProperty<u32>,
+
+    /// Number of work cycles before a long break.
+    #[serde(rename = "cycles-before-long-break")]
+    #[default(4)]
+    pub cycles_before_long_break: ConfigProperty<u32>,
+
+    /// Symbolic icon name.
+    #[serde(rename = "icon-name")]
+    #[default(String::from("ld-clock-symbolic"))]
+    pub icon_name: ConfigProperty<String>,
+
+    /// Display border around button.
+    #[serde(rename = "border-show")]
+    #[default(false)]
+    pub border_show: ConfigProperty<bool>,
+
+    /// Border color token.
+    #[serde(rename = "border-color")]
+    #[default(ColorValue::Token(CssToken::BorderAccent))]
+    pub border_color: ConfigProperty<ColorValue>,
+
+    /// Display module icon.
+    #[serde(rename = "icon-show")]
+    #[default(true)]
+    pub icon_show: ConfigProperty<bool>,
+
+    /// Icon foreground color. Auto selects based on variant for contrast.
+    #[serde(rename = "icon-color")]
+    #[default(ColorValue::Auto)]
+    pub icon_color: ConfigProperty<ColorValue>,
+
+    /// Icon container background color token.
+    #[serde(rename = "icon-bg-color")]
+    #[default(ColorValue::Token(CssToken::Blue))]
+    pub icon_bg_color: ConfigProperty<ColorValue>,
+
+    /// Display text label.
+    #[serde(rename = "label-show")]
+    #[default(true)]
+    pub label_show: ConfigProperty<bool>,
+
+    /// Label text color token.
+    #[serde(rename = "label-color")]
+    #[default(ColorValue::Token(CssToken::Blue))]
+    pub label_color: ConfigProperty<ColorValue>,
+
+    /// Max label characters before truncation with ellipsis. Set to 0 to disable.
+    #[serde(rename = "label-max-length")]
+    #[default(0)]
+    pub label_max_length: ConfigProperty<u32>,
+
+    /// Button background color token.
+    #[serde(rename = "button-bg-color")]
+    #[default(ColorValue::Token(CssToken::BgSurfaceElevated))]
+    pub button_bg_color: ConfigProperty<ColorValue>,
+
+    /// Action on left click.
+    #[serde(rename = "left-click")]
+    #[default(ClickAction::Dropdown(String::from("pomodoro")))]
+    pub left_click: ConfigProperty<ClickAction>,
+
+    /// Action on right click.
+    #[serde(rename = "right-click")]
+    #[default(ClickAction::None)]
+    pub right_click: ConfigProperty<ClickAction>,
+
+    /// Action on middle click.
+    #[serde(rename = "middle-click")]
+    #[default(ClickAction::None)]
+    pub middle_click: ConfigProperty<ClickAction>,
+
+    /// Action on scroll up.
+    #[serde(rename = "scroll-up")]
+    #[default(ClickAction::None)]
+    pub scroll_up: ConfigProperty<ClickAction>,
+
+    /// Action on scroll down.
+    #[serde(rename = "scroll-down")]
+    #[default(ClickAction::None)]
+    pub scroll_down: ConfigProperty<ClickAction>,
+}
+
+impl ModuleInfoProvider for PomodoroConfig {
+    fn module_info() -> ModuleInfo {
+        ModuleInfo {
+            name: String::from("pomodoro"),
+            icon: String::from("󱫢"),
+            description: String::from("Pomodoro timer for time management"),
+            behavior_configs: vec![(String::from("pomodoro"), || schema_for!(PomodoroConfig))],
+            styling_configs: vec![],
+        }
+    }
+}

--- a/crates/wayle-shell/locales/en-US/dropdowns/_pomodoro.ftl
+++ b/crates/wayle-shell/locales/en-US/dropdowns/_pomodoro.ftl
@@ -1,0 +1,9 @@
+### Pomodoro Dropdown
+
+dropdown-pomodoro-title = Pomodoro Timer
+dropdown-pomodoro-mode-section = Timer Mode
+dropdown-pomodoro-start = Start
+dropdown-pomodoro-pause = Pause
+dropdown-pomodoro-mode-work = Work
+dropdown-pomodoro-mode-short-break = Short Break
+dropdown-pomodoro-mode-long-break = Long Break

--- a/crates/wayle-shell/src/bootstrap/mod.rs
+++ b/crates/wayle-shell/src/bootstrap/mod.rs
@@ -31,7 +31,7 @@ use zbus::{Connection, fdo::DBusProxy};
 
 use crate::{
     services::{IdleInhibitService, ShellIpcService},
-    shell::ShellServices,
+    shell::{PomodoroSharedState, ShellServices},
     startup::StartupTimer,
     watchers::build_extractor_config,
 };
@@ -151,6 +151,16 @@ pub async fn init_services() -> Result<(StartupTimer, ShellServices), Box<dyn Er
 
     timer.mark_services_done();
 
+    // Initialize pomodoro shared state
+    let config = config_service.config();
+    let pomodoro_config = &config.modules.pomodoro;
+    let pomodoro_state = std::sync::Arc::new(PomodoroSharedState::new(
+        pomodoro_config.work_duration.get(),
+        pomodoro_config.short_break_duration.get(),
+        pomodoro_config.long_break_duration.get(),
+        pomodoro_config.cycles_before_long_break.get(),
+    ));
+
     let services = ShellServices {
         audio: daemons.audio,
         battery: core.battery,
@@ -168,6 +178,7 @@ pub async fn init_services() -> Result<(StartupTimer, ShellServices), Box<dyn Er
         wallpaper: core.wallpaper,
         weather,
         shell_ipc,
+        pomodoro_state,
     };
 
     Ok((timer, services))

--- a/crates/wayle-shell/src/shell/bar/dropdowns/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/mod.rs
@@ -6,6 +6,7 @@ mod dashboard;
 mod media;
 mod network;
 mod notification;
+mod pomodoro;
 mod registry;
 mod weather;
 
@@ -46,5 +47,6 @@ register_dropdowns! {
     "media" => media::Factory,
     "network" => network::Factory,
     "notification" => notification::Factory,
+    "pomodoro" => pomodoro::Factory,
     "weather" => weather::Factory,
 }

--- a/crates/wayle-shell/src/shell/bar/dropdowns/network/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/network/helpers.rs
@@ -99,7 +99,7 @@ pub(crate) fn sorted_unique_access_points(
     }
 
     let mut snapshots: Vec<AccessPointSnapshot> = best_by_ssid.into_values().collect();
-    snapshots.sort_by(|left, right| right.strength.cmp(&left.strength));
+    snapshots.sort_by_key(|right| std::cmp::Reverse(right.strength));
     snapshots
 }
 

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/helpers.rs
@@ -22,7 +22,7 @@ pub(super) fn group_by_app(notifications: &[Arc<Notification>]) -> Vec<Notificat
     let mut result: Vec<NotificationGroupData> = groups
         .into_iter()
         .map(|(app_name, mut notifs)| {
-            notifs.sort_by(|left, right| right.timestamp.get().cmp(&left.timestamp.get()));
+            notifs.sort_by_key(|right| std::cmp::Reverse(right.timestamp.get()));
             NotificationGroupData {
                 app_name,
                 notifications: notifs,

--- a/crates/wayle-shell/src/shell/bar/dropdowns/pomodoro/factory.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/pomodoro/factory.rs
@@ -1,0 +1,22 @@
+use relm4::prelude::*;
+
+use super::{PomodoroDropdown, messages::PomodoroDropdownInit};
+use crate::shell::{
+    bar::dropdowns::{DropdownFactory, DropdownInstance},
+    services::ShellServices,
+};
+
+pub(crate) struct Factory;
+
+impl DropdownFactory for Factory {
+    fn create(services: &ShellServices) -> Option<DropdownInstance> {
+        let init = PomodoroDropdownInit {
+            config: services.config.clone(),
+            state: services.pomodoro_state.clone(),
+        };
+        let controller = PomodoroDropdown::builder().launch(init).detach();
+
+        let popover = controller.widget().clone();
+        Some(DropdownInstance::new(popover, Box::new(controller)))
+    }
+}

--- a/crates/wayle-shell/src/shell/bar/dropdowns/pomodoro/messages.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/pomodoro/messages.rs
@@ -1,0 +1,30 @@
+use std::sync::Arc;
+
+use wayle_config::ConfigService;
+
+use crate::shell::{SharedPomodoroState, bar::pomodoro::PomodoroSnapshot};
+
+pub(crate) struct PomodoroDropdownInit {
+    pub config: Arc<ConfigService>,
+    pub state: SharedPomodoroState,
+}
+
+#[derive(Debug)]
+pub(crate) enum PomodoroDropdownInput {
+    ToggleRunning,
+    SwitchToWork,
+    SwitchToShortBreak,
+    SwitchToLongBreak,
+}
+
+#[derive(Debug)]
+pub(crate) enum PomodoroDropdownCmd {
+    StateChanged(PomodoroSnapshot),
+    ScaleChanged(f32),
+    UpdateDurations {
+        work: u32,
+        short_break: u32,
+        long_break: u32,
+        cycles: u32,
+    },
+}

--- a/crates/wayle-shell/src/shell/bar/dropdowns/pomodoro/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/pomodoro/mod.rs
@@ -1,0 +1,295 @@
+mod factory;
+mod messages;
+mod watchers;
+
+use gtk::prelude::*;
+use relm4::{gtk, prelude::*};
+use wayle_widgets::prelude::*;
+
+pub(super) use self::factory::Factory;
+use self::messages::{PomodoroDropdownCmd, PomodoroDropdownInit, PomodoroDropdownInput};
+use crate::{
+    i18n::t,
+    shell::{PomodoroMode, PomodoroSnapshot, SharedPomodoroState, TimerState},
+};
+
+const BASE_WIDTH: f32 = 340.0;
+
+pub(crate) struct PomodoroDropdown {
+    scaled_width: i32,
+    state: SharedPomodoroState,
+    snapshot: PomodoroSnapshot,
+}
+
+#[relm4::component(pub(crate))]
+impl Component for PomodoroDropdown {
+    type Init = PomodoroDropdownInit;
+    type Input = PomodoroDropdownInput;
+    type Output = ();
+    type CommandOutput = PomodoroDropdownCmd;
+
+    view! {
+        #[root]
+        gtk::Popover {
+            set_css_classes: &["dropdown", "pomodoro-dropdown"],
+            set_has_arrow: false,
+            #[watch]
+            set_width_request: model.scaled_width,
+
+            #[template]
+            Dropdown {
+
+                #[template]
+                DropdownHeader {
+                    #[template_child]
+                    icon {
+                        set_visible: true,
+                        set_icon_name: Some("ld-clock-symbolic"),
+                    },
+                    #[template_child]
+                    label {
+                        set_label: &t!("dropdown-pomodoro-title"),
+                    },
+                    #[template_child]
+                    actions {
+                        set_visible: false,
+                    },
+                },
+
+                #[template]
+                DropdownContent {
+
+                    gtk::Box {
+                        set_orientation: gtk::Orientation::Vertical,
+                        set_spacing: 0,
+
+                        gtk::Box {
+                            add_css_class: "pomodoro-hero",
+                            set_orientation: gtk::Orientation::Horizontal,
+                            set_spacing: 16,
+                            set_halign: gtk::Align::Center,
+                            set_valign: gtk::Align::Center,
+
+                            gtk::Box {
+                                add_css_class: "pomodoro-hero-meta",
+                                set_orientation: gtk::Orientation::Vertical,
+                                set_valign: gtk::Align::Center,
+
+                                gtk::Label {
+                                    add_css_class: "pomodoro-hero-time",
+                                    set_halign: gtk::Align::Center,
+                                    set_valign: gtk::Align::Center,
+                                    #[watch]
+                                    set_label: &model.snapshot.format_time(),
+                                },
+                            },
+
+                            gtk::Box {
+                                add_css_class: "pomodoro-hero-controls",
+                                set_orientation: gtk::Orientation::Horizontal,
+                                set_valign: gtk::Align::Center,
+
+                                gtk::Button {
+                                    add_css_class: "pomodoro-hero-toggle",
+                                    set_valign: gtk::Align::Center,
+                                    #[watch]
+                                    set_tooltip_text: Some(&model.primary_action_tooltip()),
+                                    connect_clicked => PomodoroDropdownInput::ToggleRunning,
+
+                                    gtk::Image {
+                                        set_valign: gtk::Align::Center,
+                                        #[watch]
+                                        set_icon_name: Some(model.primary_action_icon()),
+                                        set_pixel_size: 40,
+                                    },
+                                },
+                            },
+                        },
+
+                        gtk::Separator {
+                            set_orientation: gtk::Orientation::Horizontal,
+                            set_margin_top: 12,
+                            set_margin_bottom: 12,
+                        },
+
+                        gtk::Box {
+                            set_orientation: gtk::Orientation::Vertical,
+                            set_spacing: 8,
+
+                            gtk::Label {
+                                add_css_class: "section-label",
+                                set_label: &t!("dropdown-pomodoro-mode-section"),
+                                set_halign: gtk::Align::Start,
+                            },
+
+                            #[name = "mode_segmented"]
+                            gtk::Box {
+                                add_css_class: "profile-seg",
+                                set_homogeneous: true,
+
+                                #[name = "work_btn"]
+                                gtk::ToggleButton {
+                                    add_css_class: "profile-seg-btn",
+                                    set_cursor_from_name: Some("pointer"),
+                                    set_hexpand: true,
+                                    #[watch]
+                                    #[block_signal(work_handler)]
+                                    set_active: model.snapshot.mode == PomodoroMode::Work,
+                                    connect_toggled[sender] => move |btn| {
+                                        if btn.is_active() {
+                                            sender.input(PomodoroDropdownInput::SwitchToWork);
+                                        }
+                                    } @work_handler,
+
+                                    gtk::Box {
+                                        add_css_class: "profile-seg-btn-content",
+                                        set_halign: gtk::Align::Center,
+
+                                        gtk::Label {
+                                            set_label: &t!("dropdown-pomodoro-mode-work"),
+                                        },
+                                    },
+                                },
+
+                                #[name = "short_break_btn"]
+                                gtk::ToggleButton {
+                                    add_css_class: "profile-seg-btn",
+                                    set_cursor_from_name: Some("pointer"),
+                                    set_hexpand: true,
+                                    set_group: Some(&work_btn),
+                                    #[watch]
+                                    #[block_signal(short_handler)]
+                                    set_active: model.snapshot.mode == PomodoroMode::ShortBreak,
+                                    connect_toggled[sender] => move |btn| {
+                                        if btn.is_active() {
+                                            sender.input(PomodoroDropdownInput::SwitchToShortBreak);
+                                        }
+                                    } @short_handler,
+
+                                    gtk::Box {
+                                        add_css_class: "profile-seg-btn-content",
+                                        set_halign: gtk::Align::Center,
+
+                                        gtk::Label {
+                                            set_label: &t!("dropdown-pomodoro-mode-short-break"),
+                                        },
+                                    },
+                                },
+
+                                #[name = "long_break_btn"]
+                                gtk::ToggleButton {
+                                    add_css_class: "profile-seg-btn",
+                                    set_cursor_from_name: Some("pointer"),
+                                    set_hexpand: true,
+                                    set_group: Some(&work_btn),
+                                    #[watch]
+                                    #[block_signal(long_handler)]
+                                    set_active: model.snapshot.mode == PomodoroMode::LongBreak,
+                                    connect_toggled[sender] => move |btn| {
+                                        if btn.is_active() {
+                                            sender.input(PomodoroDropdownInput::SwitchToLongBreak);
+                                        }
+                                    } @long_handler,
+
+                                    gtk::Box {
+                                        add_css_class: "profile-seg-btn-content",
+                                        set_halign: gtk::Align::Center,
+
+                                        gtk::Label {
+                                            set_label: &t!("dropdown-pomodoro-mode-long-break"),
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        }
+    }
+
+    fn init(
+        init: Self::Init,
+        _root: Self::Root,
+        sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let config = init.config.config();
+        let pomodoro_config = &config.modules.pomodoro;
+        let scale = config.styling.scale.get().value();
+
+        let model = Self {
+            scaled_width: super::scaled_dimension(BASE_WIDTH, scale),
+            snapshot: init.state.snapshot(),
+            state: init.state,
+        };
+
+        watchers::spawn_watchers(&sender, &init.config, pomodoro_config, &model.state);
+
+        let widgets = view_output!();
+
+        ComponentParts { model, widgets }
+    }
+
+    fn update(&mut self, msg: Self::Input, _sender: ComponentSender<Self>, _root: &Self::Root) {
+        self.snapshot = match msg {
+            PomodoroDropdownInput::ToggleRunning => {
+                if self.snapshot.timer_state == TimerState::Running {
+                    self.state.pause()
+                } else {
+                    self.state.start()
+                }
+            }
+            PomodoroDropdownInput::SwitchToWork => self.state.switch_mode(PomodoroMode::Work),
+            PomodoroDropdownInput::SwitchToShortBreak => {
+                self.state.switch_mode(PomodoroMode::ShortBreak)
+            }
+            PomodoroDropdownInput::SwitchToLongBreak => {
+                self.state.switch_mode(PomodoroMode::LongBreak)
+            }
+        };
+    }
+
+    fn update_cmd(
+        &mut self,
+        msg: Self::CommandOutput,
+        _sender: ComponentSender<Self>,
+        _root: &Self::Root,
+    ) {
+        match msg {
+            PomodoroDropdownCmd::StateChanged(snapshot) => {
+                self.snapshot = snapshot;
+            }
+            PomodoroDropdownCmd::ScaleChanged(scale) => {
+                self.scaled_width = super::scaled_dimension(BASE_WIDTH, scale);
+            }
+            PomodoroDropdownCmd::UpdateDurations {
+                work,
+                short_break,
+                long_break,
+                cycles,
+            } => {
+                self.snapshot = self
+                    .state
+                    .update_durations(work, short_break, long_break, cycles);
+            }
+        }
+    }
+}
+
+impl PomodoroDropdown {
+    fn primary_action_icon(&self) -> &'static str {
+        if self.snapshot.timer_state == TimerState::Running {
+            "media-playback-pause-symbolic"
+        } else {
+            "media-playback-start-symbolic"
+        }
+    }
+
+    fn primary_action_tooltip(&self) -> String {
+        if self.snapshot.timer_state == TimerState::Running {
+            t!("dropdown-pomodoro-pause")
+        } else {
+            t!("dropdown-pomodoro-start")
+        }
+    }
+}

--- a/crates/wayle-shell/src/shell/bar/dropdowns/pomodoro/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/pomodoro/watchers.rs
@@ -1,0 +1,48 @@
+use relm4::ComponentSender;
+use tokio_stream::wrappers::WatchStream;
+use wayle_config::{ConfigService, schemas::modules::PomodoroConfig};
+use wayle_widgets::watch;
+
+use super::{PomodoroDropdown, PomodoroDropdownCmd};
+use crate::shell::SharedPomodoroState;
+
+pub(super) fn spawn_watchers(
+    sender: &ComponentSender<PomodoroDropdown>,
+    shell_config: &std::sync::Arc<ConfigService>,
+    config: &PomodoroConfig,
+    state: &SharedPomodoroState,
+) {
+    let scale = shell_config.config().styling.scale.clone();
+    watch!(sender, [scale.watch()], |out| {
+        let _ = out.send(PomodoroDropdownCmd::ScaleChanged(scale.get().value()));
+    });
+
+    let state_stream = WatchStream::new(state.subscribe());
+    let state_watch = state.clone();
+    watch!(sender, [state_stream], |out| {
+        let _ = out.send(PomodoroDropdownCmd::StateChanged(state_watch.snapshot()));
+    });
+
+    let work = config.work_duration.clone();
+    let short_break = config.short_break_duration.clone();
+    let long_break = config.long_break_duration.clone();
+    let cycles = config.cycles_before_long_break.clone();
+
+    watch!(
+        sender,
+        [
+            work.watch(),
+            short_break.watch(),
+            long_break.watch(),
+            cycles.watch()
+        ],
+        |out| {
+            let _ = out.send(PomodoroDropdownCmd::UpdateDurations {
+                work: work.get(),
+                short_break: short_break.get(),
+                long_break: long_break.get(),
+                cycles: cycles.get(),
+            });
+        }
+    );
+}

--- a/crates/wayle-shell/src/shell/bar/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/mod.rs
@@ -3,6 +3,7 @@ mod factory;
 pub(crate) mod icons;
 mod methods;
 mod modules;
+pub(crate) mod pomodoro;
 mod styling;
 mod watchers;
 

--- a/crates/wayle-shell/src/shell/bar/modules/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/mod.rs
@@ -16,6 +16,7 @@ mod microphone;
 mod netstat;
 mod network;
 mod notification;
+mod pomodoro;
 mod power;
 mod ram;
 mod registry;
@@ -73,6 +74,7 @@ register_modules! {
     Netstat => netstat::Factory,
     Network => network::Factory,
     Notifications => notification::Factory,
+    Pomodoro => pomodoro::Factory,
     Power => power::Factory,
     Ram => ram::Factory,
     Separator => separator::Factory,

--- a/crates/wayle-shell/src/shell/bar/modules/pomodoro/factory.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/pomodoro/factory.rs
@@ -1,0 +1,33 @@
+use std::rc::Rc;
+
+use relm4::prelude::*;
+use wayle_widgets::prelude::BarSettings;
+
+use super::{PomodoroInit, PomodoroModule};
+use crate::shell::{
+    bar::{
+        dropdowns::DropdownRegistry,
+        modules::registry::{ModuleFactory, ModuleInstance, dynamic_controller},
+    },
+    services::ShellServices,
+};
+
+pub(crate) struct Factory;
+
+impl ModuleFactory for Factory {
+    fn create(
+        settings: &BarSettings,
+        services: &ShellServices,
+        dropdowns: &Rc<DropdownRegistry>,
+        class: Option<String>,
+    ) -> Option<ModuleInstance> {
+        let init = PomodoroInit {
+            settings: settings.clone(),
+            config: services.config.clone(),
+            dropdowns: dropdowns.clone(),
+            state: services.pomodoro_state.clone(),
+        };
+        let controller = dynamic_controller(PomodoroModule::builder().launch(init).detach());
+        Some(ModuleInstance { controller, class })
+    }
+}

--- a/crates/wayle-shell/src/shell/bar/modules/pomodoro/messages.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/pomodoro/messages.rs
@@ -1,0 +1,34 @@
+use std::{rc::Rc, sync::Arc};
+
+use wayle_config::ConfigService;
+use wayle_widgets::prelude::BarSettings;
+
+use crate::shell::{PomodoroSnapshot, SharedPomodoroState, bar::dropdowns::DropdownRegistry};
+
+pub(crate) struct PomodoroInit {
+    pub settings: BarSettings,
+    pub config: Arc<ConfigService>,
+    pub dropdowns: Rc<DropdownRegistry>,
+    pub state: SharedPomodoroState,
+}
+
+#[derive(Debug)]
+pub(crate) enum PomodoroMsg {
+    LeftClick,
+    RightClick,
+    MiddleClick,
+    ScrollUp,
+    ScrollDown,
+}
+
+#[derive(Debug)]
+pub(crate) enum PomodoroCmd {
+    StateChanged(PomodoroSnapshot),
+    UpdateIcon(String),
+    UpdateDurations {
+        work: u32,
+        short_break: u32,
+        long_break: u32,
+        cycles: u32,
+    },
+}

--- a/crates/wayle-shell/src/shell/bar/modules/pomodoro/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/pomodoro/mod.rs
@@ -6,7 +6,10 @@ use std::{rc::Rc, sync::Arc};
 
 use gtk::prelude::*;
 use relm4::prelude::*;
-use wayle_config::{ConfigProperty, ConfigService, schemas::{modules::PomodoroConfig, styling::CssToken}};
+use wayle_config::{
+    ClickAction, ConfigProperty, ConfigService,
+    schemas::{modules::PomodoroConfig, styling::CssToken},
+};
 use wayle_widgets::prelude::{
     BarButton, BarButtonBehavior, BarButtonColors, BarButtonInit, BarButtonInput, BarButtonOutput,
 };
@@ -110,6 +113,11 @@ impl Component for PomodoroModule {
             PomodoroMsg::ScrollDown => config.scroll_down.get(),
         };
 
+        if matches!(&action, ClickAction::Shell(s) if s == ":toggle-running") {
+            self.toggle_running();
+            return;
+        }
+
         dropdowns::dispatch_click(&action, &self.dropdowns, &self.bar_button);
     }
 
@@ -147,6 +155,17 @@ impl Component for PomodoroModule {
 }
 
 impl PomodoroModule {
+    fn toggle_running(&self) {
+        match self.state.snapshot().timer_state {
+            TimerState::Running => {
+                self.state.pause();
+            }
+            TimerState::Stopped | TimerState::Paused => {
+                self.state.start();
+            }
+        }
+    }
+
     fn icon_for_snapshot(snapshot: &PomodoroSnapshot, config: &PomodoroConfig) -> String {
         match snapshot.timer_state {
             TimerState::Stopped => config.icon_name.get().clone(),

--- a/crates/wayle-shell/src/shell/bar/modules/pomodoro/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/pomodoro/mod.rs
@@ -6,13 +6,7 @@ use std::{rc::Rc, sync::Arc};
 
 use gtk::prelude::*;
 use relm4::prelude::*;
-use wayle_config::{
-    ConfigProperty, ConfigService,
-    schemas::{
-        modules::PomodoroConfig,
-        styling::{ColorValue, CssToken, ThresholdColors},
-    },
-};
+use wayle_config::{ConfigProperty, ConfigService, schemas::{modules::PomodoroConfig, styling::CssToken}};
 use wayle_widgets::prelude::{
     BarButton, BarButtonBehavior, BarButtonColors, BarButtonInit, BarButtonInput, BarButtonOutput,
 };
@@ -51,7 +45,7 @@ impl Component for PomodoroModule {
 
     fn init(
         init: Self::Init,
-        _root: Self::Root,
+        root: Self::Root,
         sender: ComponentSender<Self>,
     ) -> ComponentParts<Self> {
         let config = init.config.config();
@@ -59,6 +53,7 @@ impl Component for PomodoroModule {
 
         let initial_snapshot = init.state.snapshot();
         let initial_label = initial_snapshot.format_time();
+        Self::apply_mode_css_class(&root, &initial_snapshot);
 
         let bar_button = BarButton::builder()
             .launch(BarButtonInit {
@@ -89,10 +84,6 @@ impl Component for PomodoroModule {
                 BarButtonOutput::ScrollUp => PomodoroMsg::ScrollUp,
                 BarButtonOutput::ScrollDown => PomodoroMsg::ScrollDown,
             });
-        bar_button.emit(BarButtonInput::SetThresholdColors(Self::colors_for_snapshot(
-            &initial_snapshot,
-            pomodoro_config,
-        )));
 
         watchers::spawn_watchers(&sender, pomodoro_config, &init.state);
 
@@ -126,18 +117,16 @@ impl Component for PomodoroModule {
         &mut self,
         msg: Self::CommandOutput,
         _sender: ComponentSender<Self>,
-        _root: &Self::Root,
+        root: &Self::Root,
     ) {
         match msg {
             PomodoroCmd::StateChanged(snapshot) => {
                 let pomodoro_config = &self.config.config().modules.pomodoro;
                 let icon = Self::icon_for_snapshot(&snapshot, pomodoro_config);
-                let colors = Self::colors_for_snapshot(&snapshot, pomodoro_config);
+                Self::apply_mode_css_class(root, &snapshot);
                 self.bar_button
                     .emit(BarButtonInput::SetLabel(snapshot.format_time()));
                 self.bar_button.emit(BarButtonInput::SetIcon(icon));
-                self.bar_button
-                    .emit(BarButtonInput::SetThresholdColors(colors));
             }
             PomodoroCmd::UpdateIcon(icon) => {
                 if self.state.snapshot().timer_state == TimerState::Stopped {
@@ -166,22 +155,23 @@ impl PomodoroModule {
         }
     }
 
-    fn colors_for_snapshot(
-        snapshot: &PomodoroSnapshot,
-        config: &PomodoroConfig,
-    ) -> ThresholdColors {
-        let accent = match snapshot.mode {
-            PomodoroMode::Work => config.work_color.get(),
-            PomodoroMode::ShortBreak => config.short_break_color.get(),
-            PomodoroMode::LongBreak => config.long_break_color.get(),
-        };
-
-        ThresholdColors {
-            icon_color: Some(ColorValue::Token(CssToken::FgOnAccent)),
-            label_color: Some(accent.clone()),
-            icon_background: Some(accent.clone()),
-            button_background: None,
-            border_color: Some(accent),
+    fn apply_mode_css_class(root: &gtk::Box, snapshot: &PomodoroSnapshot) {
+        match snapshot.mode {
+            PomodoroMode::Work => {
+                root.remove_css_class("pomodoro-short-break");
+                root.remove_css_class("pomodoro-long-break");
+                root.add_css_class("pomodoro-work");
+            }
+            PomodoroMode::ShortBreak => {
+                root.remove_css_class("pomodoro-work");
+                root.remove_css_class("pomodoro-long-break");
+                root.add_css_class("pomodoro-short-break");
+            }
+            PomodoroMode::LongBreak => {
+                root.remove_css_class("pomodoro-work");
+                root.remove_css_class("pomodoro-short-break");
+                root.add_css_class("pomodoro-long-break");
+            }
         }
     }
 }

--- a/crates/wayle-shell/src/shell/bar/modules/pomodoro/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/pomodoro/mod.rs
@@ -1,0 +1,139 @@
+mod factory;
+mod messages;
+mod watchers;
+
+use std::{rc::Rc, sync::Arc};
+
+use gtk::prelude::*;
+use relm4::prelude::*;
+use wayle_config::{ConfigProperty, ConfigService, schemas::styling::CssToken};
+use wayle_widgets::prelude::{
+    BarButton, BarButtonBehavior, BarButtonColors, BarButtonInit, BarButtonInput, BarButtonOutput,
+};
+
+pub(crate) use self::{
+    factory::Factory,
+    messages::{PomodoroCmd, PomodoroInit, PomodoroMsg},
+};
+use crate::shell::{
+    SharedPomodoroState,
+    bar::dropdowns::{self, DropdownRegistry},
+};
+
+pub(crate) struct PomodoroModule {
+    bar_button: Controller<BarButton>,
+    config: Arc<ConfigService>,
+    dropdowns: Rc<DropdownRegistry>,
+    state: SharedPomodoroState,
+}
+
+#[relm4::component(pub(crate))]
+impl Component for PomodoroModule {
+    type Init = PomodoroInit;
+    type Input = PomodoroMsg;
+    type Output = ();
+    type CommandOutput = PomodoroCmd;
+
+    view! {
+        gtk::Box {
+            add_css_class: "pomodoro",
+
+            #[local_ref]
+            bar_button -> gtk::MenuButton {},
+        }
+    }
+
+    fn init(
+        init: Self::Init,
+        _root: Self::Root,
+        sender: ComponentSender<Self>,
+    ) -> ComponentParts<Self> {
+        let config = init.config.config();
+        let pomodoro_config = &config.modules.pomodoro;
+
+        let initial_label = init.state.snapshot().format_time();
+
+        let bar_button = BarButton::builder()
+            .launch(BarButtonInit {
+                icon: pomodoro_config.icon_name.get().clone(),
+                label: initial_label,
+                tooltip: None,
+                colors: BarButtonColors {
+                    icon_color: pomodoro_config.icon_color.clone(),
+                    label_color: pomodoro_config.label_color.clone(),
+                    icon_background: pomodoro_config.icon_bg_color.clone(),
+                    button_background: pomodoro_config.button_bg_color.clone(),
+                    border_color: pomodoro_config.border_color.clone(),
+                    auto_icon_color: CssToken::Accent,
+                },
+                behavior: BarButtonBehavior {
+                    label_max_chars: pomodoro_config.label_max_length.clone(),
+                    show_icon: pomodoro_config.icon_show.clone(),
+                    show_label: pomodoro_config.label_show.clone(),
+                    show_border: pomodoro_config.border_show.clone(),
+                    visible: ConfigProperty::new(true),
+                },
+                settings: init.settings,
+            })
+            .forward(sender.input_sender(), |output| match output {
+                BarButtonOutput::LeftClick => PomodoroMsg::LeftClick,
+                BarButtonOutput::RightClick => PomodoroMsg::RightClick,
+                BarButtonOutput::MiddleClick => PomodoroMsg::MiddleClick,
+                BarButtonOutput::ScrollUp => PomodoroMsg::ScrollUp,
+                BarButtonOutput::ScrollDown => PomodoroMsg::ScrollDown,
+            });
+
+        watchers::spawn_watchers(&sender, pomodoro_config, &init.state);
+
+        let model = Self {
+            bar_button,
+            config: init.config,
+            dropdowns: init.dropdowns,
+            state: init.state,
+        };
+        let bar_button = model.bar_button.widget();
+        let widgets = view_output!();
+
+        ComponentParts { model, widgets }
+    }
+
+    fn update(&mut self, msg: Self::Input, _sender: ComponentSender<Self>, _root: &Self::Root) {
+        let config = &self.config.config().modules.pomodoro;
+
+        let action = match msg {
+            PomodoroMsg::LeftClick => config.left_click.get(),
+            PomodoroMsg::RightClick => config.right_click.get(),
+            PomodoroMsg::MiddleClick => config.middle_click.get(),
+            PomodoroMsg::ScrollUp => config.scroll_up.get(),
+            PomodoroMsg::ScrollDown => config.scroll_down.get(),
+        };
+
+        dropdowns::dispatch_click(&action, &self.dropdowns, &self.bar_button);
+    }
+
+    fn update_cmd(
+        &mut self,
+        msg: Self::CommandOutput,
+        _sender: ComponentSender<Self>,
+        _root: &Self::Root,
+    ) {
+        match msg {
+            PomodoroCmd::StateChanged(snapshot) => {
+                self.bar_button
+                    .emit(BarButtonInput::SetLabel(snapshot.format_time()));
+            }
+            PomodoroCmd::UpdateIcon(icon) => {
+                self.bar_button.emit(BarButtonInput::SetIcon(icon));
+            }
+            PomodoroCmd::UpdateDurations {
+                work,
+                short_break,
+                long_break,
+                cycles,
+            } => {
+                self.state
+                    .update_durations(work, short_break, long_break, cycles);
+            }
+        }
+    }
+}

--- a/crates/wayle-shell/src/shell/bar/modules/pomodoro/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/pomodoro/mod.rs
@@ -6,7 +6,13 @@ use std::{rc::Rc, sync::Arc};
 
 use gtk::prelude::*;
 use relm4::prelude::*;
-use wayle_config::{ConfigProperty, ConfigService, schemas::styling::CssToken};
+use wayle_config::{
+    ConfigProperty, ConfigService,
+    schemas::{
+        modules::PomodoroConfig,
+        styling::{ColorValue, CssToken, ThresholdColors},
+    },
+};
 use wayle_widgets::prelude::{
     BarButton, BarButtonBehavior, BarButtonColors, BarButtonInit, BarButtonInput, BarButtonOutput,
 };
@@ -16,7 +22,7 @@ pub(crate) use self::{
     messages::{PomodoroCmd, PomodoroInit, PomodoroMsg},
 };
 use crate::shell::{
-    SharedPomodoroState,
+    PomodoroMode, PomodoroSnapshot, SharedPomodoroState, TimerState,
     bar::dropdowns::{self, DropdownRegistry},
 };
 
@@ -51,11 +57,12 @@ impl Component for PomodoroModule {
         let config = init.config.config();
         let pomodoro_config = &config.modules.pomodoro;
 
-        let initial_label = init.state.snapshot().format_time();
+        let initial_snapshot = init.state.snapshot();
+        let initial_label = initial_snapshot.format_time();
 
         let bar_button = BarButton::builder()
             .launch(BarButtonInit {
-                icon: pomodoro_config.icon_name.get().clone(),
+                icon: Self::icon_for_snapshot(&initial_snapshot, pomodoro_config),
                 label: initial_label,
                 tooltip: None,
                 colors: BarButtonColors {
@@ -82,6 +89,10 @@ impl Component for PomodoroModule {
                 BarButtonOutput::ScrollUp => PomodoroMsg::ScrollUp,
                 BarButtonOutput::ScrollDown => PomodoroMsg::ScrollDown,
             });
+        bar_button.emit(BarButtonInput::SetThresholdColors(Self::colors_for_snapshot(
+            &initial_snapshot,
+            pomodoro_config,
+        )));
 
         watchers::spawn_watchers(&sender, pomodoro_config, &init.state);
 
@@ -119,11 +130,19 @@ impl Component for PomodoroModule {
     ) {
         match msg {
             PomodoroCmd::StateChanged(snapshot) => {
+                let pomodoro_config = &self.config.config().modules.pomodoro;
+                let icon = Self::icon_for_snapshot(&snapshot, pomodoro_config);
+                let colors = Self::colors_for_snapshot(&snapshot, pomodoro_config);
                 self.bar_button
                     .emit(BarButtonInput::SetLabel(snapshot.format_time()));
+                self.bar_button.emit(BarButtonInput::SetIcon(icon));
+                self.bar_button
+                    .emit(BarButtonInput::SetThresholdColors(colors));
             }
             PomodoroCmd::UpdateIcon(icon) => {
-                self.bar_button.emit(BarButtonInput::SetIcon(icon));
+                if self.state.snapshot().timer_state == TimerState::Stopped {
+                    self.bar_button.emit(BarButtonInput::SetIcon(icon));
+                }
             }
             PomodoroCmd::UpdateDurations {
                 work,
@@ -134,6 +153,35 @@ impl Component for PomodoroModule {
                 self.state
                     .update_durations(work, short_break, long_break, cycles);
             }
+        }
+    }
+}
+
+impl PomodoroModule {
+    fn icon_for_snapshot(snapshot: &PomodoroSnapshot, config: &PomodoroConfig) -> String {
+        match snapshot.timer_state {
+            TimerState::Stopped => config.icon_name.get().clone(),
+            TimerState::Running => String::from("ld-play-symbolic"),
+            TimerState::Paused => String::from("ld-pause-symbolic"),
+        }
+    }
+
+    fn colors_for_snapshot(
+        snapshot: &PomodoroSnapshot,
+        config: &PomodoroConfig,
+    ) -> ThresholdColors {
+        let accent = match snapshot.mode {
+            PomodoroMode::Work => config.work_color.get(),
+            PomodoroMode::ShortBreak => config.short_break_color.get(),
+            PomodoroMode::LongBreak => config.long_break_color.get(),
+        };
+
+        ThresholdColors {
+            icon_color: Some(ColorValue::Token(CssToken::FgOnAccent)),
+            label_color: Some(accent.clone()),
+            icon_background: Some(accent.clone()),
+            button_background: None,
+            border_color: Some(accent),
         }
     }
 }

--- a/crates/wayle-shell/src/shell/bar/modules/pomodoro/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/pomodoro/watchers.rs
@@ -1,0 +1,58 @@
+use std::time::Duration;
+
+use relm4::ComponentSender;
+use tokio::time::interval;
+use tokio_stream::wrappers::{IntervalStream, WatchStream};
+use wayle_config::schemas::modules::PomodoroConfig;
+use wayle_widgets::watch;
+
+use super::{PomodoroCmd, PomodoroModule};
+use crate::shell::SharedPomodoroState;
+
+pub(super) fn spawn_watchers(
+    sender: &ComponentSender<PomodoroModule>,
+    config: &PomodoroConfig,
+    state: &SharedPomodoroState,
+) {
+    let state_tick = state.clone();
+    let interval_stream = IntervalStream::new(interval(Duration::from_secs(1)));
+    watch!(sender, [interval_stream], |out| {
+        if let Some(snapshot) = state_tick.tick() {
+            let _ = out.send(PomodoroCmd::StateChanged(snapshot));
+        }
+    });
+
+    let state_stream = WatchStream::new(state.subscribe());
+    let state_watch = state.clone();
+    watch!(sender, [state_stream], |out| {
+        let _ = out.send(PomodoroCmd::StateChanged(state_watch.snapshot()));
+    });
+
+    let icon_name = config.icon_name.clone();
+    watch!(sender, [icon_name.watch()], |out| {
+        let _ = out.send(PomodoroCmd::UpdateIcon(icon_name.get().clone()));
+    });
+
+    let work = config.work_duration.clone();
+    let short_break = config.short_break_duration.clone();
+    let long_break = config.long_break_duration.clone();
+    let cycles = config.cycles_before_long_break.clone();
+
+    watch!(
+        sender,
+        [
+            work.watch(),
+            short_break.watch(),
+            long_break.watch(),
+            cycles.watch()
+        ],
+        |out| {
+            let _ = out.send(PomodoroCmd::UpdateDurations {
+                work: work.get(),
+                short_break: short_break.get(),
+                long_break: long_break.get(),
+                cycles: cycles.get(),
+            });
+        }
+    );
+}

--- a/crates/wayle-shell/src/shell/bar/modules/pomodoro/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/pomodoro/watchers.rs
@@ -33,6 +33,22 @@ pub(super) fn spawn_watchers(
         let _ = out.send(PomodoroCmd::UpdateIcon(icon_name.get().clone()));
     });
 
+    let work_color = config.work_color.clone();
+    let short_break_color = config.short_break_color.clone();
+    let long_break_color = config.long_break_color.clone();
+    let state_colors = state.clone();
+    watch!(
+        sender,
+        [
+            work_color.watch(),
+            short_break_color.watch(),
+            long_break_color.watch()
+        ],
+        |out| {
+            let _ = out.send(PomodoroCmd::StateChanged(state_colors.snapshot()));
+        }
+    );
+
     let work = config.work_duration.clone();
     let short_break = config.short_break_duration.clone();
     let long_break = config.long_break_duration.clone();

--- a/crates/wayle-shell/src/shell/bar/modules/pomodoro/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/pomodoro/watchers.rs
@@ -33,22 +33,6 @@ pub(super) fn spawn_watchers(
         let _ = out.send(PomodoroCmd::UpdateIcon(icon_name.get().clone()));
     });
 
-    let work_color = config.work_color.clone();
-    let short_break_color = config.short_break_color.clone();
-    let long_break_color = config.long_break_color.clone();
-    let state_colors = state.clone();
-    watch!(
-        sender,
-        [
-            work_color.watch(),
-            short_break_color.watch(),
-            long_break_color.watch()
-        ],
-        |out| {
-            let _ = out.send(PomodoroCmd::StateChanged(state_colors.snapshot()));
-        }
-    );
-
     let work = config.work_duration.clone();
     let short_break = config.short_break_duration.clone();
     let long_break = config.long_break_duration.clone();

--- a/crates/wayle-shell/src/shell/bar/pomodoro.rs
+++ b/crates/wayle-shell/src/shell/bar/pomodoro.rs
@@ -1,0 +1,221 @@
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::watch;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PomodoroMode {
+    Work,
+    ShortBreak,
+    LongBreak,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TimerState {
+    Stopped,
+    Running,
+    Paused,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PomodoroSnapshot {
+    pub(crate) mode: PomodoroMode,
+    pub(crate) timer_state: TimerState,
+    pub(crate) remaining_seconds: u32,
+}
+
+impl PomodoroSnapshot {
+    pub(crate) fn format_time(self) -> String {
+        let minutes = self.remaining_seconds / 60;
+        let seconds = self.remaining_seconds % 60;
+        format!("{minutes:02}:{seconds:02}")
+    }
+}
+
+struct PomodoroTimerState {
+    mode: PomodoroMode,
+    timer_state: TimerState,
+    remaining_seconds: u32,
+    work_duration: u32,
+    short_break_duration: u32,
+    long_break_duration: u32,
+    cycles_before_long_break: u32,
+    completed_cycles: u32,
+}
+
+impl PomodoroTimerState {
+    fn new(
+        work_duration: u32,
+        short_break_duration: u32,
+        long_break_duration: u32,
+        cycles_before_long_break: u32,
+    ) -> Self {
+        Self {
+            mode: PomodoroMode::Work,
+            timer_state: TimerState::Stopped,
+            remaining_seconds: work_duration * 60,
+            work_duration,
+            short_break_duration,
+            long_break_duration,
+            cycles_before_long_break,
+            completed_cycles: 0,
+        }
+    }
+
+    fn snapshot(&self) -> PomodoroSnapshot {
+        PomodoroSnapshot {
+            mode: self.mode,
+            timer_state: self.timer_state,
+            remaining_seconds: self.remaining_seconds,
+        }
+    }
+
+    fn tick(&mut self) -> bool {
+        if self.timer_state != TimerState::Running {
+            return false;
+        }
+
+        if self.remaining_seconds > 0 {
+            self.remaining_seconds -= 1;
+        } else {
+            self.on_timer_complete();
+        }
+        true
+    }
+
+    fn start(&mut self) {
+        self.timer_state = TimerState::Running;
+    }
+
+    fn pause(&mut self) {
+        self.timer_state = TimerState::Paused;
+    }
+
+    fn switch_mode(&mut self, mode: PomodoroMode) {
+        self.mode = mode;
+        self.timer_state = TimerState::Stopped;
+        self.remaining_seconds = match mode {
+            PomodoroMode::Work => self.work_duration * 60,
+            PomodoroMode::ShortBreak => self.short_break_duration * 60,
+            PomodoroMode::LongBreak => self.long_break_duration * 60,
+        };
+    }
+
+    fn update_durations(&mut self, work: u32, short_break: u32, long_break: u32, cycles: u32) {
+        self.work_duration = work;
+        self.short_break_duration = short_break;
+        self.long_break_duration = long_break;
+        self.cycles_before_long_break = cycles;
+
+        if self.timer_state == TimerState::Stopped {
+            self.remaining_seconds = match self.mode {
+                PomodoroMode::Work => work * 60,
+                PomodoroMode::ShortBreak => short_break * 60,
+                PomodoroMode::LongBreak => long_break * 60,
+            };
+        }
+    }
+
+    fn on_timer_complete(&mut self) {
+        match self.mode {
+            PomodoroMode::Work => {
+                self.completed_cycles += 1;
+                if self.completed_cycles >= self.cycles_before_long_break {
+                    self.switch_mode(PomodoroMode::LongBreak);
+                    self.completed_cycles = 0;
+                } else {
+                    self.switch_mode(PomodoroMode::ShortBreak);
+                }
+            }
+            PomodoroMode::ShortBreak | PomodoroMode::LongBreak => {
+                self.switch_mode(PomodoroMode::Work);
+            }
+        }
+    }
+}
+
+pub(crate) struct PomodoroSharedState {
+    state: Mutex<PomodoroTimerState>,
+    sender: watch::Sender<PomodoroSnapshot>,
+}
+
+impl PomodoroSharedState {
+    pub(crate) fn new(
+        work_duration: u32,
+        short_break_duration: u32,
+        long_break_duration: u32,
+        cycles_before_long_break: u32,
+    ) -> Self {
+        let state = PomodoroTimerState::new(
+            work_duration,
+            short_break_duration,
+            long_break_duration,
+            cycles_before_long_break,
+        );
+        let snapshot = state.snapshot();
+        let (sender, _) = watch::channel(snapshot);
+        Self {
+            state: Mutex::new(state),
+            sender,
+        }
+    }
+
+    pub(crate) fn snapshot(&self) -> PomodoroSnapshot {
+        self.state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .snapshot()
+    }
+
+    pub(crate) fn subscribe(&self) -> watch::Receiver<PomodoroSnapshot> {
+        self.sender.subscribe()
+    }
+
+    pub(crate) fn tick(&self) -> Option<PomodoroSnapshot> {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        if !state.tick() {
+            return None;
+        }
+
+        let snapshot = state.snapshot();
+        let _ = self.sender.send(snapshot);
+        Some(snapshot)
+    }
+
+    pub(crate) fn start(&self) -> PomodoroSnapshot {
+        self.mutate(|state| state.start())
+    }
+
+    pub(crate) fn pause(&self) -> PomodoroSnapshot {
+        self.mutate(|state| state.pause())
+    }
+
+    pub(crate) fn switch_mode(&self, mode: PomodoroMode) -> PomodoroSnapshot {
+        self.mutate(|state| state.switch_mode(mode))
+    }
+
+    pub(crate) fn update_durations(
+        &self,
+        work: u32,
+        short_break: u32,
+        long_break: u32,
+        cycles: u32,
+    ) -> PomodoroSnapshot {
+        self.mutate(|state| state.update_durations(work, short_break, long_break, cycles))
+    }
+
+    fn mutate(&self, f: impl FnOnce(&mut PomodoroTimerState)) -> PomodoroSnapshot {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
+        f(&mut state);
+        let snapshot = state.snapshot();
+        let _ = self.sender.send(snapshot);
+        snapshot
+    }
+}
+
+pub(crate) type SharedPomodoroState = Arc<PomodoroSharedState>;

--- a/crates/wayle-shell/src/shell/mod.rs
+++ b/crates/wayle-shell/src/shell/mod.rs
@@ -14,6 +14,9 @@ use relm4::{gtk, gtk::prelude::*, prelude::*};
 pub(crate) use services::ShellServices;
 use tracing::{debug, info};
 
+pub(crate) use self::bar::pomodoro::{
+    PomodoroMode, PomodoroSharedState, PomodoroSnapshot, SharedPomodoroState, TimerState,
+};
 use self::{
     notification_popup::{NotificationPopupHost, PopupHostInit},
     osd::{Osd, OsdInit},

--- a/crates/wayle-shell/src/shell/services.rs
+++ b/crates/wayle-shell/src/shell/services.rs
@@ -16,7 +16,10 @@ use wayle_systray::SystemTrayService;
 use wayle_wallpaper::WallpaperService;
 use wayle_weather::WeatherService;
 
-use crate::services::{IdleInhibitService, ShellIpcService};
+use crate::{
+    services::{IdleInhibitService, ShellIpcService},
+    shell::SharedPomodoroState,
+};
 
 /// Container for services used by shell components.
 ///
@@ -40,4 +43,5 @@ pub(crate) struct ShellServices {
     pub wallpaper: Option<Arc<WallpaperService>>,
     pub weather: Arc<WeatherService>,
     pub shell_ipc: Arc<ShellIpcService>,
+    pub pomodoro_state: SharedPomodoroState,
 }

--- a/crates/wayle-styling/scss/modules/_index.scss
+++ b/crates/wayle-styling/scss/modules/_index.scss
@@ -1,6 +1,7 @@
 @import "cava";
 @import "notification_popup";
 @import "osd";
+@import "pomodoro";
 @import "systray";
 @import "workspaces";
 @import "audio_dropdown";

--- a/crates/wayle-styling/scss/modules/_index.scss
+++ b/crates/wayle-styling/scss/modules/_index.scss
@@ -11,4 +11,5 @@
 @import "media_dropdown";
 @import "network_dropdown";
 @import "notification_dropdown";
+@import "pomodoro_dropdown";
 @import "weather_dropdown";

--- a/crates/wayle-styling/scss/modules/_pomodoro.scss
+++ b/crates/wayle-styling/scss/modules/_pomodoro.scss
@@ -1,0 +1,52 @@
+.pomodoro {
+    &.pomodoro-work {
+        menubutton.bar-button {
+            .bar-button-label {
+                color: var(--blue);
+            }
+
+            .icon-container {
+                background-color: var(--blue);
+            }
+
+            .icon-container image,
+            > button.toggle image {
+                color: var(--fg-on-accent);
+            }
+        }
+    }
+
+    &.pomodoro-short-break {
+        menubutton.bar-button {
+            .bar-button-label {
+                color: var(--green);
+            }
+
+            .icon-container {
+                background-color: var(--green);
+            }
+
+            .icon-container image,
+            > button.toggle image {
+                color: var(--fg-on-accent);
+            }
+        }
+    }
+
+    &.pomodoro-long-break {
+        menubutton.bar-button {
+            .bar-button-label {
+                color: var(--yellow);
+            }
+
+            .icon-container {
+                background-color: var(--yellow);
+            }
+
+            .icon-container image,
+            > button.toggle image {
+                color: var(--fg-on-accent);
+            }
+        }
+    }
+}

--- a/crates/wayle-styling/scss/modules/pomodoro_dropdown/_hero.scss
+++ b/crates/wayle-styling/scss/modules/pomodoro_dropdown/_hero.scss
@@ -1,0 +1,23 @@
+.pomodoro-dropdown {
+    .pomodoro-hero {
+        padding: 0 0 var(--space-xs);
+    }
+
+    label.pomodoro-hero-time {
+        font-size: calc(var(--text-2xl) * 2);
+        font-weight: var(--weight-normal);
+        color: var(--fg-default);
+    }
+
+    .pomodoro-hero-meta {
+        min-width: 0;
+    }
+
+    .pomodoro-hero-controls {
+        button.pomodoro-hero-toggle {
+            min-width: calc(var(--text-2xl) * 2);
+            min-height: calc(var(--text-2xl) * 2);
+            border-radius: 999px;
+        }
+    }
+}

--- a/crates/wayle-styling/scss/modules/pomodoro_dropdown/_index.scss
+++ b/crates/wayle-styling/scss/modules/pomodoro_dropdown/_index.scss
@@ -1,0 +1,1 @@
+@import "hero";


### PR DESCRIPTION
Basic pomodoro module.
<img width="344" height="301" alt="image" src="https://github.com/user-attachments/assets/1d3ea4e0-7a6a-40ab-85c7-dd57a374eb4b" />

to operate:
- in dropdown, you can choose between work / short break / long break, and start the timer
- even with dropdown closed, you can pause/start the timer (right click by default)
- after each mode completes, auto-advances (between work and short and long breaks) as configured
- icon changes based on timer (stopped=default, started and paused)
- color of label and icon changes based on current mode via scss

so once you know how it works, it shouldn't even require opening the dropdown to operate.

Remarks:
1) the timer countdown freezes on the bar module when dropdown is open, this was actually due to a deliberate change on master i believe
2) no notifications yet, not sure i would actually want this. personally i'm happy with the more subtle color changes
3) no integration with calendar, todo list systems etc. something to explore in the future
