### PR TITLE
fix: make background colour of dropdown transparent not entire dropdown

### DIFF
--- a/crates/wayle-shell/src/shell/bar/dropdowns/registry.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/registry.rs
@@ -202,7 +202,6 @@ impl DropdownInstance {
     }
 
     fn apply_style(&self, style: &DropdownStyle) {
-        self.popover.set_opacity(style.opacity);
         self.popover.set_autohide(style.autohide);
         if style.shadow_enabled {
             self.popover.add_css_class("shadow");

--- a/crates/wayle-shell/src/shell/bar/modules/custom/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/custom/helpers.rs
@@ -97,7 +97,7 @@ impl ParsedOutput {
         let mut ctx = self
             .json
             .clone()
-            .and_then(|v| if v.is_object() { Some(v) } else { None })
+            .filter(|v| v.is_object())
             .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
 
         if let Value::Object(map) = &mut ctx {

--- a/crates/wayle-styling/scss/_palette.scss
+++ b/crates/wayle-styling/scss/_palette.scss
@@ -13,6 +13,7 @@
     --palette-yellow: #f9e2af;
     --palette-green: #a6e3a1;
     --palette-blue: #74c7ec;
+    --dropdown-surface: rgba(30,30,30,0.5);
 
     --cfg-font-sans: "Inter";
     --cfg-font-mono: "JetBrains Mono";

--- a/crates/wayle-styling/scss/primitives/dropdown/_index.scss
+++ b/crates/wayle-styling/scss/primitives/dropdown/_index.scss
@@ -1,6 +1,6 @@
 .dropdown {
     all: unset;
-    background: var(--bg-surface);
+    background: transparent;
     border-radius: var(--rounding-container);
     border: 1px solid var(--border-default);
     min-width: calc(28rem * var(--global-scale));
@@ -35,7 +35,6 @@ popover.shadow.position-right > contents .dropdown {
 }
 
 popover.dropdown {
-    background: transparent;
     border: none;
     box-shadow: none;
     min-width: 0;
@@ -49,10 +48,12 @@ popover.dropdown {
 
     > contents {
         all: unset;
-        background: transparent;
+        opacity: 1.0;
 
         > .dropdown {
             min-width: 0;
+            background-color: var(--dropdown-surface);
+            opacity: 1.0;
         }
     }
 }

--- a/crates/wayle-styling/src/lib.rs
+++ b/crates/wayle-styling/src/lib.rs
@@ -23,6 +23,8 @@ use wayle_config::{
     },
 };
 
+use palette_provider::color::hex_to_rgba;
+
 /// Static CSS compiled at build time.
 pub const STATIC_CSS: &str = include_str!(concat!(env!("OUT_DIR"), "/style.css"));
 
@@ -55,6 +57,8 @@ pub fn theme_css(
     let bar_values = bar_rounding.to_bar_css_values();
     let bar_button_values = button_rounding.to_bar_element_css_values();
     let bar_group_values = group_rounding.to_bar_element_css_values();
+    let dropdown_opacity = (bar.dropdown_opacity.get().value() as f32)/100.0;
+    let dropdown_surface = hex_to_rgba(&resolved.surface, dropdown_opacity);
 
     format!(
         r#":root {{
@@ -68,6 +72,7 @@ pub fn theme_css(
     --palette-yellow: {yellow};
     --palette-green: {green};
     --palette-blue: {blue};
+    --dropdown-surface: {dropdown_surface};
 
     --cfg-font-sans: "{font_sans}";
     --cfg-font-mono: "{font_mono}";

--- a/crates/wayle-styling/src/lib.rs
+++ b/crates/wayle-styling/src/lib.rs
@@ -13,6 +13,7 @@ use std::{
 };
 
 pub use errors::Error;
+use palette_provider::color::hex_to_rgba;
 use tracing::error;
 use wayle_config::{
     infrastructure::themes::Palette,
@@ -22,8 +23,6 @@ use wayle_config::{
         styling::{StylingConfig, ThemeProvider},
     },
 };
-
-use palette_provider::color::hex_to_rgba;
 
 /// Static CSS compiled at build time.
 pub const STATIC_CSS: &str = include_str!(concat!(env!("OUT_DIR"), "/style.css"));
@@ -57,7 +56,7 @@ pub fn theme_css(
     let bar_values = bar_rounding.to_bar_css_values();
     let bar_button_values = button_rounding.to_bar_element_css_values();
     let bar_group_values = group_rounding.to_bar_element_css_values();
-    let dropdown_opacity = (bar.dropdown_opacity.get().value() as f32)/100.0;
+    let dropdown_opacity = (bar.dropdown_opacity.get().value() as f32) / 100.0;
     let dropdown_surface = hex_to_rgba(&resolved.surface, dropdown_opacity);
 
     format!(

--- a/crates/wayle-styling/src/palette_provider/color.rs
+++ b/crates/wayle-styling/src/palette_provider/color.rs
@@ -29,10 +29,7 @@ pub(crate) fn hex_to_rgba(hex: &str, alpha: f32) -> String {
     let srgb = srgb.into_format::<u8>();
     format!(
         "rgba({}, {}, {}, {:.2})",
-        srgb.red,
-        srgb.green,
-        srgb.blue,
-        alpha
+        srgb.red, srgb.green, srgb.blue, alpha
     )
 }
 

--- a/crates/wayle-styling/src/palette_provider/color.rs
+++ b/crates/wayle-styling/src/palette_provider/color.rs
@@ -24,6 +24,18 @@ pub(crate) fn derive_layers(background: &str, is_light: bool) -> Layers {
     }
 }
 
+pub(crate) fn hex_to_rgba(hex: &str, alpha: f32) -> String {
+    let srgb = parse(hex);
+    let srgb = srgb.into_format::<u8>();
+    format!(
+        "rgba({}, {}, {}, {:.2})",
+        srgb.red,
+        srgb.green,
+        srgb.blue,
+        alpha
+    )
+}
+
 fn parse(hex: &str) -> Srgb<f32> {
     let hex = hex.trim_start_matches('#');
     let r = u8::from_str_radix(&hex[0..2], 16).unwrap_or(0);


### PR DESCRIPTION
## Objective
The opacity setting for the drop down is simply making the entire dropdown transclucent and hence difficult to look at content
## Solution
Implementing the setting to only set background colour of the drop down
## Test Plan
1. set opacity 
2. open dropdown
3. check visibility


### Before
Notice how the dropdown became almost invisible when opacity setting is reduced?
<img width="454" height="833" alt="Screenshot from 2026-06-03 16-41-47" src="https://github.com/user-attachments/assets/69fa69a3-1d5d-448a-ae96-7082d35e0632" />
<img width="454" height="833" alt="Screenshot from 2026-06-03 16-41-26" src="https://github.com/user-attachments/assets/1c0a1e0f-f65f-45d6-8221-f59ecad268a8" />
<img width="454" height="833" alt="Screenshot from 2026-06-03 16-41-00" src="https://github.com/user-attachments/assets/daa1d2c2-0bce-4aac-b989-60f02633c21a" />


### After
<img width="830" height="773" alt="Screenshot from 2026-06-03 16-43-48" src="https://github.com/user-attachments/assets/895f2eca-19a4-4914-88ff-7df094fc4481" />
<img width="454" height="833" alt="Screenshot from 2026-06-03 16-43-05" src="https://github.com/user-attachments/assets/14f83cb0-0f77-4db9-b25e-bfbc789f0bf4" />
<img width="454" height="833" alt="Screenshot from 2026-06-03 16-42-42" src="https://github.com/user-attachments/assets/a4b2324c-d3cb-4037-8c19-8ac3089e5a82" />
