### PR TITLE
feat: Hyprland-workspaces allow highlight of ws active on different monitor if monitor-specific is false

### DIFF
--- a/crates/wayle-config/src/schemas/modules/hyprland_workspaces/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/hyprland_workspaces/mod.rs
@@ -331,6 +331,16 @@ pub struct HyprlandWorkspacesConfig {
     #[default(ActiveIndicator::Background)]
     pub active_indicator: ConfigProperty<ActiveIndicator>,
 
+    /// Highlight workspaces active on other monitors with a different color.
+    ///
+    /// When true, workspaces active on a different monior are highlicted differently.
+    /// When false, workspaces active on a another monitor are not specially highlighted.
+    ///
+    /// This setting only makes sense when `monitor-specific` is false.
+    #[serde(rename = "highlight-active-on-other-monitor")]
+    #[default(true)]
+    pub highlight_active_on_other_monitor: ConfigProperty<bool>,
+
     /// Color for the active (focused) workspace.
     ///
     /// Applied to icons and labels. In `background` indicator mode,
@@ -367,6 +377,13 @@ pub struct HyprlandWorkspacesConfig {
     #[serde(rename = "border-color")]
     #[default(ColorValue::Token(CssToken::BorderDefault))]
     pub border_color: ConfigProperty<ColorValue>,
+
+    /// Active on other minitor indicator color.
+    ///
+    /// Only applies when `highlight-active-on-other-monitor` is `true`.
+    #[serde(rename = "active-on-other-monitor-color")]
+    #[default(ColorValue::Token(CssToken::Accent))]
+    pub active_on_other_monitor_color: ConfigProperty<ColorValue>,
 
     /// Per-workspace icon and color overrides.
     ///

--- a/crates/wayle-i18n/locales/en-US/config/modules/_hyprland-workspaces.ftl
+++ b/crates/wayle-i18n/locales/en-US/config/modules/_hyprland-workspaces.ftl
@@ -11,6 +11,9 @@ settings-modules-hyprland-workspaces-monitor-specific = Monitor Specific
 settings-modules-hyprland-workspaces-show-special = Show Special
     .description = Include scratchpad workspaces
 
+settings-modules-hyprland-workspaces-highlight-active-on-other-monitor = Highlight Active on Other Monitor
+    .description = Use a different color for active workspaces on other monitors (only applies when { settings-modules-hyprland-workspaces-monitor-specific } is false)
+
 settings-modules-hyprland-workspaces-urgent-show = Show Urgent
     .description = Pulse animation on workspaces with urgent windows
 
@@ -58,6 +61,9 @@ settings-modules-hyprland-workspaces-active-indicator = Active Indicator
 
 settings-modules-hyprland-workspaces-active-color = Active Color
     .description = Color for focused workspace icons and labels
+
+settings-modules-hyprland-workspaces-active-on-other-monitor-color = Active on Other Monitor Color
+    .description = Color for focused workspace icons and labels active on other monitors (only used when { settings-modules-hyprland-workspaces-highlight-active-on-other-monitor } is true)
 
 settings-modules-hyprland-workspaces-occupied-color = Occupied Color
     .description = Color for occupied workspace icons and labels

--- a/crates/wayle-settings/src/pages/modules/hyprland_workspaces.rs
+++ b/crates/wayle-settings/src/pages/modules/hyprland_workspaces.rs
@@ -33,6 +33,7 @@ pub(crate) fn entry(config: &Config) -> LeafEntry {
                         number_u8(&module.min_workspace_count),
                         toggle(&module.monitor_specific),
                         toggle(&module.show_special),
+                        toggle(&module.highlight_active_on_other_monitor),
                     ],
                 },
                 SectionSpec {
@@ -98,6 +99,7 @@ pub(crate) fn entry(config: &Config) -> LeafEntry {
                     items: vec![
                         enum_select(&module.active_indicator),
                         color_value(&module.active_color),
+                        color_value(&module.active_on_other_monitor_color),
                         color_value(&module.occupied_color),
                         color_value(&module.empty_color),
                         color_value(&module.container_bg_color),

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/button/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/button/mod.rs
@@ -27,6 +27,7 @@ pub(crate) struct ButtonBuildContext<'a> {
     pub name: &'a str,
     pub windows: u16,
     pub is_active: bool,
+    pub is_active_any_monitor: bool,
     pub is_urgent: bool,
     pub is_vertical: bool,
 }
@@ -44,6 +45,7 @@ pub(crate) struct WorkspaceButtonInit {
     pub name: String,
     pub windows: u16,
     pub is_active: bool,
+    pub is_active_any_monitor: bool,
     pub is_urgent: bool,
     pub is_vertical: bool,
 
@@ -95,6 +97,7 @@ pub(crate) enum WorkspaceButtonInput {
     UpdateState {
         windows: u16,
         is_active: bool,
+        is_active_any_monitor: bool,
         is_urgent: bool,
         urgent_addresses: HashSet<Address>,
     },
@@ -173,7 +176,8 @@ impl FactoryComponent for WorkspaceButton {
     }
 
     fn init_model(init: Self::Init, _index: &DynamicIndex, _sender: FactorySender<Self>) -> Self {
-        let state = determine_workspace_state(init.is_active, init.windows);
+        let state =
+            determine_workspace_state(init.is_active, init.is_active_any_monitor, init.windows);
         let static_classes = compute_static_css_classes(
             init.id,
             init.active_indicator.css_class(),
@@ -242,10 +246,11 @@ impl FactoryComponent for WorkspaceButton {
             WorkspaceButtonInput::UpdateState {
                 windows,
                 is_active,
+                is_active_any_monitor,
                 is_urgent,
                 urgent_addresses,
             } => {
-                self.state = determine_workspace_state(is_active, windows);
+                self.state = determine_workspace_state(is_active, is_active_any_monitor, windows);
                 self.apply_urgency(is_urgent, &urgent_addresses);
             }
         }
@@ -293,6 +298,7 @@ pub(crate) fn build_button_init(
         name: ctx.name.to_string(),
         windows: ctx.windows,
         is_active: ctx.is_active,
+        is_active_any_monitor: ctx.is_active_any_monitor,
         is_urgent: ctx.is_urgent,
         is_vertical: ctx.is_vertical,
 

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/helpers.rs
@@ -130,6 +130,7 @@ pub(super) fn format_workspace_label(
 pub(crate) enum WorkspaceState {
     Active,
     Occupied,
+    ActiveOtherMonitor,
     Empty,
 }
 
@@ -137,6 +138,7 @@ impl WorkspaceState {
     pub fn css_class(self) -> &'static str {
         match self {
             Self::Active => "active",
+            Self::ActiveOtherMonitor => "active-other-monitor",
             Self::Occupied => "occupied",
             Self::Empty => "empty",
         }
@@ -167,9 +169,15 @@ pub(crate) fn matches_ignore_patterns(id: WorkspaceId, patterns: &[String]) -> b
     false
 }
 
-pub(crate) fn determine_workspace_state(is_active: bool, windows: u16) -> WorkspaceState {
+pub(crate) fn determine_workspace_state(
+    is_active: bool,
+    is_active_on_any_monitor: bool,
+    windows: u16,
+) -> WorkspaceState {
     if is_active {
         WorkspaceState::Active
+    } else if is_active_on_any_monitor {
+        WorkspaceState::ActiveOtherMonitor
     } else if windows > 0 {
         WorkspaceState::Occupied
     } else {
@@ -434,25 +442,34 @@ mod tests {
 
         #[test]
         fn active_takes_precedence() {
-            assert_eq!(determine_workspace_state(true, 5), WorkspaceState::Active);
+            assert_eq!(
+                determine_workspace_state(true, false, 5),
+                WorkspaceState::Active
+            );
         }
 
         #[test]
         fn active_with_no_windows() {
-            assert_eq!(determine_workspace_state(true, 0), WorkspaceState::Active);
+            assert_eq!(
+                determine_workspace_state(true, true, 0),
+                WorkspaceState::Active
+            );
         }
 
         #[test]
         fn occupied_when_has_windows() {
             assert_eq!(
-                determine_workspace_state(false, 3),
+                determine_workspace_state(false, false, 3),
                 WorkspaceState::Occupied
             );
         }
 
         #[test]
         fn empty_when_no_windows() {
-            assert_eq!(determine_workspace_state(false, 0), WorkspaceState::Empty);
+            assert_eq!(
+                determine_workspace_state(false, false, 0),
+                WorkspaceState::Empty
+            );
         }
     }
 

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/methods.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/methods.rs
@@ -134,6 +134,21 @@ impl HyprlandWorkspaces {
         }
     }
 
+    pub(super) fn initial_active_workspace_other_monitor(
+        hyprland: &Option<Arc<HyprlandService>>,
+    ) -> HashSet<WorkspaceId> {
+        let Some(hyprland) = hyprland else {
+            return HashSet::new();
+        };
+
+        hyprland
+            .monitors
+            .get()
+            .into_iter()
+            .map(|m| m.active_workspace.get().id)
+            .collect::<HashSet<WorkspaceId>>()
+    }
+
     pub(super) fn should_apply_workspace_event(&self) -> bool {
         let Some(bar_monitor) = self.settings.monitor_name.as_ref() else {
             return true;
@@ -182,10 +197,20 @@ impl HyprlandWorkspaces {
 
         let config = self.config.config();
         let monitor_specific = config.modules.hyprland_workspaces.monitor_specific.get();
+        let highlight_monitor_specific = config
+            .modules
+            .hyprland_workspaces
+            .highlight_active_on_other_monitor
+            .get();
 
         let monitors = hyprland.monitors.get();
 
-        if monitor_specific
+        self.active_workspace_any_monitor = monitors
+            .iter()
+            .map(|m| m.active_workspace.get().id)
+            .collect();
+
+        if (monitor_specific || highlight_monitor_specific)
             && let Some(bar_monitor) = &self.settings.monitor_name
             && let Some(monitor) = monitors.iter().find(|m| m.name.get() == *bar_monitor)
         {
@@ -245,6 +270,7 @@ impl HyprlandWorkspaces {
                     name: &ws.name,
                     windows: ws.windows,
                     is_active: ws.id == self.active_workspace_id,
+                    is_active_any_monitor: self.active_workspace_any_monitor.contains(&ws.id),
                     is_urgent,
                     is_vertical,
                 };
@@ -321,6 +347,7 @@ impl HyprlandWorkspaces {
                 WorkspaceButtonInput::UpdateState {
                     windows: self.window_count_for_workspace(button_id, hyprland),
                     is_active: button_id == self.active_workspace_id,
+                    is_active_any_monitor: self.active_workspace_any_monitor.contains(&button_id),
                     is_urgent,
                     urgent_addresses: urgent_addrs,
                 },

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/mod.rs
@@ -50,6 +50,7 @@ pub(crate) struct HyprlandWorkspaces {
     config: Arc<ConfigService>,
     settings: BarSettings,
     active_workspace_id: WorkspaceId,
+    active_workspace_any_monitor: HashSet<WorkspaceId>,
     focused_monitor: Option<String>,
     workspace_monitor_rules: HashMap<WorkspaceId, String>,
     urgent_windows: HashSet<Address>,
@@ -86,10 +87,15 @@ impl Component for HyprlandWorkspaces {
         let config = init.config.config();
         let workspaces_config = &config.modules.hyprland_workspaces;
         let monitor_specific = workspaces_config.monitor_specific.get();
+        let monitor_specific_highlight = workspaces_config.highlight_active_on_other_monitor.get();
         let theme_provider = config.styling.theme_provider.clone();
 
-        let active_id =
-            Self::initial_active_workspace(&init.hyprland, &init.settings, monitor_specific);
+        let active_id = Self::initial_active_workspace(
+            &init.hyprland,
+            &init.settings,
+            monitor_specific || monitor_specific_highlight,
+        );
+        let active_any_monitor = Self::initial_active_workspace_other_monitor(&init.hyprland);
         let focused_monitor = Self::initial_focused_monitor(&init.hyprland);
         let bar_scale = config.bar.scale.clone();
 
@@ -125,6 +131,7 @@ impl Component for HyprlandWorkspaces {
             config: init.config,
             settings: init.settings,
             active_workspace_id: active_id,
+            active_workspace_any_monitor: active_any_monitor,
             focused_monitor,
             workspace_monitor_rules: HashMap::new(),
             urgent_windows: HashSet::new(),
@@ -180,17 +187,27 @@ impl Component for HyprlandWorkspaces {
                 self.update_app_icons_on_title_change();
             }
             WorkspacesCmd::ActiveWorkspaceChanged(id) => {
-                let config = self.config.config();
-                let monitor_specific = config.modules.hyprland_workspaces.monitor_specific.get();
-                let has_min_workspace_count =
-                    config.modules.hyprland_workspaces.min_workspace_count.get() > 0;
+                let config_hypr = &self.config.config().modules.hyprland_workspaces;
+                let monitor_specific = config_hypr.monitor_specific.get();
+                let monitor_specific_highlight =
+                    config_hypr.highlight_active_on_other_monitor.get();
+                let has_min_workspace_count = config_hypr.min_workspace_count.get() > 0;
 
-                if !self.should_apply_active_workspace_change(id, monitor_specific) {
+                if !self.should_apply_active_workspace_change(
+                    id,
+                    monitor_specific || monitor_specific_highlight,
+                ) {
+                    if (!monitor_specific) && monitor_specific_highlight {
+                        self.rebuild_buttons();
+                    }
                     return;
                 }
 
                 self.clear_urgent_windows_for_workspace(id);
                 self.stop_blink_if_no_urgent();
+                self.active_workspace_any_monitor
+                    .remove(&self.active_workspace_id);
+                self.active_workspace_any_monitor.insert(id);
                 self.active_workspace_id = id;
                 self.sync_after_active_workspace_change(has_min_workspace_count);
             }
@@ -203,11 +220,16 @@ impl Component for HyprlandWorkspaces {
 
                 let config = self.config.config();
                 let monitor_specific = config.modules.hyprland_workspaces.monitor_specific.get();
+                let monitor_specific_highlight = config
+                    .modules
+                    .hyprland_workspaces
+                    .highlight_active_on_other_monitor
+                    .get();
                 let has_min_workspace_count =
                     config.modules.hyprland_workspaces.min_workspace_count.get() > 0;
 
                 if should_update_for_monitor(
-                    monitor_specific,
+                    monitor_specific || monitor_specific_highlight,
                     self.settings.monitor_name.as_deref(),
                     &monitor,
                 ) {

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/styling.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/styling.rs
@@ -24,6 +24,8 @@ pub(super) fn apply_styling(
     let is_wayle_theme = matches!(config.styling.theme_provider.get(), ThemeProvider::Wayle);
 
     let active_color = resolve_color(&ws_config.active_color, is_wayle_theme);
+    let active_on_other_color =
+        resolve_color(&ws_config.active_on_other_monitor_color, is_wayle_theme);
     let occupied_color = resolve_color(&ws_config.occupied_color, is_wayle_theme);
     let empty_color = resolve_color(&ws_config.empty_color, is_wayle_theme);
     let container_bg_color = resolve_color(&ws_config.container_bg_color, is_wayle_theme);
@@ -49,6 +51,7 @@ pub(super) fn apply_styling(
     let mut css = format!(
         ".workspaces {{ \
             --ws-active-color: {active_color}; \
+            --ws-active-other-monitor-color: {active_on_other_color}; \
             --ws-occupied-color: {occupied_color}; \
             --ws-empty-color: {empty_color}; \
             --ws-container-bg-color: {container_bg_color}; \

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/watchers.rs
@@ -149,6 +149,7 @@ fn spawn_config_watchers(
     let min_count = config.min_workspace_count.clone();
     let monitor_specific = config.monitor_specific.clone();
     let show_special = config.show_special.clone();
+    let highlight_active_on_other_monitor = config.highlight_active_on_other_monitor.clone();
     let urgent_show = config.urgent_show.clone();
     let display_mode = config.display_mode.clone();
     let label_use_name = config.label_use_name.clone();
@@ -165,6 +166,7 @@ fn spawn_config_watchers(
     let workspace_ignore = config.workspace_ignore.clone();
     let active_indicator = config.active_indicator.clone();
     let active_color = config.active_color.clone();
+    let active_on_other_color = config.active_on_other_monitor_color.clone();
     let occupied_color = config.occupied_color.clone();
     let empty_color = config.empty_color.clone();
     let container_bg_color = config.container_bg_color.clone();
@@ -182,6 +184,7 @@ fn spawn_config_watchers(
             min_count.watch(),
             monitor_specific.watch(),
             show_special.watch(),
+            highlight_active_on_other_monitor.watch(),
             urgent_show.watch(),
             display_mode.watch(),
             label_use_name.watch(),
@@ -198,6 +201,7 @@ fn spawn_config_watchers(
             workspace_ignore.watch(),
             active_indicator.watch(),
             active_color.watch(),
+            active_on_other_color.watch(),
             occupied_color.watch(),
             empty_color.watch(),
             container_bg_color.watch(),

--- a/crates/wayle-styling/scss/modules/_workspaces.scss
+++ b/crates/wayle-styling/scss/modules/_workspaces.scss
@@ -41,21 +41,42 @@
         &.active {
             background-color: var(--ws-override-color, var(--ws-active-color));
         }
+        &.active-other-monitor {
+            background-color: var(--ws-override-color, var(--ws-active-other-monitor-color));
+        }
     }
 
-    &.indicator-underline.active {
-        background-image: linear-gradient(
-            to top,
-            var(--ws-override-color, var(--ws-active-color)) 2px,
-            transparent 2px
-        );
-
-        &.vertical {
+    &.indicator-underline{
+        &.active {
             background-image: linear-gradient(
-                to right,
+                to top,
                 var(--ws-override-color, var(--ws-active-color)) 2px,
                 transparent 2px
             );
+
+            &.vertical {
+                background-image: linear-gradient(
+                    to right,
+                    var(--ws-override-color, var(--ws-active-color)) 2px,
+                    transparent 2px
+                );
+            }
+        }
+
+        &.active-other-monitor {
+            background-image: linear-gradient(
+                to top,
+                var(--ws-override-color, var(--ws-active-other-monitor-color)) 2px,
+                transparent 2px
+            );
+
+            &.vertical {
+                background-image: linear-gradient(
+                    to right,
+                    var(--ws-override-color, var(--ws-active-other-monitor-color)) 2px,
+                    transparent 2px
+                );
+            }
         }
     }
 
@@ -65,6 +86,24 @@
         .workspace-custom-icon,
         .workspace-divider {
             color: var(--ws-override-color, var(--ws-active-color));
+        }
+
+        &.indicator-background {
+            .workspace-label,
+            .workspace-icon,
+            .workspace-custom-icon,
+            .workspace-divider {
+                color: var(--fg-on-accent);
+            }
+        }
+    }
+
+    &.active-other-monitor {
+        .workspace-label,
+        .workspace-icon,
+        .workspace-custom-icon,
+        .workspace-divider {
+            color: var(--ws-override-color, var(--ws-active-other-monitor-color));
         }
 
         &.indicator-background {

--- a/docs/config/modules/hyprland-workspaces.md
+++ b/docs/config/modules/hyprland-workspaces.md
@@ -24,6 +24,7 @@ right = ["hyprland-workspaces"]
 | `min-workspace-count` | u8 | `0` | Minimum number of workspace buttons to display. |
 | `monitor-specific` | bool | `true` | Show only workspaces belonging to the bar's monitor. |
 | `show-special` | bool | `true` | Include special workspaces (scratchpads) in the display. |
+| `highlight-active-on-other-monitor` | bool | `true` | Highlight workspace active on current moinitor and workspaces on other monitors with a different color. |
 | `urgent-show` | bool | `true` | Pulse animation on workspaces with urgent windows. |
 | `urgent-mode` | [`UrgentMode`](/config/types#urgent-mode) | `"workspace"` | Where the urgent pulse is applied. |
 | `display-mode` | [`DisplayMode`](/config/types#display-mode) | `"label"` | What identifies each workspace button. |
@@ -41,6 +42,7 @@ right = ["hyprland-workspaces"]
 | `workspace-ignore` | array of string | `[]` | Workspaces to hide from the display. |
 | `active-indicator` | [`ActiveIndicator`](/config/types#active-indicator) | `"background"` | Visual indicator for the active workspace. |
 | `active-color` | [`ColorValue`](/config/types#color-value) | `"accent"` | Color for the active (focused) workspace. |
+| `active-on-other-monitor-color` | [`ColorValue`](/config/types#color-value) | `"accent"` | Color for workspaces active (focused) on different monitors. |
 | `occupied-color` | [`ColorValue`](/config/types#color-value) | `"fg-muted"` | Color for occupied workspaces (has windows but not focused). |
 | `empty-color` | [`ColorValue`](/config/types#color-value) | `"fg-subtle"` | Color for empty workspaces. |
 | `container-bg-color` | [`ColorValue`](/config/types#color-value) | `"bg-surface-elevated"` | Background color for the workspaces container. |
@@ -69,6 +71,14 @@ When false, all workspaces from all monitors are shown.
 Special workspaces have negative IDs in Hyprland.
 
 :::
+
+::: details More about `highlight-active-on-other-monitor`
+
+This option only has an effect when `monitor-specific` is false.
+- When false, the currently active workspace is highlighted with `active-color` on all monitors.
+- When true, the workspace active on the current monitor is indicated with `active-color`, but all workspaces active on different monitors are indicated with `active-on-other-monitor-color`.
+There will be no visual indication for the global active workspace.
+
 
 ::: details More about `urgent-show`
 
@@ -176,6 +186,14 @@ Glob patterns matching workspace IDs. Examples:
 
 Applied to icons and labels. In `background` indicator mode,
 also used as the button background.
+
+:::
+
+::: details More about `active-on-other-monitor-color`
+
+Applied to icons and labels. In `background` indicator mode,
+also used as the button background.
+Only makes a difference when `highlight-active-on-other-monitor` is true.
 
 :::
 


### PR DESCRIPTION
This should introduce the same feature as

https://github.com/Jas-SinghFSU/HyprPanel/pull/1106?notification_referrer_id=NT_kwHOAkahLNoAJVJlcG9zaXRvcnk7ODEyNTU0NjcxO0lzc3VlOzM0MTUwNDg4OTU#issuecomment-4302052114 


<img width="340" height="53" alt="image" src="https://github.com/user-attachments/assets/bdbb8c10-3968-4524-89ac-751c424fd65c" />
Previous state: if monitor-specific is false the global active workspace is highlighted not the WS active on the current monitor. Additionally, workspaces active on another monitor are not indicated at all.

<img width="347" height="51" alt="image" src="https://github.com/user-attachments/assets/6dda8928-9fda-4ed5-bdd4-4b0575b5833b" />
Now: The actual workspace active on the current monitor is highlighted (on each monitor a different one). Additionally, The monitors active on different monitors are highlighted in a different color.

## Objective

I use Hyprland with Qtile style workspaces, so a number of global workspaces that are moved to the currently focused monitor when the hotkey for that workspace is pressed.

You can use the same setup in Hyprland by using

```hyprlang
bind = $mainMod, A, focusworkspaceoncurrentmonitor, 1
bind = $mainMod, S, focusworkspaceoncurrentmonitor, 2
bind = $mainMod, D, focusworkspaceoncurrentmonitor, 3
bind = $mainMod, F, focusworkspaceoncurrentmonitor, 4
bind = $mainMod, G, focusworkspaceoncurrentmonitor, 5
bind = $mainMod, I, focusworkspaceoncurrentmonitor, 6
bind = $mainMod, 1, focusworkspaceoncurrentmonitor, 7
bind = $mainMod, 2, focusworkspaceoncurrentmonitor, 8
bind = $mainMod, 3, focusworkspaceoncurrentmonitor, 9
bind = $mainMod, 4, focusworkspaceoncurrentmonitor, 10
bind = $mainMod, 5, focusworkspaceoncurrentmonitor, 11
```

I then like to have a visual indicator on each monitor which workspace is currently displayed and which workspaces are currently opened by other monitors like the Qtile Groupbox widget:

https://docs.qtile.org/en/latest/manual/ref/widgets.html#groupbox

## Solution

Introduce two new settings:
- One for enabling this behaviour of highlighting the workspace on the correct monitor and highlighting workspaces active on another monitor
- One for the color of the other monitor highlight

## Notes

- I have basically no Rust knowledge
- I would have liked to preserve the occupied indicator on workspaces active on other monitors, but this would have meant more modifications, because as far as I can tell only one "modifier" can be active at a time.  Id did not want to change that much.
 
