### PR TITLE
fix: resolve dropdown rendering failures under fractional scaling

### DIFF
--- a/crates/wayle-shell/src/shell/bar/dropdowns/dashboard/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/dashboard/mod.rs
@@ -113,23 +113,36 @@ impl Component for DashboardDropdown {
                 DropdownContent {
                     set_vexpand: true,
 
-                    #[local_ref]
-                    quick_actions_widget -> gtk::Box {},
+                    gtk::ScrolledWindow {
+                        set_hscrollbar_policy: gtk::PolicyType::Never,
+                        set_vexpand: true,
+                        set_propagate_natural_height: true,
+                        add_css_class: "dashboard-scroll",
 
-                    #[local_ref]
-                    controls_widget -> gtk::Box {},
+                        #[wrap(Some)]
+                        set_child = &gtk::Box {
+                            add_css_class: "dashboard-content-box",
+                            set_orientation: gtk::Orientation::Vertical,
 
-                    #[local_ref]
-                    media_widget -> gtk::Box {},
+                            #[local_ref]
+                            quick_actions_widget -> gtk::Box {},
 
-                    #[local_ref]
-                    info_row_widget -> gtk::Box {},
+                            #[local_ref]
+                            controls_widget -> gtk::Box {},
 
-                    #[local_ref]
-                    system_stats_widget -> gtk::Box {},
+                            #[local_ref]
+                            media_widget -> gtk::Box {},
 
-                    #[local_ref]
-                    user_session_widget -> gtk::Box {},
+                            #[local_ref]
+                            info_row_widget -> gtk::Box {},
+
+                            #[local_ref]
+                            system_stats_widget -> gtk::Box {},
+
+                            #[local_ref]
+                            user_session_widget -> gtk::Box {},
+                        },
+                    },
                 },
             },
         }

--- a/crates/wayle-shell/src/shell/bar/dropdowns/registry.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/registry.rs
@@ -42,11 +42,13 @@ pub(crate) struct DropdownInstance {
     popover: gtk::Popover,
     _controller: Box<dyn Any>,
     thaw_target: Rc<Cell<Option<relm4::Sender<BarButtonInput>>>>,
+    original_height: Cell<Option<i32>>,
 }
 
 impl DropdownInstance {
     pub(crate) fn new(popover: gtk::Popover, controller: Box<dyn Any>) -> Self {
         let thaw_target: Rc<Cell<Option<relm4::Sender<BarButtonInput>>>> = Rc::default();
+        let original_height = Cell::new(None);
 
         popover.connect_map(|popover| {
             debug!(
@@ -82,10 +84,48 @@ impl DropdownInstance {
             set_bar_keyboard_mode(popover, KeyboardMode::None);
         });
 
+        popover.connect_notify_local(Some("height-request"), move |popover, _| {
+            let Some(parent) = popover.parent() else {
+                return;
+            };
+            let Some(root) = parent.root().and_then(|r| r.downcast::<gtk::Window>().ok()) else {
+                return;
+            };
+            let display = gtk::prelude::WidgetExt::display(&root);
+            let monitor = if let Some(native) = root.dynamic_cast_ref::<gtk::Native>() {
+                native
+                    .surface()
+                    .and_then(|surface| display.monitor_at_surface(&surface))
+            } else {
+                None
+            };
+            let monitor = monitor.or_else(|| {
+                let monitors = display.monitors();
+                if monitors.n_items() > 0 {
+                    monitors.item(0).and_downcast::<gtk::gdk::Monitor>()
+                } else {
+                    None
+                }
+            });
+
+            if let Some(monitor) = monitor {
+                let monitor_height = monitor.geometry().height();
+                let max_allowed_height = monitor_height - 100;
+
+                Self::find_and_clamp_scrolled_windows(popover.upcast_ref(), max_allowed_height);
+
+                let current = popover.height_request();
+                if current > max_allowed_height {
+                    popover.set_height_request(max_allowed_height);
+                }
+            }
+        });
+
         Self {
             popover,
             _controller: controller,
             thaw_target,
+            original_height,
         }
     }
 
@@ -143,6 +183,7 @@ impl DropdownInstance {
         self.apply_position();
         self.apply_margins(style.margins);
         self.apply_style(&style);
+        self.clamp_height();
         set_bar_keyboard_mode(&self.popover, KeyboardMode::OnDemand);
         debug!(
             classes = ?self.popover.css_classes(),
@@ -191,6 +232,7 @@ impl DropdownInstance {
         self.apply_position();
         self.apply_margins(style.margins);
         self.apply_style(&style);
+        self.clamp_height();
         set_bar_keyboard_mode(&self.popover, KeyboardMode::OnDemand);
         debug!(
             classes = ?self.popover.css_classes(),
@@ -199,6 +241,83 @@ impl DropdownInstance {
             "popup (button path)"
         );
         self.popover.popup();
+    }
+
+    fn clamp_height(&self) {
+        let current_height = self.popover.height_request();
+
+        if self.original_height.get().is_none() && current_height > 0 {
+            self.original_height.set(Some(current_height));
+        }
+
+        let height_to_clamp = self.original_height.get().unwrap_or(current_height);
+
+        let Some(parent) = self.popover.parent() else {
+            return;
+        };
+        let Some(root) = parent.root().and_then(|r| r.downcast::<gtk::Window>().ok()) else {
+            return;
+        };
+        let display = gtk::prelude::WidgetExt::display(&root);
+        let monitor = if let Some(native) = root.dynamic_cast_ref::<gtk::Native>() {
+            native
+                .surface()
+                .and_then(|surface| display.monitor_at_surface(&surface))
+        } else {
+            None
+        };
+        let monitor = monitor.or_else(|| {
+            let monitors = display.monitors();
+            if monitors.n_items() > 0 {
+                monitors.item(0).and_downcast::<gtk::gdk::Monitor>()
+            } else {
+                None
+            }
+        });
+
+        if let Some(monitor) = monitor {
+            let monitor_height = monitor.geometry().height();
+            let max_allowed_height = monitor_height - 100;
+
+            Self::find_and_clamp_scrolled_windows(self.popover.upcast_ref(), max_allowed_height);
+
+            let height_to_check = if height_to_clamp > 0 {
+                height_to_clamp
+            } else {
+                self.popover.preferred_size().1.height()
+            };
+
+            if height_to_check > max_allowed_height {
+                self.popover.set_height_request(max_allowed_height);
+                debug!(
+                    clamped_height = max_allowed_height,
+                    original_height = height_to_check,
+                    "clamped popover height request"
+                );
+            } else if height_to_clamp > 0 {
+                self.popover.set_height_request(height_to_clamp);
+            } else {
+                self.popover.set_height_request(-1);
+            }
+        }
+    }
+
+    fn find_and_clamp_scrolled_windows(widget: &gtk::Widget, max_allowed_height: i32) {
+        if let Some(scrolled) = widget.downcast_ref::<gtk::ScrolledWindow>() {
+            let content_max = max_allowed_height - 80;
+            let current_min = scrolled.min_content_height();
+            if current_min > content_max {
+                scrolled.set_min_content_height(content_max);
+            }
+            scrolled.set_max_content_height(content_max);
+            scrolled.set_propagate_natural_height(true);
+            return;
+        }
+        let mut child = widget.first_child();
+        while let Some(c) = child {
+            Self::find_and_clamp_scrolled_windows(&c, max_allowed_height);
+            child = c.next_sibling();
+        }
     }
 
     fn apply_style(&self, style: &DropdownStyle) {

--- a/crates/wayle-shell/src/shell/bar/dropdowns/weather/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/weather/mod.rs
@@ -97,24 +97,32 @@ impl Component for WeatherDropdown {
                         set_vhomogeneous: true,
                         set_hhomogeneous: true,
                         #[name = "loaded_page"]
-                        add_named[Some("loaded")] = &gtk::Box {
-                            set_orientation: gtk::Orientation::Vertical,
+                        add_named[Some("loaded")] = &gtk::ScrolledWindow {
+                            set_hscrollbar_policy: gtk::PolicyType::Never,
                             set_vexpand: true,
+                            set_propagate_natural_height: true,
+                            add_css_class: "weather-scroll",
 
-                            #[local_ref]
-                            weather_header_widget -> gtk::Box {},
+                            #[wrap(Some)]
+                            set_child = &gtk::Box {
+                                set_orientation: gtk::Orientation::Vertical,
+                                set_vexpand: true,
 
-                            #[local_ref]
-                            stats_grid_widget -> gtk::Box {},
+                                #[local_ref]
+                                weather_header_widget -> gtk::Box {},
 
-                            #[local_ref]
-                            hourly_forecast_widget -> gtk::Box {},
+                                #[local_ref]
+                                stats_grid_widget -> gtk::Box {},
 
-                            #[local_ref]
-                            daily_forecast_widget -> gtk::Box {},
+                                #[local_ref]
+                                hourly_forecast_widget -> gtk::Box {},
 
-                            #[local_ref]
-                            sun_times_widget -> gtk::Box {},
+                                #[local_ref]
+                                daily_forecast_widget -> gtk::Box {},
+
+                                #[local_ref]
+                                sun_times_widget -> gtk::Box {},
+                            },
                         },
 
                         #[name = "loading_page"]

--- a/crates/wayle-styling/scss/modules/dashboard_dropdown/_dashboard.scss
+++ b/crates/wayle-styling/scss/modules/dashboard_dropdown/_dashboard.scss
@@ -7,6 +7,18 @@
         border-spacing: var(--space-sm);
     }
 
+    .dashboard-content-box {
+        border-spacing: var(--space-sm);
+    }
+
+    .dashboard-scroll {
+        background: transparent;
+
+        scrollbar range trough {
+            background: transparent;
+        }
+    }
+
     .dashboard-card {
         border-radius: var(--rounding-element);
         min-width: 0;

--- a/crates/wayle-styling/scss/modules/weather_dropdown/_index.scss
+++ b/crates/wayle-styling/scss/modules/weather_dropdown/_index.scss
@@ -4,3 +4,12 @@
 @import "daily";
 @import "sun_times";
 @import "states";
+
+.weather-scroll {
+    background: transparent;
+
+    scrollbar range trough {
+        background: transparent;
+    }
+}
+


### PR DESCRIPTION
<!--
- Link to a related issue with "Fixes #123" if one exists
- For visual changes, include before/after screenshots
- Ensure `cargo fmt` and `cargo clippy --workspace` pass
-->

Fixes #242 

No pictures to compare as normally the dashboard weather and notifications dropdown were not rendering

## Objective

Fixes an issue where large dropdown menus (specifically the **dashboard**, **weather**, and **notification** dropdowns) fail to render entirely under larger display scaling factors (such as `1.5x` and above on `1080p` or `1440p` monitors).

This is not a bug inherent to fractional scaling itself (as smaller scales like `1.25x` still work), but rather a boundary limitation when the scaling factor significantly reduces the monitor's logical vertical space:
* On a `1080p` monitor at `1.5x` scaling, the logical height drops to `720` pixels.
* On a `1440p` monitor at `1.5x` scaling, the logical height drops to `960` pixels.
* The weather dropdown requests `1043` logical pixels, and the notifications dropdown requests `1088` logical pixels.
* GTK4 Popovers on Wayland fail to map/render completely when their requested height exceeds the available vertical space on the display. Smaller dropdowns like audio, network, and bluetooth render successfully since their base height is `512` logical pixels.

## Solution

1. **Dynamic Clamping**:
   - Added a `connect_notify_local` listener for `height-request` changes on `DropdownInstance` in `registry.rs`.
   - Before a popover maps, we query its current monitor's geometry height. If the popover's requested or preferred height exceeds `monitor_height - 100` logical pixels, we clamp it to that limit.
2. **Scrolled Window Traversal**:
   - Implemented a recursive `find_and_clamp_scrolled_windows` function in `registry.rs` to walk the popover's widget tree and dynamically constrain the `max_content_height` and enable `propagate-natural-height` on any child `gtk::ScrolledWindow` instances.
3. **Dropdown Layout wrapping**:
   - Wrapped the main `loaded_page` child box inside the `weather` dropdown in a `gtk::ScrolledWindow`.
   - Wrapped the `DropdownContent` widgets inside the `dashboard` dropdown in a `gtk::ScrolledWindow` inside a new `dashboard-content-box` layout wrapper.
4. **Theme Styling**:
   - Styled `.weather-scroll` and `.dashboard-scroll` classes in SCSS to ensure scroll containers feature transparent backgrounds and clean scroll tracks matching the tray.

## Test Plan

### Automated Checks
* Verified that code formats correctly by running:
  ```sh
  cargo fmt --all
