### PR TITLE
chore: Build RPM in Fedora container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,6 @@ jobs:
             - name: Install dependencies
               run: |
                   pacman --noconfirm --needed -Syu \
-                    desktop-file-utils \
                     git \
                     rustup \
                     clang \
@@ -135,7 +134,6 @@ jobs:
                     libpulse \
                     fftw \
                     libpipewire \
-                    rpm-tools \
                     systemd-libs
 
             - name: Setup Rust
@@ -158,20 +156,80 @@ jobs:
                   echo "archive=wayle-${VERSION}-x86_64-linux.tar.gz" >> "$GITHUB_OUTPUT"
                   echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
-            - name: Build packages
+    rpm:
+        name: RPM
+        needs: changes
+        if: needs.changes.outputs.code == 'true'
+        runs-on: ubuntu-latest
+        container:
+            image: fedora:latest
+        steps:
+            - name: Install dependencies
+              run: |
+                  dnf -y install \
+                    clang \
+                    cmake \
+                    fftw-devel \
+                    gcc \
+                    git \
+                    gtk4-devel \
+                    gtk4-layer-shell-devel \
+                    gtksourceview5-devel \
+                    libxkbcommon-devel \
+                    make \
+                    pipewire-devel \
+                    pkgconf-pkg-config \
+                    pulseaudio-libs-devel \
+                    rpm-build \
+                    systemd-devel
+
+            - name: Checkout repository
+              uses: actions/checkout@v6
+
+            - name: Fix Git ownership
+              run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+            - name: Install RPM build dependencies
+              run: |
+                  VERSION=$(sed -n '/\[workspace\.package\]/,/\[/{/^version/p}' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+                  DATE="$(LC_ALL=C date '+%a %b %d %Y')"
+                  sed \
+                    -e "s/@VERSION@/${VERSION}/g" \
+                    -e "s/@DATE@/${DATE}/g" \
+                    packaging/rpm/wayle.spec.in >/tmp/wayle.spec
+                  dnf -y --setopt=install_weak_deps=False builddep /tmp/wayle.spec
+
+            - name: Setup Rust
+              uses: actions-rust-lang/setup-rust-toolchain@v1
+              with:
+                  toolchain: stable
+
+            - name: Build workspace
+              run: cargo build --workspace --locked
+
+            - name: Build archive
+              id: archive
+              run: |
+                  VERSION=$(sed -n '/\[workspace\.package\]/,/\[/{/^version/p}' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+                  ./scripts/ci/build-archive.sh target/debug "${VERSION}" x86_64
+                  echo "archive=wayle-${VERSION}-x86_64-linux.tar.gz" >> "$GITHUB_OUTPUT"
+                  echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+            - name: Build RPM
               run: ./scripts/ci/build-packages.sh "${{ steps.archive.outputs.archive }}" "${{ steps.archive.outputs.version }}"
 
     ci-status:
         name: CI Status
         if: always()
-        needs: [lint, test, build]
+        needs: [lint, test, build, rpm]
         runs-on: ubuntu-latest
         steps:
             - name: Check results
               run: |
                   if [[ "${{ needs.lint.result }}" == "failure" || \
                         "${{ needs.test.result }}" == "failure" || \
-                        "${{ needs.build.result }}" == "failure" ]]; then
+                        "${{ needs.build.result }}" == "failure" || \
+                        "${{ needs.rpm.result }}" == "failure" ]]; then
                     echo "One or more checks failed"
                     exit 1
                   fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,6 @@ jobs:
             - name: Install dependencies
               run: |
                   pacman --noconfirm --needed -Syu \
-                    desktop-file-utils \
                     git \
                     github-cli \
                     rustup \
@@ -75,7 +74,6 @@ jobs:
                     libpulse \
                     fftw \
                     libpipewire \
-                    rpm-tools \
                     systemd-libs
 
             - name: Setup Rust
@@ -94,11 +92,6 @@ jobs:
             - name: Build archive
               run: ./scripts/ci/build-archive.sh target/release "${GITHUB_REF_NAME#v}" "${{ matrix.arch }}"
 
-            - name: Build packages
-              run: |
-                  VERSION="${GITHUB_REF_NAME#v}"
-                  ./scripts/ci/build-packages.sh "wayle-${VERSION}-${{ matrix.arch }}-linux.tar.gz" "${VERSION}"
-
             - name: Upload to release
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -107,12 +100,82 @@ jobs:
                   ARCH="${{ matrix.arch }}"
                   gh release upload "${{ github.ref_name }}" \
                     "wayle-${VERSION}-${ARCH}-linux.tar.gz" \
+                    --clobber
+
+    rpm:
+        name: RPM (${{ matrix.arch }})
+        needs: changelog
+        runs-on: ubuntu-latest
+        container:
+            image: fedora:latest
+        strategy:
+            matrix:
+                arch: [x86_64]
+        steps:
+            - name: Install dependencies
+              run: |
+                  dnf -y install \
+                    clang \
+                    cmake \
+                    fftw-devel \
+                    gcc \
+                    gh \
+                    git \
+                    gtk4-devel \
+                    gtk4-layer-shell-devel \
+                    gtksourceview5-devel \
+                    libxkbcommon-devel \
+                    make \
+                    pipewire-devel \
+                    pkgconf-pkg-config \
+                    pulseaudio-libs-devel \
+                    rpm-build \
+                    systemd-devel
+
+            - name: Checkout repository
+              uses: actions/checkout@v6
+
+            - name: Fix Git ownership
+              run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+            - name: Install RPM build dependencies
+              run: |
+                  VERSION=$(sed -n '/\[workspace\.package\]/,/\[/{/^version/p}' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+                  DATE="$(LC_ALL=C date '+%a %b %d %Y')"
+                  sed \
+                    -e "s/@VERSION@/${VERSION}/g" \
+                    -e "s/@DATE@/${DATE}/g" \
+                    packaging/rpm/wayle.spec.in >/tmp/wayle.spec
+                  dnf -y --setopt=install_weak_deps=False builddep /tmp/wayle.spec
+
+            - name: Setup Rust
+              uses: actions-rust-lang/setup-rust-toolchain@v1
+              with:
+                  toolchain: stable
+
+            - name: Build release binaries
+              run: cargo build --release --locked
+
+            - name: Build archive
+              run: ./scripts/ci/build-archive.sh target/release "${GITHUB_REF_NAME#v}" "${{ matrix.arch }}"
+
+            - name: Build RPM
+              run: |
+                  VERSION="${GITHUB_REF_NAME#v}"
+                  ./scripts/ci/build-packages.sh "wayle-${VERSION}-${{ matrix.arch }}-linux.tar.gz" "${VERSION}"
+
+            - name: Upload to release
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  ARCH="${{ matrix.arch }}"
+                  gh release upload "${{ github.ref_name }}" \
                     rpmbuild/RPMS/${ARCH}/*.rpm \
                     --clobber
 
     checksums:
         name: Checksums
-        needs: [changelog, build]
+        needs: [changelog, build, rpm]
         runs-on: ubuntu-latest
         steps:
             - name: Download assets

--- a/packaging/rpm/wayle.spec.in
+++ b/packaging/rpm/wayle.spec.in
@@ -3,9 +3,6 @@
 %global debug_package %{nil}
 %global _build_id_links none
 
-# Arch's rpm-tools lacks systemd-rpm-macros, so _userunitdir may be undefined.
-%{!?_userunitdir: %global _userunitdir %{_prefix}/lib/systemd/user}
-
 Name:           wayle
 Version:        @VERSION@
 Release:        1%{?dist}
@@ -16,6 +13,7 @@ Source0:        https://github.com/wayle-rs/wayle/releases/download/v%{version}/
 ExclusiveArch:  x86_64
 
 BuildRequires:  desktop-file-utils
+BuildRequires:  systemd-rpm-macros
 Requires:       hicolor-icon-theme
 
 %description

--- a/scripts/ci/build-packages.sh
+++ b/scripts/ci/build-packages.sh
@@ -21,4 +21,4 @@ sed \
 	-e "s/@VERSION@/${VERSION}/g" \
 	-e "s/@DATE@/${DATE}/g" \
 	packaging/rpm/wayle.spec.in >"${TOPDIR}/SPECS/wayle.spec"
-rpmbuild --define "_topdir ${TOPDIR}" --nodeps -bb "${TOPDIR}/SPECS/wayle.spec"
+rpmbuild --define "_topdir ${TOPDIR}" -bb "${TOPDIR}/SPECS/wayle.spec"


### PR DESCRIPTION
Builds on #121. Building an RPM in a different distribution's toolchain is fragile and prone to errors, for example different library versions. This runs the RPM build in a dedicated Fedora container, which ensures maximum maintainability by using the toolchain and library versions native to Fedora.