### PR TITLE
feat: support workspace names as keys in workspace-map (#151)

### DIFF
--- a/crates/wayle-config/src/schemas/modules/hyprland_workspaces/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/hyprland_workspaces/mod.rs
@@ -100,37 +100,44 @@ pub struct WorkspaceStyle {
     pub color: Option<ColorValue>,
 }
 
-/// Per-workspace icon and color overrides, keyed by workspace ID.
+/// Per-workspace icon and color overrides, keyed by workspace ID or name.
 ///
-/// TOML table keys are always strings, so `"1"` parses into the workspace
-/// with ID `1`. Negative IDs refer to Hyprland's special workspaces. Keys
-/// that don't appear in the map fall back to the default behaviour set by
-/// [`HyprlandWorkspacesConfig::display_mode`].
+/// TOML table keys are always strings. Integer strings (`"1"`, `"-98"`) are
+/// matched against the workspace's numeric ID; any other string is matched
+/// against the workspace's name as reported by Hyprland.
+///
+/// Name-based keys are checked first, then numeric ID, so a name entry
+/// takes priority if both happen to match the same workspace.
+///
+/// Using name-based keys for special workspaces keeps icons and colors stable
+/// even when Hyprland reassigns the underlying numeric ID (which happens when
+/// a scratchpad is closed and reopened within the same session).
 ///
 /// ## Examples
 ///
 /// ```toml
 /// [modules.hyprland-workspaces.workspace-map]
-/// # Whole entry on one line with an inline table
+/// # Numeric ID keys (classic behaviour)
 /// 1 = { icon = "ld-globe-symbolic", color = "#4a90d9" }
 /// 2 = { icon = "ld-terminal-symbolic" }
-/// 3 = { icon = "ld-code-symbolic", color = "accent" }
 ///
-/// # Or spread the entry across its own subtable
-/// [modules.hyprland-workspaces.workspace-map.4]
-/// icon = "ld-message-square-symbolic"
-/// color = "status-success"
-///
-/// # Negative IDs target Hyprland special workspaces
-/// [modules.hyprland-workspaces.workspace-map.-99]
-/// icon = "ld-scratch-symbolic"
+/// # Name-based keys — stable across sessions and reopens
+/// "special:tilde"   = { icon = "utilities-terminal", color = "#fab387" }
+/// "special:spotify" = { icon = "spotify", color = "#1db954" }
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, JsonSchema)]
 #[schemars(transparent)]
-pub struct WorkspaceMap(HashMap<i32, WorkspaceStyle>);
+pub struct WorkspaceMap(HashMap<String, WorkspaceStyle>);
+
+impl WorkspaceMap {
+    /// Look up a workspace style by name first, falling back to numeric ID.
+    pub fn lookup(&self, id: i32, name: &str) -> Option<&WorkspaceStyle> {
+        self.0.get(name).or_else(|| self.0.get(&id.to_string()))
+    }
+}
 
 impl Deref for WorkspaceMap {
-    type Target = HashMap<i32, WorkspaceStyle>;
+    type Target = HashMap<String, WorkspaceStyle>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -138,8 +145,8 @@ impl Deref for WorkspaceMap {
 }
 
 impl<'a> IntoIterator for &'a WorkspaceMap {
-    type Item = (&'a i32, &'a WorkspaceStyle);
-    type IntoIter = std::collections::hash_map::Iter<'a, i32, WorkspaceStyle>;
+    type Item = (&'a String, &'a WorkspaceStyle);
+    type IntoIter = std::collections::hash_map::Iter<'a, String, WorkspaceStyle>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter()
@@ -151,12 +158,7 @@ impl Serialize for WorkspaceMap {
     where
         S: Serializer,
     {
-        let string_map: HashMap<String, &WorkspaceStyle> = self
-            .0
-            .iter()
-            .map(|(key, val)| (key.to_string(), val))
-            .collect();
-        string_map.serialize(serializer)
+        self.0.serialize(serializer)
     }
 }
 
@@ -165,13 +167,8 @@ impl<'de> Deserialize<'de> for WorkspaceMap {
     where
         D: Deserializer<'de>,
     {
-        let string_map: HashMap<String, WorkspaceStyle> = HashMap::deserialize(deserializer)?;
-        let mut result = HashMap::with_capacity(string_map.len());
-        for (key, value) in string_map {
-            let id: i32 = key.parse().map_err(serde::de::Error::custom)?;
-            result.insert(id, value);
-        }
-        Ok(WorkspaceMap(result))
+        let map = HashMap::deserialize(deserializer)?;
+        Ok(WorkspaceMap(map))
     }
 }
 
@@ -367,14 +364,17 @@ pub struct HyprlandWorkspacesConfig {
 
     /// Per-workspace icon and color overrides.
     ///
-    /// Keys are workspace IDs (use negative for special workspaces).
+    /// Keys are either numeric workspace IDs or workspace name strings.
+    /// Name keys are matched first, so they take priority over ID keys.
+    /// Use name keys for special workspaces to keep icons stable across
+    /// close/reopen cycles (e.g. `"special:tilde"`).
     ///
     /// ## Example
     ///
     /// ```toml
     /// [modules.hyprland-workspaces.workspace-map]
     /// 1 = { icon = "ld-globe-symbolic", color = "#4a90d9" }
-    /// 2 = { icon = "ld-terminal-symbolic" }
+    /// "special:tilde" = { icon = "utilities-terminal", color = "#fab387" }
     /// ```
     #[serde(rename = "workspace-map")]
     #[default(WorkspaceMap::default())]

--- a/crates/wayle-config/src/schemas/modules/hyprland_workspaces/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/hyprland_workspaces/mod.rs
@@ -1,4 +1,7 @@
-use std::{collections::BTreeMap, ops::Deref};
+use std::{
+    collections::{BTreeMap, HashMap},
+    ops::Deref,
+};
 
 use schemars::{JsonSchema, schema_for};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -102,21 +105,26 @@ pub struct WorkspaceStyle {
     pub label: Option<String>,
 }
 
-/// Per-workspace icon and color overrides, keyed by workspace ID.
+/// Per-workspace icon and color overrides, keyed by workspace ID or name.
 ///
-/// TOML table keys are always strings, so `"1"` parses into the workspace
-/// with ID `1`. Negative IDs refer to Hyprland's special workspaces. Keys
-/// that don't appear in the map fall back to the default behaviour set by
-/// [`HyprlandWorkspacesConfig::display_mode`].
+/// TOML table keys are always strings. Integer strings (`"1"`, `"-98"`) are
+/// matched against the workspace's numeric ID; any other string is matched
+/// against the workspace's name as reported by Hyprland.
+///
+/// Name-based keys are checked first, then numeric ID, so a name entry
+/// takes priority if both happen to match the same workspace.
+///
+/// Using name-based keys for special workspaces keeps icons and colors stable
+/// even when Hyprland reassigns the underlying numeric ID (which happens when
+/// a scratchpad is closed and reopened within the same session).
 ///
 /// ## Examples
 ///
 /// ```toml
 /// [modules.hyprland-workspaces.workspace-map]
-/// # Whole entry on one line with an inline table
+/// # Numeric ID keys (classic behaviour)
 /// 1 = { label = "Web", icon = "ld-globe-symbolic", color = "#4a90d9" }
 /// 2 = { icon = "ld-terminal-symbolic" }
-/// 3 = { icon = "ld-code-symbolic", color = "accent" }
 ///
 /// # Or spread the entry across its own subtable
 /// [modules.hyprland-workspaces.workspace-map.4]
@@ -127,13 +135,24 @@ pub struct WorkspaceStyle {
 /// # Negative IDs target Hyprland special workspaces
 /// [modules.hyprland-workspaces.workspace-map.-99]
 /// icon = "ld-scratch-symbolic"
+///
+/// # Name-based keys — stable across sessions and reopens
+/// "special:tilde"   = { icon = "utilities-terminal", color = "#fab387" }
+/// "special:spotify" = { icon = "spotify", color = "#1db954" }
 /// ```
 #[derive(Debug, Clone, Default, PartialEq, JsonSchema)]
 #[schemars(transparent)]
-pub struct WorkspaceMap(BTreeMap<i32, WorkspaceStyle>);
+pub struct WorkspaceMap(HashMap<String, WorkspaceStyle>);
+
+impl WorkspaceMap {
+    /// Look up a workspace style by name first, falling back to numeric ID.
+    pub fn lookup(&self, id: i32, name: &str) -> Option<&WorkspaceStyle> {
+        self.0.get(name).or_else(|| self.0.get(&id.to_string()))
+    }
+}
 
 impl Deref for WorkspaceMap {
-    type Target = BTreeMap<i32, WorkspaceStyle>;
+    type Target = HashMap<String, WorkspaceStyle>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -141,8 +160,8 @@ impl Deref for WorkspaceMap {
 }
 
 impl<'a> IntoIterator for &'a WorkspaceMap {
-    type Item = (&'a i32, &'a WorkspaceStyle);
-    type IntoIter = std::collections::btree_map::Iter<'a, i32, WorkspaceStyle>;
+    type Item = (&'a String, &'a WorkspaceStyle);
+    type IntoIter = std::collections::hash_map::Iter<'a, String, WorkspaceStyle>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.iter()
@@ -154,12 +173,7 @@ impl Serialize for WorkspaceMap {
     where
         S: Serializer,
     {
-        let string_map: BTreeMap<String, &WorkspaceStyle> = self
-            .0
-            .iter()
-            .map(|(key, val)| (key.to_string(), val))
-            .collect();
-        string_map.serialize(serializer)
+        self.0.serialize(serializer)
     }
 }
 
@@ -168,13 +182,8 @@ impl<'de> Deserialize<'de> for WorkspaceMap {
     where
         D: Deserializer<'de>,
     {
-        let string_map: BTreeMap<String, WorkspaceStyle> = BTreeMap::deserialize(deserializer)?;
-        let mut result = BTreeMap::new();
-        for (key, value) in string_map {
-            let id: i32 = key.parse().map_err(serde::de::Error::custom)?;
-            result.insert(id, value);
-        }
-        Ok(WorkspaceMap(result))
+        let map = HashMap::deserialize(deserializer)?;
+        Ok(WorkspaceMap(map))
     }
 }
 
@@ -370,14 +379,17 @@ pub struct HyprlandWorkspacesConfig {
 
     /// Per-workspace icon and color overrides.
     ///
-    /// Keys are workspace IDs (use negative for special workspaces).
+    /// Keys are either numeric workspace IDs or workspace name strings.
+    /// Name keys are matched first, so they take priority over ID keys.
+    /// Use name keys for special workspaces to keep icons stable across
+    /// close/reopen cycles (e.g. `"special:tilde"`).
     ///
     /// ## Example
     ///
     /// ```toml
     /// [modules.hyprland-workspaces.workspace-map]
     /// 1 = { icon = "ld-globe-symbolic", color = "#4a90d9" }
-    /// 2 = { icon = "ld-terminal-symbolic" }
+    /// "special:tilde" = { icon = "utilities-terminal", color = "#fab387" }
     /// ```
     #[serde(rename = "workspace-map")]
     #[default(WorkspaceMap::default())]

--- a/crates/wayle-config/src/schemas/modules/hyprland_workspaces/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/hyprland_workspaces/mod.rs
@@ -3,14 +3,14 @@ use std::{
     ops::Deref,
 };
 
-use schemars::{JsonSchema, schema_for};
+use schemars::{schema_for, JsonSchema};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use wayle_derive::{wayle_config, wayle_enum};
 
 use crate::{
-    ConfigProperty,
     docs::{ConfigGroup, GroupDefaults, ModuleInfo, ModuleInfoProvider},
     schemas::styling::{ColorValue, CssToken, ScaleFactor, Spacing},
+    ConfigProperty,
 };
 
 /// What identifies a workspace in the UI.
@@ -146,7 +146,7 @@ pub struct WorkspaceMap(HashMap<String, WorkspaceStyle>);
 
 impl WorkspaceMap {
     /// Look up a workspace style by name first, falling back to numeric ID.
-    pub fn lookup(&self, id: i32, name: &str) -> Option<&WorkspaceStyle> {
+    pub fn lookup(&self, id: i64, name: &str) -> Option<&WorkspaceStyle> {
         self.0.get(name).or_else(|| self.0.get(&id.to_string()))
     }
 }

--- a/crates/wayle-config/src/schemas/modules/hyprland_workspaces/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/hyprland_workspaces/mod.rs
@@ -3,14 +3,14 @@ use std::{
     ops::Deref,
 };
 
-use schemars::{schema_for, JsonSchema};
+use schemars::{JsonSchema, schema_for};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use wayle_derive::{wayle_config, wayle_enum};
 
 use crate::{
+    ConfigProperty,
     docs::{ConfigGroup, GroupDefaults, ModuleInfo, ModuleInfoProvider},
     schemas::styling::{ColorValue, CssToken, ScaleFactor, Spacing},
-    ConfigProperty,
 };
 
 /// What identifies a workspace in the UI.

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/button/methods.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/button/methods.rs
@@ -51,12 +51,14 @@ impl WorkspaceButton {
     }
 
     pub(super) fn current_css_classes(&self) -> Vec<&str> {
-        collect_button_css_classes(
+        let mut classes = collect_button_css_classes(
             &self.static_classes,
             &self.css_id_class,
             self.state,
             self.is_urgent,
-        )
+        );
+        classes.push(&self.css_name_class);
+        classes
     }
 
     pub(super) fn orientation(&self) -> gtk::Orientation {

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/button/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/button/mod.rs
@@ -9,7 +9,7 @@ use wayle_hyprland::{Address, Client, WorkspaceId};
 
 use crate::shell::bar::modules::hyprland_workspaces::helpers::{
     IconContext, WorkspaceState, compute_static_css_classes, determine_workspace_state,
-    resolve_workspace_icons, workspace_id_css_class,
+    resolve_workspace_icons, workspace_id_css_class, workspace_name_css_class,
 };
 
 const WORKSPACE_LABEL_CSS: &str = "workspace-label";
@@ -70,6 +70,7 @@ pub(crate) struct WorkspaceButton {
     pub(super) state: WorkspaceState,
     pub(super) is_urgent: bool,
     pub(super) css_id_class: String,
+    pub(super) css_name_class: String,
     pub(super) static_classes: Vec<&'static str>,
 
     pub(super) display_id: WorkspaceId,
@@ -183,6 +184,7 @@ impl FactoryComponent for WorkspaceButton {
             state,
             is_urgent: init.is_urgent,
             css_id_class: workspace_id_css_class(init.id),
+            css_name_class: workspace_name_css_class(&init.name),
             static_classes,
 
             display_id: init.display_id,
@@ -256,10 +258,10 @@ pub(crate) fn build_button_init(
     urgent_addresses: HashSet<Address>,
 ) -> WorkspaceButtonInit {
     let workspace_map = config.workspace_map.get();
-    let mapped_icon = i32::try_from(ctx.id)
+    let mapped_style = i32::try_from(ctx.id)
         .ok()
-        .and_then(|style_id| workspace_map.get(&style_id))
-        .and_then(|style| style.icon.clone());
+        .and_then(|id| workspace_map.lookup(id, ctx.name));
+    let mapped_icon = mapped_style.and_then(|style| style.icon.clone());
 
     let app_icons = if config.app_icons_show.get() {
         let user_map = config.app_icon_map.get();

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/button/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/button/mod.rs
@@ -9,7 +9,7 @@ use wayle_hyprland::{Address, Client, WorkspaceId};
 
 use crate::shell::bar::modules::hyprland_workspaces::helpers::{
     IconContext, WorkspaceState, compute_static_css_classes, determine_workspace_state,
-    resolve_workspace_icons, workspace_id_css_class,
+    resolve_workspace_icons, workspace_id_css_class, workspace_name_css_class,
 };
 
 const WORKSPACE_LABEL_CSS: &str = "workspace-label";
@@ -71,6 +71,7 @@ pub(crate) struct WorkspaceButton {
     pub(super) state: WorkspaceState,
     pub(super) is_urgent: bool,
     pub(super) css_id_class: String,
+    pub(super) css_name_class: String,
     pub(super) static_classes: Vec<&'static str>,
 
     pub(super) display_id: WorkspaceId,
@@ -185,6 +186,7 @@ impl FactoryComponent for WorkspaceButton {
             state,
             is_urgent: init.is_urgent,
             css_id_class: workspace_id_css_class(init.id),
+            css_name_class: workspace_name_css_class(&init.name),
             static_classes,
 
             display_id: init.display_id,
@@ -261,7 +263,7 @@ pub(crate) fn build_button_init(
     let workspace_map = config.workspace_map.get();
     let mapped_style = i32::try_from(ctx.id)
         .ok()
-        .and_then(|style_id| workspace_map.get(&style_id));
+        .and_then(|id| workspace_map.lookup(id, ctx.name));
     let mapped_icon = mapped_style.and_then(|style| style.icon.clone());
     let mapped_label = mapped_style.and_then(|style| style.label.clone());
 

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/button/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/button/mod.rs
@@ -8,8 +8,8 @@ use wayle_config::schemas::modules::{ActiveIndicator, DisplayMode, HyprlandWorks
 use wayle_hyprland::{Address, Client, WorkspaceId};
 
 use crate::shell::bar::modules::hyprland_workspaces::helpers::{
-    compute_static_css_classes, determine_workspace_state, resolve_workspace_icons,
-    workspace_id_css_class, workspace_name_css_class, IconContext, WorkspaceState,
+    IconContext, WorkspaceState, compute_static_css_classes, determine_workspace_state,
+    resolve_workspace_icons, workspace_id_css_class, workspace_name_css_class,
 };
 
 const WORKSPACE_LABEL_CSS: &str = "workspace-label";

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/button/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/button/mod.rs
@@ -8,8 +8,8 @@ use wayle_config::schemas::modules::{ActiveIndicator, DisplayMode, HyprlandWorks
 use wayle_hyprland::{Address, Client, WorkspaceId};
 
 use crate::shell::bar::modules::hyprland_workspaces::helpers::{
-    IconContext, WorkspaceState, compute_static_css_classes, determine_workspace_state,
-    resolve_workspace_icons, workspace_id_css_class, workspace_name_css_class,
+    compute_static_css_classes, determine_workspace_state, resolve_workspace_icons,
+    workspace_id_css_class, workspace_name_css_class, IconContext, WorkspaceState,
 };
 
 const WORKSPACE_LABEL_CSS: &str = "workspace-label";
@@ -261,9 +261,7 @@ pub(crate) fn build_button_init(
     urgent_addresses: HashSet<Address>,
 ) -> WorkspaceButtonInit {
     let workspace_map = config.workspace_map.get();
-    let mapped_style = i32::try_from(ctx.id)
-        .ok()
-        .and_then(|id| workspace_map.lookup(id, ctx.name));
+    let mapped_style = workspace_map.lookup(ctx.id, ctx.name);
     let mapped_icon = mapped_style.and_then(|style| style.icon.clone());
     let mapped_label = mapped_style.and_then(|style| style.label.clone());
 

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/helpers.rs
@@ -151,6 +151,14 @@ pub(crate) fn workspace_id_css_class(id: WorkspaceId) -> String {
     }
 }
 
+pub(crate) fn workspace_name_css_class(name: &str) -> String {
+    let safe: String = name
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { '-' })
+        .collect();
+    format!("workspace-name-{safe}")
+}
+
 pub(crate) fn matches_ignore_patterns(id: WorkspaceId, patterns: &[String]) -> bool {
     if patterns.is_empty() {
         return false;

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/styling.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/styling.rs
@@ -4,7 +4,7 @@ use relm4::gtk;
 use wayle_config::{ConfigService, schemas::styling::ThemeProvider};
 use wayle_widgets::{prelude::BarSettings, styling::resolve_color};
 
-use super::helpers::workspace_id_css_class;
+use super::helpers::{workspace_id_css_class, workspace_name_css_class};
 
 const REM_BASE: f32 = 16.0;
 const ICON_BASE_REM: f32 = 1.3;
@@ -61,15 +61,19 @@ pub(super) fn apply_styling(
         }}"
     );
 
-    for (workspace_id, style) in &ws_config.workspace_map.get() {
+    for (key, style) in &ws_config.workspace_map.get() {
         let Some(color) = style.color.as_ref() else {
             continue;
         };
 
-        let id_class = workspace_id_css_class(i64::from(*workspace_id));
+        let css_class = if let Ok(id) = key.parse::<i32>() {
+            workspace_id_css_class(i64::from(id))
+        } else {
+            workspace_name_css_class(key)
+        };
         let color_css = color.to_css();
         css.push_str(&format!(
-            ".workspaces .workspace.{id_class} {{ --ws-override-color: {color_css}; }}"
+            ".workspaces .workspace.{css_class} {{ --ws-override-color: {color_css}; }}"
         ));
     }
 


### PR DESCRIPTION
Fixes #151

Before:
After initial load you could set the applications to a negative id. The issue arrises when you close that app and reopen the applications to the negative ids now do not match up:
<img width="252" height="45" alt="image" src="https://github.com/user-attachments/assets/d72b8c25-4099-4d45-a078-391f70a0b65c" />

After the changes you can map icons to the workspace name also:
<img width="233" height="52" alt="image" src="https://github.com/user-attachments/assets/54a18121-5501-468c-b2ff-dfc3172c9661" />

Configuration:
```toml
[modules.hyprland-workspaces.workspace-map."special:tilde"]
icon = "utilities-terminal"
color = "#fab387"

[modules.hyprland-workspaces.workspace-map."special:spotify"]
icon = "spotify"
color = "#1db954"

[modules.hyprland-workspaces.workspace-map."special:discord"]
icon = "discord"
color = "#7289da"

[modules.hyprland-workspaces.workspace-map."special:steam"]
icon = "steam"
color = "#c6d4df"
```

## Objective

Special workspaces get negative numeric IDs assigned by Hyprland at runtime based on creation order, which is non-deterministic. This makes `workspace-map` numeric keys unreliable — icons shuffle after most reboots.

## Solution

Change `WorkspaceMap` internal key type from `i32` to `String`. Keys that parse as integers are matched against the workspace's numeric ID; all other keys are matched against the workspace name reported by Hyprland. Name-based keys are checked first, so they take priority over numeric keys.

Also adds a `workspace-name-{name}` CSS class to each workspace button so that name-based color overrides in `styling.rs` are applied correctly.

Existing numeric key behaviour is unchanged.

## Test Plan
- [ ] Numeric ID keys still resolve correctly
- [ ] Name-based keys resolve and take priority over numeric keys for the same workspace
- [ ] Color overrides apply correctly via the new `workspace-name-*` CSS class
- [ ] `cargo fmt` and `cargo clippy --workspace` pass