### PR TITLE
fix: fetch charge support info from battery device instead of DisplayDevice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4523,8 +4523,6 @@ dependencies = [
 [[package]]
 name = "wayle-battery"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84c4e68a9846ac0ef9bc9582595480250bfd189be6b4857965a7843766b7bb3"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -4623,8 +4621,6 @@ dependencies = [
 [[package]]
 name = "wayle-core"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "867109345d4043305fbee2df1847e8cd9ca33bac34550b541323fc17ae81e513"
 dependencies = [
  "futures",
  "schemars",
@@ -4938,8 +4934,6 @@ dependencies = [
 [[package]]
 name = "wayle-traits"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0833629ad4481a1302cb6df07da2b438bdb1c99dc5e5844e3198d53945728a6d"
 
 [[package]]
 name = "wayle-wallpaper"

--- a/crates/wayle-shell/src/bootstrap/mod.rs
+++ b/crates/wayle-shell/src/bootstrap/mod.rs
@@ -202,7 +202,17 @@ async fn init_core_services(
 
     let startup_duration = modules.idle_inhibit.startup_duration.get();
 
-    let battery_task = tokio::spawn(BatteryService::new());
+    let battery_task = tokio::spawn(async {
+        let devices = BatteryService::enumerate_devices().await?;
+        let battery_path = devices
+            .into_iter()
+            .find(|p| p.as_str().contains("/battery_"));
+        if let Some(path) = battery_path {
+            BatteryService::builder().device_path(path).build().await
+        } else {
+            BatteryService::new().await
+        }
+    });
     let brightness_task = tokio::spawn(BrightnessService::new());
     let network_task = tokio::spawn(NetworkService::new());
     let wallpaper_cfg = config.wallpaper.clone();


### PR DESCRIPTION
<!--
- Link to a related issue with "Fixes #123" if one exists
- For visual changes, include before/after screenshots
- Ensure `cargo fmt` and `cargo clippy --workspace` pass
-->

## Objective
As it stands, because the battery module fetches DBus properties from DisplayDevice, charge limits always be marked as "not supported" since the DisplayDevice does not contain charge limit support information. The relevant issue is posted in wayle-services [(#15)](https://github.com/wayle-rs/wayle-services/issues/15). This is a companion PR to wayle-services [#16](https://github.com/wayle-rs/wayle-services/pull/16)

## Solution
In wayle-services, a new UPower proxy is added with an enumerate_devices() function. In the Wayle shell, the first battery device is found and used instead of DisplayDevice. This diverges from what is recommended by UPower, but will be fine for the majority of devices. It is possible to keep DisplayDevice for power information and just use individual battery devices for charge limits, however it'll require an extra design decision (I'd like some input from maintainers on this).

## Test Plan
1. Pull the changes in both wayle and wayle-services
2. In the wayle repo, add the following to Cargo.toml:
[patch.crates-io]                                            
wayle-battery = { path = "/path/to/wayle-services/wayle-battery" }
wayle-core = { path = "/path/to/wayle-services/wayle-core" }       
wayle-traits = { path = "/path/to/wayle-services/wayle-traits" }
3. Compile and run with `cargo run --bin wayle -- shell`
4. Open the battery module and verify the charge limit switch is shown