### PR TITLE
feat: selectable start of the week for dropdown:calendar *SUGGESTION*

### DIFF
--- a/crates/wayle-config/src/schemas/modules/clock/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/clock/mod.rs
@@ -1,4 +1,5 @@
-use schemars::schema_for;
+use schemars::{JsonSchema, schema_for};
+use serde::{Deserialize, Serialize};
 use wayle_derive::wayle_config;
 
 use crate::{
@@ -7,7 +8,28 @@ use crate::{
     schemas::styling::{ColorValue, CssToken},
 };
 
-/// Time display with a calendar dropdown.
+/// Which day appears in the first column of the calendar dropdown.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum WeekStart {
+    /// Week starts on Monday.
+    Monday,
+    /// Week starts on Tuesday.
+    Tuesday,
+    /// Week starts on Wednesday.
+    Wednesday,
+    /// Week starts on Thursday.
+    Thursday,
+    /// Week starts on Friday.
+    Friday,
+    /// Week starts on Saturday.
+    Saturday,
+    /// Week starts on Sunday (default).
+    #[default]
+    Sunday,
+}
+
+/// Clock module configuration.
 #[wayle_config(bar_button, i18n_prefix = "settings-modules-clock")]
 pub struct ClockConfig {
     /// Format string using strftime syntax.
@@ -113,6 +135,11 @@ pub struct ClockConfig {
     #[serde(rename = "dropdown-show-seconds")]
     #[default(false)]
     pub dropdown_show_seconds: ConfigProperty<bool>,
+
+    /// First day of the week in the calendar dropdown.
+    #[serde(rename = "calendar-weekday-start")]
+    #[default(WeekStart::Sunday)]
+    pub calendar_weekday_start: ConfigProperty<WeekStart>,
 }
 
 impl ModuleInfoProvider for ClockConfig {

--- a/crates/wayle-config/src/schemas/modules/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/mod.rs
@@ -34,7 +34,7 @@ pub use cava::{
     BarCount as CavaBarCount, CavaConfig, CavaDirection, CavaInput, CavaStyle,
     Framerate as CavaFramerate, FrequencyHz,
 };
-pub use clock::ClockConfig;
+pub use clock::{ClockConfig, WeekStart};
 pub use cpu::CpuConfig;
 pub use custom::{CustomModuleDefinition, ExecutionMode, RestartDelay, RestartPolicy};
 pub use dashboard::DashboardConfig;

--- a/crates/wayle-config/src/schemas/modules/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/mod.rs
@@ -38,7 +38,7 @@ pub use cava::{
     BarCount as CavaBarCount, CavaConfig, CavaDirection, CavaInput, CavaStyle,
     Framerate as CavaFramerate, FrequencyHz,
 };
-pub use clock::ClockConfig;
+pub use clock::{ClockConfig, WeekStart};
 pub use cpu::CpuConfig;
 pub use custom::{CustomModuleDefinition, ExecutionMode, RestartDelay, RestartPolicy};
 pub use dashboard::DashboardConfig;

--- a/crates/wayle-i18n/locales/en-US/config/modules/_clock.ftl
+++ b/crates/wayle-i18n/locales/en-US/config/modules/_clock.ftl
@@ -52,3 +52,6 @@ settings-modules-clock-scroll-down = Scroll Down
 
 settings-modules-clock-dropdown-show-seconds = Show Seconds
     .description = Show seconds in the calendar dropdown clock display
+
+settings-modules-clock-calendar-weekday-start = Calendar Week Start
+    .description = First day of the week in the calendar dropdown

--- a/crates/wayle-shell/src/shell/bar/dropdowns/calendar/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/calendar/helpers.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Datelike, Local};
+use chrono::{DateTime, Datelike, Local, Weekday};
 
 use crate::i18n::t;
 
@@ -48,8 +48,9 @@ pub(super) fn day_names_array() -> [String; 7] {
     ]
 }
 
-pub(super) fn weekdays_array() -> [String; 7] {
-    [
+pub(super) fn weekdays_array(week_start: Weekday) -> [String; 7] {
+    // Base order is Sunday-first (matches num_days_from_sunday indexing).
+    let base = [
         t!("cal-weekday-sun"),
         t!("cal-weekday-mon"),
         t!("cal-weekday-tue"),
@@ -57,7 +58,10 @@ pub(super) fn weekdays_array() -> [String; 7] {
         t!("cal-weekday-thu"),
         t!("cal-weekday-fri"),
         t!("cal-weekday-sat"),
-    ]
+    ];
+    // Rotate left by the start day's Sunday-offset so week_start lands at col 0.
+    let rot = week_start.num_days_from_sunday() as usize;
+    std::array::from_fn(|i| base[(rot + i) % 7].clone())
 }
 
 pub(super) fn months_array() -> [String; 12] {

--- a/crates/wayle-shell/src/shell/bar/dropdowns/calendar/messages.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/calendar/messages.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use chrono::Weekday;
 use wayle_config::ConfigService;
 
 pub(crate) struct CalendarDropdownInit {
@@ -12,4 +13,5 @@ pub(crate) enum CalendarDropdownCmd {
     TimeTick,
     FormatChanged(bool),
     ShowSecondsChanged(bool),
+    WeekStartChanged(Weekday),
 }

--- a/crates/wayle-shell/src/shell/bar/dropdowns/calendar/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/calendar/mod.rs
@@ -16,6 +16,8 @@ use self::{
     helpers::{day_names_array, format_date_rest, months_array, weekdays_array},
     messages::{CalendarDropdownCmd, CalendarDropdownInit},
 };
+use chrono::Weekday;
+
 use crate::{i18n::t, shell::bar::dropdowns::scaled_dimension};
 
 const BASE_WIDTH: f32 = 340.0;
@@ -25,6 +27,7 @@ pub(crate) struct CalendarDropdown {
     scaled_width: i32,
     use_12h: bool,
     show_seconds: bool,
+    week_start: Weekday,
     last_today: NaiveDate,
 
     day_names: [String; 7],
@@ -162,15 +165,18 @@ impl Component for CalendarDropdown {
         let format_str = clock_config.format.get();
         let use_12h = helpers::is_12h_format(&format_str);
         let show_seconds = clock_config.dropdown_show_seconds.get();
+        let week_start =
+            watchers::week_start_to_weekday(clock_config.calendar_weekday_start.get());
 
         let months = months_array();
 
         let calendar = Calendar::builder()
             .launch(CalendarInit {
                 today,
+                week_start,
                 labels: CalendarLabels {
                     today: t!("cal-today"),
-                    weekdays: weekdays_array(),
+                    weekdays: weekdays_array(week_start),
                     months: months.clone(),
                     month_year: t!("cal-month-year", month = "{month}", year = "{year}"),
                 },
@@ -182,6 +188,7 @@ impl Component for CalendarDropdown {
         watchers::spawn(&sender, &init.config);
 
         let day_names = day_names_array();
+        // day_names is always Sunday-indexed, so index with num_days_from_sunday.
         let weekday_idx = now.weekday().num_days_from_sunday() as usize;
 
         let model = Self {
@@ -189,6 +196,7 @@ impl Component for CalendarDropdown {
             scaled_width: scaled_dimension(BASE_WIDTH, scale),
             use_12h,
             show_seconds,
+            week_start,
             last_today: today,
             hours: helpers::hours_text(&now, use_12h),
             minutes: helpers::minutes_text(&now),
@@ -243,6 +251,11 @@ impl Component for CalendarDropdown {
 
             CalendarDropdownCmd::ShowSecondsChanged(show) => {
                 self.show_seconds = show;
+            }
+
+            CalendarDropdownCmd::WeekStartChanged(week_start) => {
+                self.week_start = week_start;
+                self.calendar.emit(CalendarInput::UpdateWeekStart(week_start));
             }
         }
     }

--- a/crates/wayle-shell/src/shell/bar/dropdowns/calendar/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/calendar/watchers.rs
@@ -1,7 +1,8 @@
 use std::{sync::Arc, time::Duration};
 
 use relm4::ComponentSender;
-use wayle_config::ConfigService;
+use chrono::Weekday;
+use wayle_config::{ConfigService, schemas::modules::WeekStart};
 use wayle_widgets::watch;
 
 use super::{CalendarDropdown, helpers, messages::CalendarDropdownCmd};
@@ -13,6 +14,7 @@ pub(super) fn spawn(sender: &ComponentSender<CalendarDropdown>, config: &Arc<Con
     spawn_time_tick(sender);
     spawn_format_watcher(sender, config);
     spawn_show_seconds_watcher(sender, config);
+    spawn_week_start_watcher(sender, config);
 }
 
 fn spawn_scale_watcher(sender: &ComponentSender<CalendarDropdown>, config: &Arc<ConfigService>) {
@@ -57,4 +59,29 @@ fn spawn_show_seconds_watcher(
     watch!(sender, [show_seconds.watch()], |out| {
         let _ = out.send(CalendarDropdownCmd::ShowSecondsChanged(show_seconds.get()));
     });
+}
+
+fn spawn_week_start_watcher(
+    sender: &ComponentSender<CalendarDropdown>,
+    config: &Arc<ConfigService>,
+) {
+    let week_start_prop = config.config().modules.clock.calendar_weekday_start.clone();
+
+    watch!(sender, [week_start_prop.watch()], |out| {
+        let _ = out.send(CalendarDropdownCmd::WeekStartChanged(
+            week_start_to_weekday(week_start_prop.get()),
+        ));
+    });
+}
+
+pub(super) fn week_start_to_weekday(ws: WeekStart) -> Weekday {
+    match ws {
+        WeekStart::Monday => Weekday::Mon,
+        WeekStart::Tuesday => Weekday::Tue,
+        WeekStart::Wednesday => Weekday::Wed,
+        WeekStart::Thursday => Weekday::Thu,
+        WeekStart::Friday => Weekday::Fri,
+        WeekStart::Saturday => Weekday::Sat,
+        WeekStart::Sunday => Weekday::Sun,
+    }
 }

--- a/crates/wayle-widgets/src/components/calendar/helpers.rs
+++ b/crates/wayle-widgets/src/components/calendar/helpers.rs
@@ -18,15 +18,22 @@ pub struct DayCell {
 /// Always returns exactly 42 cells to keep the grid height stable across
 /// month navigation. Otherwise gtk annoyingly auto hides hides popovers
 /// when their dimensions change.
+///
+/// `week_start` controls which day appears in column 0.
 pub fn build_month_grid(
     month: NaiveDate,
     today: NaiveDate,
     selected: Option<NaiveDate>,
+    week_start: Weekday,
 ) -> Vec<DayCell> {
     let first_of_month = month.with_day(1).unwrap_or(month);
     let target_month = first_of_month.month();
 
-    let leading_days = first_of_month.weekday().num_days_from_sunday();
+    // Number of leading filler days before the 1st: how many days from week_start
+    // to first_of_month's weekday, counting forward (mod 7).
+    let start_offset = week_start.num_days_from_monday();
+    let dow_offset = first_of_month.weekday().num_days_from_monday();
+    let leading_days = (dow_offset + 7 - start_offset) % 7;
     let grid_start = first_of_month - Duration::days(i64::from(leading_days));
 
     (0..GRID_CELLS)
@@ -64,26 +71,26 @@ mod tests {
 
     #[test]
     fn always_produces_42_cells() {
-        let march = build_month_grid(date(2026, 3, 1), date(2026, 3, 5), None);
+        let march = build_month_grid(date(2026, 3, 1), date(2026, 3, 5), None, Weekday::Sun);
         assert_eq!(march.len(), 42);
 
-        let august = build_month_grid(date(2026, 8, 1), date(2026, 3, 5), None);
+        let august = build_month_grid(date(2026, 8, 1), date(2026, 3, 5), None, Weekday::Sun);
         assert_eq!(august.len(), 42);
 
-        let february = build_month_grid(date(2026, 2, 1), date(2026, 3, 5), None);
+        let february = build_month_grid(date(2026, 2, 1), date(2026, 3, 5), None, Weekday::Sun);
         assert_eq!(february.len(), 42);
     }
 
     #[test]
     fn march_2026_starts_on_sunday() {
-        let grid = build_month_grid(date(2026, 3, 1), date(2026, 3, 5), None);
+        let grid = build_month_grid(date(2026, 3, 1), date(2026, 3, 5), None, Weekday::Sun);
         assert_eq!(grid[0].date, date(2026, 3, 1));
         assert_eq!(grid[0].date.weekday(), Weekday::Sun);
     }
 
     #[test]
     fn march_2026_trailing_days_are_other_month() {
-        let grid = build_month_grid(date(2026, 3, 1), date(2026, 3, 5), None);
+        let grid = build_month_grid(date(2026, 3, 1), date(2026, 3, 5), None, Weekday::Sun);
         assert!(grid[30].is_current_month);
         assert_eq!(grid[30].date, date(2026, 3, 31));
         assert!(!grid[31].is_current_month);
@@ -92,7 +99,7 @@ mod tests {
 
     #[test]
     fn august_2026_starts_with_leading_days() {
-        let grid = build_month_grid(date(2026, 8, 1), date(2026, 3, 5), None);
+        let grid = build_month_grid(date(2026, 8, 1), date(2026, 3, 5), None, Weekday::Sun);
         assert_eq!(grid[0].date, date(2026, 7, 26));
         assert!(!grid[0].is_current_month);
     }
@@ -100,7 +107,7 @@ mod tests {
     #[test]
     fn today_is_highlighted() {
         let today = date(2026, 3, 5);
-        let grid = build_month_grid(date(2026, 3, 1), today, None);
+        let grid = build_month_grid(date(2026, 3, 1), today, None, Weekday::Sun);
         let march_5 = grid.iter().find(|c| c.date == today).unwrap();
         assert!(march_5.is_today);
         assert!(march_5.is_current_month);
@@ -109,22 +116,23 @@ mod tests {
     #[test]
     fn selected_day_is_marked() {
         let selected = date(2026, 3, 20);
-        let grid = build_month_grid(date(2026, 3, 1), date(2026, 3, 5), Some(selected));
+        let grid = build_month_grid(date(2026, 3, 1), date(2026, 3, 5), Some(selected), Weekday::Sun);
         let march_20 = grid.iter().find(|c| c.date == selected).unwrap();
         assert!(march_20.is_selected);
     }
 
     #[test]
     fn weekends_are_marked() {
-        let grid = build_month_grid(date(2026, 3, 1), date(2026, 3, 5), None);
-        assert!(grid[0].is_weekend);
-        assert!(!grid[1].is_weekend);
-        assert!(grid[6].is_weekend);
+        // is_weekend is date-based (Sat/Sun), independent of week start
+        let grid = build_month_grid(date(2026, 3, 1), date(2026, 3, 5), None, Weekday::Sun);
+        assert!(grid[0].is_weekend); // 2026-03-01 is a Sunday
+        assert!(!grid[1].is_weekend); // Monday
+        assert!(grid[6].is_weekend); // Saturday
     }
 
     #[test]
     fn february_2026_has_28_current_month_days() {
-        let grid = build_month_grid(date(2026, 2, 1), date(2026, 3, 5), None);
+        let grid = build_month_grid(date(2026, 2, 1), date(2026, 3, 5), None, Weekday::Sun);
         assert_eq!(grid[0].date, date(2026, 2, 1));
         let feb_cells: Vec<_> = grid.iter().filter(|cell| cell.is_current_month).collect();
         assert_eq!(feb_cells.len(), 28);
@@ -132,27 +140,27 @@ mod tests {
 
     #[test]
     fn today_in_different_month_not_highlighted() {
-        let grid = build_month_grid(date(2026, 4, 1), date(2026, 3, 5), None);
+        let grid = build_month_grid(date(2026, 4, 1), date(2026, 3, 5), None, Weekday::Sun);
         assert!(grid.iter().all(|c| !c.is_today));
     }
 
     #[test]
     fn any_day_in_month_selects_correct_month() {
-        let from_mid = build_month_grid(date(2026, 3, 15), date(2026, 3, 5), None);
-        let from_first = build_month_grid(date(2026, 3, 1), date(2026, 3, 5), None);
+        let from_mid = build_month_grid(date(2026, 3, 15), date(2026, 3, 5), None, Weekday::Sun);
+        let from_first = build_month_grid(date(2026, 3, 1), date(2026, 3, 5), None, Weekday::Sun);
         assert_eq!(from_mid, from_first);
     }
 
     #[test]
     fn leap_year_february_has_29_days() {
-        let grid = build_month_grid(date(2028, 2, 1), date(2028, 2, 15), None);
+        let grid = build_month_grid(date(2028, 2, 1), date(2028, 2, 15), None, Weekday::Sun);
         let feb_cells: Vec<_> = grid.iter().filter(|cell| cell.is_current_month).collect();
         assert_eq!(feb_cells.len(), 29);
     }
 
     #[test]
     fn december_year_boundary() {
-        let grid = build_month_grid(date(2026, 12, 1), date(2026, 12, 25), None);
+        let grid = build_month_grid(date(2026, 12, 1), date(2026, 12, 25), None, Weekday::Sun);
         let dec_cells: Vec<_> = grid.iter().filter(|cell| cell.is_current_month).collect();
         assert_eq!(dec_cells.len(), 31);
 
@@ -168,25 +176,38 @@ mod tests {
 
     #[test]
     fn january_year_boundary() {
-        let grid = build_month_grid(date(2027, 1, 1), date(2027, 1, 10), None);
+        let grid = build_month_grid(date(2027, 1, 1), date(2027, 1, 10), None, Weekday::Sun);
         let jan_cells: Vec<_> = grid.iter().filter(|cell| cell.is_current_month).collect();
         assert_eq!(jan_cells.len(), 31);
     }
 
     #[test]
-    fn first_column_is_always_sunday() {
-        for month in 1..=12 {
-            let grid = build_month_grid(date(2026, month, 1), date(2026, 1, 1), None);
-            assert_eq!(
-                grid[0].date.weekday(),
-                Weekday::Sun,
-                "month {month} col 0 not Sunday"
-            );
-            assert_eq!(
-                grid[6].date.weekday(),
-                Weekday::Sat,
-                "month {month} col 6 not Saturday"
-            );
+    fn first_column_matches_week_start() {
+        // (week_start, expected weekday at col 6)
+        let cases: &[(Weekday, Weekday)] = &[
+            (Weekday::Sun, Weekday::Sat),
+            (Weekday::Mon, Weekday::Sun),
+            (Weekday::Tue, Weekday::Mon),
+            (Weekday::Wed, Weekday::Tue),
+            (Weekday::Thu, Weekday::Wed),
+            (Weekday::Fri, Weekday::Thu),
+            (Weekday::Sat, Weekday::Fri),
+        ];
+        for &(start, expected_last_col) in cases {
+            for month in 1..=12 {
+                let grid =
+                    build_month_grid(date(2026, month, 1), date(2026, 1, 1), None, start);
+                assert_eq!(
+                    grid[0].date.weekday(),
+                    start,
+                    "start={start:?} month={month}: col 0 wrong"
+                );
+                assert_eq!(
+                    grid[6].date.weekday(),
+                    expected_last_col,
+                    "start={start:?} month={month}: col 6 wrong"
+                );
+            }
         }
     }
 

--- a/crates/wayle-widgets/src/components/calendar/messages.rs
+++ b/crates/wayle-widgets/src/components/calendar/messages.rs
@@ -1,8 +1,8 @@
-use chrono::NaiveDate;
+use chrono::{NaiveDate, Weekday};
 
 /// Localized strings for the calendar widget.
 pub struct CalendarLabels {
-    /// Abbreviated weekday names starting from Sunday.
+    /// Abbreviated weekday names starting from the configured week start day.
     pub weekdays: [String; 7],
     /// Full month names starting from January.
     pub months: [String; 12],
@@ -21,6 +21,8 @@ pub struct CalendarInit {
     pub today: NaiveDate,
     /// Localized strings for weekdays, months, and navigation.
     pub labels: CalendarLabels,
+    /// The weekday that appears in column 0 of the calendar grid.
+    pub week_start: Weekday,
 }
 
 /// Calendar widget input messages.
@@ -36,6 +38,8 @@ pub enum CalendarInput {
     DayClicked(NaiveDate),
     /// Midnight rollover — parent sends the new date.
     UpdateToday(NaiveDate),
+    /// Week start day changed at runtime via config hot-reload.
+    UpdateWeekStart(Weekday),
 }
 
 /// Calendar widget output messages.

--- a/crates/wayle-widgets/src/components/calendar/methods.rs
+++ b/crates/wayle-widgets/src/components/calendar/methods.rs
@@ -1,4 +1,4 @@
-use chrono::Datelike;
+use chrono::{Datelike, Weekday};
 use gtk::prelude::*;
 use relm4::{ComponentSender, gtk};
 
@@ -10,12 +10,13 @@ use crate::components::calendar::{
 impl Calendar {
     pub(super) fn rebuild_grid(&self, sender: &ComponentSender<Self>) {
         clear_grid(&self.grid);
-        attach_weekday_headers(&self.grid, &self.weekdays);
+        attach_weekday_headers(&self.grid, &self.weekdays, self.week_start);
         attach_day_cells(
             &self.grid,
             self.displayed_month,
             self.today,
             self.selected_day,
+            self.week_start,
             sender,
         );
     }
@@ -27,14 +28,19 @@ fn clear_grid(grid: &gtk::Grid) {
     }
 }
 
-fn attach_weekday_headers(grid: &gtk::Grid, weekdays: &[String; 7]) {
+fn attach_weekday_headers(grid: &gtk::Grid, weekdays: &[String; 7], week_start: Weekday) {
+    // Compute which columns land on Saturday and Sunday for the chosen week_start.
+    // num_days_from_monday: Mon=0, Tue=1, Wed=2, Thu=3, Fri=4, Sat=5, Sun=6
+    let start = week_start.num_days_from_monday() as usize;
+    let sat_col = (5usize + 7 - start) % 7;
+    let sun_col = (6usize + 7 - start) % 7;
+
     for (col, weekday_name) in weekdays.iter().enumerate() {
         let label = gtk::Label::new(Some(weekday_name));
         label.add_css_class("cal-weekday");
         label.set_hexpand(true);
 
-        let is_weekend = col == 0 || col == 6;
-        if is_weekend {
+        if col == sat_col || col == sun_col {
             label.add_css_class("weekend");
         }
 
@@ -47,9 +53,10 @@ fn attach_day_cells(
     displayed_month: chrono::NaiveDate,
     today: chrono::NaiveDate,
     selected_day: Option<chrono::NaiveDate>,
+    week_start: Weekday,
     sender: &ComponentSender<Calendar>,
 ) {
-    let cells = build_month_grid(displayed_month, today, selected_day);
+    let cells = build_month_grid(displayed_month, today, selected_day, week_start);
 
     for (idx, cell) in cells.iter().enumerate() {
         let col = (idx % 7) as i32;

--- a/crates/wayle-widgets/src/components/calendar/mod.rs
+++ b/crates/wayle-widgets/src/components/calendar/mod.rs
@@ -4,7 +4,7 @@ pub mod helpers;
 pub mod messages;
 mod methods;
 
-use chrono::{Datelike, Months, NaiveDate};
+use chrono::{Datelike, Months, NaiveDate, Weekday};
 use gtk::prelude::*;
 use relm4::{gtk, prelude::*};
 
@@ -21,6 +21,7 @@ pub struct Calendar {
     months: [String; 12],
     month_year_pattern: String,
     weekdays: [String; 7],
+    week_start: Weekday,
     grid: gtk::Grid,
 }
 
@@ -112,6 +113,7 @@ impl Component for Calendar {
             months: init.labels.months,
             month_year_pattern,
             weekdays: init.labels.weekdays,
+            week_start: init.week_start,
             grid: grid.clone(),
         };
 
@@ -167,6 +169,13 @@ impl Component for Calendar {
             CalendarInput::UpdateToday(new_today) => {
                 if self.today != new_today {
                     self.today = new_today;
+                    self.rebuild_grid(&sender);
+                }
+            }
+
+            CalendarInput::UpdateWeekStart(week_start) => {
+                if self.week_start != week_start {
+                    self.week_start = week_start;
                     self.rebuild_grid(&sender);
                 }
             }


### PR DESCRIPTION
:warning: VIBECODED w/ Claude (Sonnet 4.6) :warning: 
- I don't control rust in a capacity to meaningfully contribute myself.

Please consider introducing a feat that will allow user to select a starting day of a week.

:green_circle:  Confirmed to work

`calendar-weekday-start = "monday"`

Please don't mindlessly merge this :exclamation: 
If nothing else, please check whether the code is up to your standards or you can inspire yourself and close the PR altogether.