### PR TITLE
docs: document upower dependency for battery module

### DIFF
--- a/crates/wayle-config/src/schemas/modules/battery/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/battery/mod.rs
@@ -8,6 +8,12 @@ use crate::{
 };
 
 /// Battery level, charging state, and a dropdown with power-profile controls.
+/// 
+/// ::: warning
+/// 
+/// This module uses `upower` (D-Bus) for battery information. Ensure `upower` daemon is running and exposes a battery device (verify with `upower --battery` or `upower --dump`).
+/// 
+/// :::
 #[wayle_config(bar_button, i18n_prefix = "settings-modules-battery")]
 pub struct BatteryConfig {
     /// Icons for battery levels from empty to full.

--- a/crates/wayle-config/src/schemas/modules/battery/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/battery/mod.rs
@@ -8,11 +8,11 @@ use crate::{
 };
 
 /// Battery level, charging state, and a dropdown with power-profile controls.
-/// 
+///
 /// ::: warning
-/// 
+///
 /// This module uses `upower` (D-Bus) for battery information. Ensure `upower` daemon is running and exposes a battery device (verify with `upower --battery` or `upower --dump`).
-/// 
+///
 /// :::
 #[wayle_config(bar_button, i18n_prefix = "settings-modules-battery")]
 pub struct BatteryConfig {

--- a/docs/config/modules/battery.md
+++ b/docs/config/modules/battery.md
@@ -9,6 +9,12 @@ outline: [2, 3]
 
 Battery level, charging state, and a dropdown with power-profile controls.
 
+::: warning
+
+This module uses `upower` (D-Bus) for battery information. Ensure `upower` daemon is running and exposes a battery device (verify with `upower --battery` or `upower --dump`).
+
+:::
+
 Add it to your layout with `battery`:
 
 ```toml


### PR DESCRIPTION
## Objective
Clarify that the battery module depends on `upower` and requires the daemon to be running with an exposed battery device.

Related to #176

## Solution
Add a warning block in `docs/config/modules/battery.md`

## Test Plan
Render the site and check the `/config/modules/battery`