### PR TITLE
fix: settings GUI layout wipe, symlinked config hot-reload, and CLI b…

### DIFF
--- a/crates/wayle-config/src/infrastructure/watcher.rs
+++ b/crates/wayle-config/src/infrastructure/watcher.rs
@@ -61,6 +61,19 @@ impl FileWatcher {
 
         info!(?config_dir, "Config directory watcher started");
 
+        let config_path = ConfigPaths::main_config();
+        if let Ok(canonical_path) = config_path.canonicalize() {
+            if let Some(canonical_dir) = canonical_path.parent() {
+                if canonical_dir != config_dir {
+                    if let Err(e) = watcher.watch(canonical_dir, RecursiveMode::NonRecursive) {
+                        tracing::warn!(error = %e, ?canonical_dir, "failed to watch canonical config folder");
+                    } else {
+                        info!(?canonical_dir, "Canonical config folder watcher started");
+                    }
+                }
+            }
+        }
+
         let file_watcher = Self {
             config_service,
             secrets_tx,

--- a/crates/wayle-settings/src/editors/bar_layout/card/methods.rs
+++ b/crates/wayle-settings/src/editors/bar_layout/card/methods.rs
@@ -131,13 +131,21 @@ impl LayoutCard {
     }
 
     pub(super) fn on_monitor_changed(&mut self) -> bool {
-        self.monitor = self.monitor_entry.text().to_string();
+        let new_monitor = self.monitor_entry.text().to_string();
+        if self.monitor == new_monitor {
+            return false;
+        }
+        self.monitor = new_monitor;
         true
     }
 
     pub(super) fn on_extends_changed(&mut self) -> bool {
         let text = self.extends_entry.text().to_string();
-        self.extends = if text.is_empty() { None } else { Some(text) };
+        let new_extends = if text.is_empty() { None } else { Some(text) };
+        if self.extends == new_extends {
+            return false;
+        }
+        self.extends = new_extends;
         true
     }
 
@@ -152,11 +160,17 @@ impl LayoutCard {
         let Some(BarItem::Group(group)) = items.get_mut(group_index) else {
             return false;
         };
+        if group.name == name {
+            return false;
+        }
         group.name = name;
         true
     }
 
     pub(super) fn on_show_toggled(&mut self, active: bool, sender: &FactorySender<Self>) -> bool {
+        if self.show == active {
+            return false;
+        }
         self.show = active;
         self.rebuild_body(sender);
         true

--- a/wayle/src/cli/panel/settings.rs
+++ b/wayle/src/cli/panel/settings.rs
@@ -17,7 +17,18 @@ use crate::cli::CliAction;
 pub async fn execute() -> CliAction {
     info!("Launching Wayle settings");
 
-    Command::new("wayle-settings")
+    let mut command = if let Ok(current_exe) = std::env::current_exe() {
+        let sibling = current_exe.parent().map(|p| p.join("wayle-settings"));
+        if let Some(ref sibling_path) = sibling && sibling_path.exists() {
+            Command::new(sibling_path)
+        } else {
+            Command::new("wayle-settings")
+        }
+    } else {
+        Command::new("wayle-settings")
+    };
+
+    command
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())


### PR DESCRIPTION
<!--
- Link to a related issue with "Fixes #123" if one exists
- For visual changes, include before/after screenshots
- Ensure `cargo fmt` and `cargo clippy --workspace` pass
-->

## Objective

This PR addresses three key developer and user experience bugs:
1. **Layout Settings Wipe**: Opening the settings GUI automatically wiped the user's layout from `runtime.toml` on startup.
2. **Symlink Hot-Reload Failure**: Editing a `config.toml` file that is symlinked (e.g., from a dotfiles repository) did not trigger the hot-reload watcher.
3. **CLI Settings Launcher Sibling Resolution**: In local development, running `cargo run --bin wayle -- panel settings` spawned the globally-installed `wayle-settings` binary instead of the newly built workspace version.

## Solution

### 1. Settings GUI (`crates/wayle-settings`)
GTK's programmatic setting of switch and entry values during card setup triggers `changed` and `state-set` events synchronously. Because the event handlers on the layout card returned `true` immediately without comparing the value, this triggered a chain reaction that committed the layout back to `ConfigProperty::set`, wiping the layout overrides from `runtime.toml` if they matched `config.toml`. 

- Added validation checks to `on_monitor_changed`, `on_extends_changed`, `on_group_name_changed`, and `on_show_toggled` inside `crates/wayle-settings/src/editors/bar_layout/card/methods.rs` to verify value differences and return `false` if unchanged.

### 2. Config Watcher (`crates/wayle-config`)
Standard `inotify` watchers on the `~/.config/wayle` directory fail to catch target file modifications when text editors write directly to the target of a symlink.

- Modified `FileWatcher::start` inside `crates/wayle-config/src/infrastructure/watcher.rs` to resolve the canonical target path of `config.toml` and dynamically watch its parent directory if it points outside the default config directory.

### 3. Sibling Binary Resolution (`wayle` CLI)
- Updated `wayle/src/cli/panel/settings.rs` to lookup a sibling `wayle-settings` binary inside the executing `wayle` CLI's parent directory first before falling back to spawning the global command from the system `PATH`.

## Test Plan

### Automated Tests
- Verified that all workspace tests pass successfully:
  ```bash
  cargo test
