### PR TITLE
fix: persist theme preset

### DIFF
--- a/crates/wayle-config/src/schemas/styling/mod.rs
+++ b/crates/wayle-config/src/schemas/styling/mod.rs
@@ -112,6 +112,11 @@ pub struct StylingConfig {
     /// Active color palette.
     pub palette: PaletteConfig,
 
+    /// Currently active theme preset name 
+    // and/or base for palette if pallette is modified.
+    #[default(String::new())]
+    pub palette_base_theme: ConfigProperty<String>,
+
     /// Discovered themes (runtime-populated).
     #[serde(skip)]
     #[schemars(skip)]

--- a/crates/wayle-settings/src/editors/theme_selector/helpers.rs
+++ b/crates/wayle-settings/src/editors/theme_selector/helpers.rs
@@ -70,6 +70,7 @@ fn build_theme_row(
 }
 
 pub(super) fn apply_palette(target: &PaletteConfig, source: &Palette) {
+    // println!("{:?}", &target);
     set_if_valid(&target.bg, &source.bg);
     set_if_valid(&target.surface, &source.surface);
     set_if_valid(&target.elevated, &source.elevated);

--- a/crates/wayle-settings/src/editors/theme_selector/helpers.rs
+++ b/crates/wayle-settings/src/editors/theme_selector/helpers.rs
@@ -70,7 +70,6 @@ fn build_theme_row(
 }
 
 pub(super) fn apply_palette(target: &PaletteConfig, source: &Palette) {
-    // println!("{:?}", &target);
     set_if_valid(&target.bg, &source.bg);
     set_if_valid(&target.surface, &source.surface);
     set_if_valid(&target.elevated, &source.elevated);

--- a/crates/wayle-settings/src/editors/theme_selector/methods.rs
+++ b/crates/wayle-settings/src/editors/theme_selector/methods.rs
@@ -23,6 +23,7 @@ impl ThemeSelectorControl {
             badge.set_css_classes(&["badge", "badge-subtle"]);
         }
 
+        self.palette_base_theme.set(name);
         apply_palette(&self.palette, &theme.palette);
         self.popover.popdown();
     }

--- a/crates/wayle-settings/src/editors/theme_selector/methods.rs
+++ b/crates/wayle-settings/src/editors/theme_selector/methods.rs
@@ -4,7 +4,6 @@ use relm4::{gtk::prelude::*, prelude::*};
 
 use super::{
     ThemeSelectorControl,
-    ThemeSelectorInit,
     helpers::{apply_palette, populate_list},
     scaled_max_height,
 };

--- a/crates/wayle-settings/src/editors/theme_selector/methods.rs
+++ b/crates/wayle-settings/src/editors/theme_selector/methods.rs
@@ -4,6 +4,7 @@ use relm4::{gtk::prelude::*, prelude::*};
 
 use super::{
     ThemeSelectorControl,
+    ThemeSelectorInit,
     helpers::{apply_palette, populate_list},
     scaled_max_height,
 };
@@ -15,6 +16,12 @@ impl ThemeSelectorControl {
         let Some(theme) = themes.iter().find(|entry| entry.name == name) else {
             return;
         };
+
+        if let Some(ref badge) = self.dirty_badge {
+            badge.set_label(&name);
+            badge.set_visible(true);
+            badge.set_css_classes(&["badge", "badge-subtle"]);
+        }
 
         apply_palette(&self.palette, &theme.palette);
         self.popover.popdown();

--- a/crates/wayle-settings/src/editors/theme_selector/mod.rs
+++ b/crates/wayle-settings/src/editors/theme_selector/mod.rs
@@ -34,6 +34,7 @@ pub(crate) struct ThemeSelectorControl {
     pub(super) available: ConfigProperty<Vec<ThemeEntry>>,
     pub(super) palette: PaletteConfig,
     pub(super) scale: ConfigProperty<ScaleFactor>,
+    pub(crate) dirty_badge: Option<gtk::Label>,
     pub(super) popover: gtk::Popover,
     pub(super) list_box: gtk::ListBox,
     pub(super) scrolled: gtk::ScrolledWindow,
@@ -45,6 +46,7 @@ pub(crate) struct ThemeSelectorInit {
     pub(crate) available: ConfigProperty<Vec<ThemeEntry>>,
     pub(crate) palette: PaletteConfig,
     pub(crate) scale: ConfigProperty<ScaleFactor>,
+    pub(crate) dirty_badge: Option<gtk::Label>,
 }
 
 #[derive(Debug)]
@@ -141,6 +143,7 @@ impl SimpleComponent for ThemeSelectorControl {
             available: init.available,
             palette: init.palette,
             scale: init.scale,
+            dirty_badge: init.dirty_badge,
             popover,
             list_box,
             scrolled,

--- a/crates/wayle-settings/src/editors/theme_selector/mod.rs
+++ b/crates/wayle-settings/src/editors/theme_selector/mod.rs
@@ -33,6 +33,7 @@ thread_local! {
 pub(crate) struct ThemeSelectorControl {
     pub(super) available: ConfigProperty<Vec<ThemeEntry>>,
     pub(super) palette: PaletteConfig,
+    pub(super) palette_base_theme: ConfigProperty<String>,
     pub(super) scale: ConfigProperty<ScaleFactor>,
     pub(crate) dirty_badge: Option<gtk::Label>,
     pub(super) popover: gtk::Popover,
@@ -45,6 +46,7 @@ pub(crate) struct ThemeSelectorControl {
 pub(crate) struct ThemeSelectorInit {
     pub(crate) available: ConfigProperty<Vec<ThemeEntry>>,
     pub(crate) palette: PaletteConfig,
+    pub(super) palette_base_theme: ConfigProperty<String>,
     pub(crate) scale: ConfigProperty<ScaleFactor>,
     pub(crate) dirty_badge: Option<gtk::Label>,
 }
@@ -142,6 +144,7 @@ impl SimpleComponent for ThemeSelectorControl {
         let model = Self {
             available: init.available,
             palette: init.palette,
+            palette_base_theme: init.palette_base_theme,
             scale: init.scale,
             dirty_badge: init.dirty_badge,
             popover,

--- a/crates/wayle-settings/src/editors/theme_selector/row.rs
+++ b/crates/wayle-settings/src/editors/theme_selector/row.rs
@@ -18,14 +18,23 @@ use crate::{
 pub(crate) fn theme_selector(
     available: &ConfigProperty<Vec<ThemeEntry>>,
     palette: &PaletteConfig,
+    palette_base_theme: &ConfigProperty<String>, 
     scale: &ConfigProperty<ScaleFactor>,
     i18n_key: &'static str,
 ) -> SettingRowInit {
     let badge = make_dirty_badge();
+    let base_theme = palette_base_theme.get();
+    if !base_theme.is_empty() {
+        badge.set_label(&base_theme);
+        badge.set_visible(true);
+        badge.set_css_classes(&["badge", "badge-subtle"]);
+    }
+
     let controller = ThemeSelectorControl::builder()
         .launch(ThemeSelectorInit {
             available: available.clone(),
             palette: palette.clone(),
+            palette_base_theme: palette_base_theme.clone(),
             scale: scale.clone(),
             dirty_badge: Some(badge.clone()),
         })

--- a/crates/wayle-settings/src/editors/theme_selector/row.rs
+++ b/crates/wayle-settings/src/editors/theme_selector/row.rs
@@ -7,8 +7,10 @@ use wayle_config::{
 };
 
 use crate::{
-    editors::theme_selector::{ThemeSelectorControl, ThemeSelectorInit},
-    editors::make_dirty_badge,
+    editors::{
+        make_dirty_badge,
+        theme_selector::{ThemeSelectorControl, ThemeSelectorInit},
+    },
     pages::spec::SettingRowInit,
     property_handle::PropertyHandle,
     row::RowBehavior,
@@ -18,7 +20,7 @@ use crate::{
 pub(crate) fn theme_selector(
     available: &ConfigProperty<Vec<ThemeEntry>>,
     palette: &PaletteConfig,
-    palette_base_theme: &ConfigProperty<String>, 
+    palette_base_theme: &ConfigProperty<String>,
     scale: &ConfigProperty<ScaleFactor>,
     i18n_key: &'static str,
 ) -> SettingRowInit {

--- a/crates/wayle-settings/src/editors/theme_selector/row.rs
+++ b/crates/wayle-settings/src/editors/theme_selector/row.rs
@@ -8,6 +8,7 @@ use wayle_config::{
 
 use crate::{
     editors::theme_selector::{ThemeSelectorControl, ThemeSelectorInit},
+    editors::make_dirty_badge,
     pages::spec::SettingRowInit,
     property_handle::PropertyHandle,
     row::RowBehavior,
@@ -20,11 +21,13 @@ pub(crate) fn theme_selector(
     scale: &ConfigProperty<ScaleFactor>,
     i18n_key: &'static str,
 ) -> SettingRowInit {
+    let badge = make_dirty_badge();
     let controller = ThemeSelectorControl::builder()
         .launch(ThemeSelectorInit {
             available: available.clone(),
             palette: palette.clone(),
             scale: scale.clone(),
+            dirty_badge: Some(badge.clone()),
         })
         .detach();
 
@@ -36,7 +39,7 @@ pub(crate) fn theme_selector(
         control: widget.upcast(),
         keepalive: Box::new(controller),
         full_width: false,
-        dirty_badge: None,
+        dirty_badge: Some(badge),
         behavior: RowBehavior::Action,
         unit: None,
     }

--- a/crates/wayle-settings/src/pages/styling/mod.rs
+++ b/crates/wayle-settings/src/pages/styling/mod.rs
@@ -42,6 +42,7 @@ pub(crate) fn entry(config: &Config) -> LeafEntry {
                         theme_selector(
                             &styling.available,
                             palette,
+                            &styling.palette_base_theme,
                             &styling.scale,
                             "settings-theme-preset",
                         ),


### PR DESCRIPTION
## Objective
When browsing through preset themes in settings it is hard to track what is the previous theme, unless you remember the colours which come from the theme name
## Solution
Save the last selected preset in config and display it in theme preset badge
Before
## Test Plan
1. change theme preset in settings
2. notice the badge

### Before
<img width="433" height="114" alt="Screenshot from 2026-05-31 17-56-18" src="https://github.com/user-attachments/assets/5ed2b9ec-f5e1-427a-a0b6-46afdbfc7789" />

### After
<img width="433" height="114" alt="Screenshot from 2026-05-31 17-55-36" src="https://github.com/user-attachments/assets/d586c25f-78b9-41c9-bb34-e7e8a8a6f09f" />
