### PR TITLE
feat: add visibility toggle for media module

### DIFF
--- a/crates/wayle-config/src/schemas/modules/media/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/media/mod.rs
@@ -85,6 +85,11 @@ pub struct MediaConfig {
     #[default(String::from("{{ title }} - {{ artist }}"))]
     pub format: ConfigProperty<String>,
 
+    /// Visibility mode for the module.
+    #[serde(rename = "visibility")]
+    #[default(MediaVisibility::Always)]
+    pub visibility: ConfigProperty<MediaVisibility>,
+
     /// Symbolic icon name for default mode.
     #[serde(rename = "icon-name")]
     #[default(String::from("ld-music-symbolic"))]
@@ -188,6 +193,29 @@ impl MediaIconType {
             Self::Application => "application",
             Self::SpinningDisc => "spinning-disc",
             Self::ApplicationMapped => "application-mapped",
+        }
+    }
+}
+
+/// Visibility mode for the media module.
+#[wayle_enum(default)]
+pub enum MediaVisibility {
+    /// Always show the module.
+    #[default]
+    Always,
+    /// Only show when a player is in Playing state.
+    Playing,
+    /// Only show when an active media player exists.
+    Active,
+}
+
+impl MediaVisibility {
+    /// Returns the kebab-case string representation.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Always => "always",
+            Self::Playing => "playing",
+            Self::Active => "active",
         }
     }
 }

--- a/crates/wayle-config/src/schemas/modules/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/mod.rs
@@ -48,7 +48,7 @@ pub use hyprsunset::HyprsunsetConfig;
 pub use idle_inhibit::IdleInhibitConfig;
 pub use keybind_mode::KeybindModeConfig;
 pub use keyboard_input::KeyboardInputConfig;
-pub use media::{BUILTIN_MAPPINGS, MediaConfig, MediaIconType};
+pub use media::{BUILTIN_MAPPINGS, MediaConfig, MediaIconType, MediaVisibility};
 pub use microphone::MicrophoneConfig;
 pub use netstat::NetstatConfig;
 pub use network::NetworkConfig;

--- a/crates/wayle-i18n/locales/en-US/config/modules/_media.ftl
+++ b/crates/wayle-i18n/locales/en-US/config/modules/_media.ftl
@@ -17,6 +17,9 @@ settings-modules-media-player-priority = Player Priority
 settings-modules-media-format = Format
     .description = Label format with placeholders: {"{{ title }}"}, {"{{ artist }}"}, {"{{ album }}"}, {"{{ status }}"}, {"{{ status_icon }}"}
 
+settings-modules-media-visibility = Visibility
+    .description = Visibility mode for the module
+
 settings-modules-media-icon-name = Icon Name
     .description = Symbolic icon name for default mode
 
@@ -71,3 +74,8 @@ enum-media-icon-type-default = Default
 enum-media-icon-type-application = Application
 enum-media-icon-type-spinning-disc = Spinning Disc
 enum-media-icon-type-application-mapped = Application Mapped
+
+## MediaVisibility variants
+enum-media-visibility-always = Always
+enum-media-visibility-playing = Playing
+enum-media-visibility-active = Active

--- a/crates/wayle-settings/src/pages/modules/media.rs
+++ b/crates/wayle-settings/src/pages/modules/media.rs
@@ -44,6 +44,7 @@ pub(crate) fn entry(config: &Config) -> LeafEntry {
                     title_key: "settings-section-general",
                     items: vec![
                         enum_select(&module.icon_type),
+                        enum_select(&module.visibility),
                         text(&module.format),
                         text(&module.icon_name),
                         text(&module.spinning_disc_icon),

--- a/crates/wayle-shell/src/shell/bar/modules/media/messages.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/media/messages.rs
@@ -27,6 +27,7 @@ pub(crate) enum MediaCmd {
     PlayerChanged(Option<Arc<Player>>),
     MetadataChanged,
     PlaybackStateChanged,
+    VisibilityChanged,
     UpdateIcon(String),
     IconTypeChanged,
 }

--- a/crates/wayle-shell/src/shell/bar/modules/media/methods.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/media/methods.rs
@@ -1,9 +1,26 @@
 use relm4::{gtk, gtk::prelude::*};
-use wayle_media::types::PlaybackState;
+use wayle_config::schemas::modules::{MediaConfig, MediaVisibility};
+use wayle_media::{MediaService, types::PlaybackState};
 
 use super::MediaModule;
 
 impl MediaModule {
+    /// Determines if the module should be visible based on config and playback state.
+    pub(super) fn update_visibility(config: &MediaConfig, media: &MediaService) -> bool {
+        match config.visibility.get() {
+            MediaVisibility::Always => true,
+            MediaVisibility::Playing => {
+                // Only show if there is an active player that is currently playing.
+                if let Some(player) = media.active_player() {
+                    player.playback_state.get() == PlaybackState::Playing
+                } else {
+                    false
+                }
+            }
+            MediaVisibility::Active => media.active_player().is_some(),
+        }
+    }
+
     pub(super) fn update_disc_mode(root: &gtk::Box, enabled: bool) {
         if enabled {
             root.add_css_class("media-disc");

--- a/crates/wayle-shell/src/shell/bar/modules/media/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/media/mod.rs
@@ -59,6 +59,8 @@ impl Component for MediaModule {
         let config = init.config.config();
         let media_config = &config.modules.media;
 
+        let visible = Self::update_visibility(media_config, &init.media);
+
         let bar_button = BarButton::builder()
             .launch(BarButtonInit {
                 icon: media_config.icon_name.get().clone(),
@@ -77,7 +79,7 @@ impl Component for MediaModule {
                     show_icon: media_config.icon_show.clone(),
                     show_label: media_config.label_show.clone(),
                     show_border: media_config.border_show.clone(),
-                    visible: ConfigProperty::new(true),
+                    visible: ConfigProperty::new(visible),
                 },
                 settings: init.settings,
             })
@@ -127,6 +129,10 @@ impl Component for MediaModule {
                     player.is_some() && media_config.icon_type.get() == MediaIconType::SpinningDisc;
                 Self::update_disc_mode(root, use_disc);
 
+                // Update visibility when the active player changes.
+                let visible = Self::update_visibility(media_config, &self.media);
+                self.bar_button.emit(BarButtonInput::SetVisible(visible));
+
                 if let Some(player) = player {
                     let label = helpers::build_label(media_config, &player);
                     self.bar_button.emit(BarButtonInput::SetLabel(label));
@@ -154,12 +160,21 @@ impl Component for MediaModule {
                 }
             }
             MediaCmd::PlaybackStateChanged => {
+                // Update visibility when playback status (playing/paused) changes.
+                let visible = Self::update_visibility(media_config, &self.media);
+                self.bar_button.emit(BarButtonInput::SetVisible(visible));
+
                 if let Some(player) = self.media.active_player() {
                     let label = helpers::build_label(media_config, &player);
                     self.bar_button.emit(BarButtonInput::SetLabel(label));
                     let state = player.playback_state.get();
                     Self::update_spinning_state(root, state);
                 }
+            }
+            MediaCmd::VisibilityChanged => {
+                // Update visibility when the 'show-only-playing' config option is toggled.
+                let visible = Self::update_visibility(media_config, &self.media);
+                self.bar_button.emit(BarButtonInput::SetVisible(visible));
             }
             MediaCmd::UpdateIcon(icon) => {
                 self.bar_button.emit(BarButtonInput::SetIcon(icon));

--- a/crates/wayle-shell/src/shell/bar/modules/media/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/media/watchers.rs
@@ -42,6 +42,10 @@ pub(super) fn spawn_watchers(
     watch!(sender, [config.icon_type.watch()], |out| {
         let _ = out.send(MediaCmd::IconTypeChanged);
     });
+
+    watch!(sender, [config.visibility.watch()], |out| {
+        let _ = out.send(MediaCmd::VisibilityChanged);
+    });
 }
 
 pub(super) fn spawn_player_watchers(

--- a/crates/wayle-widgets/src/components/bar_buttons/component.rs
+++ b/crates/wayle-widgets/src/components/bar_buttons/component.rs
@@ -48,6 +48,8 @@ pub enum BarButtonInput {
     SetLabel(String),
     /// Update the tooltip.
     SetTooltip(Option<String>),
+    /// Update visibility of the button.
+    SetVisible(bool),
     /// Lock label width to prevent resize while a popover is open.
     FreezeSize,
     /// Unlock label width, restoring normal sizing.
@@ -226,6 +228,9 @@ impl Component for BarButton {
                 }
             }
             BarButtonInput::SetTooltip(tooltip) => self.tooltip = tooltip,
+            BarButtonInput::SetVisible(visible) => {
+                self.behavior.visible.set(visible);
+            }
             BarButtonInput::FreezeSize => {
                 self.size_frozen = true;
             }


### PR DESCRIPTION
Proposed solution for #198 
Re of #201 

## Objective

Add toggle to hide media module when no MPRIS player is detected.

## Solution

implemented an `update_visibility` method for the media module to check against config if the module should be able to hide or not. It then checks the player's playback state to assert wether it is playing or not. 
Following @Jas-SinghFSU 's advice i switched from a bool to the `visibility` enum, and then adapted the logic with this change in mind.


## Test Plan

Tested the defaults with the toggle disabled.
With the toggle activated, the logic works as intended.

_Note_: this is my first real contribution and my rust is academic and well, to say the least, rusty.  the logic of the changes is my work but the code was cleaned up with the help of AI.
