### PR TITLE
feat: add hide_when_inactive for media module

### DIFF
--- a/crates/wayle-config/src/schemas/modules/media/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/media/mod.rs
@@ -38,6 +38,11 @@ pub struct MediaConfig {
     #[default(BTreeMap::new())]
     pub player_icons: ConfigProperty<BTreeMap<String, String>>,
 
+    /// Hide the module when no active media player is available.
+    #[serde(rename = "hide-when-inactive")]
+    #[default(false)]
+    pub hide_when_inactive: ConfigProperty<bool>,
+
     /// Player bus name patterns to exclude from discovery. Requires a restart
     /// to take effect.
     ///

--- a/crates/wayle-i18n/locales/en-US/config/modules/_media.ftl
+++ b/crates/wayle-i18n/locales/en-US/config/modules/_media.ftl
@@ -5,6 +5,9 @@
 settings-modules-media-icon-type = Icon Type
     .description = Icon display mode (default, application, spinning-disc, application-mapped). spinning-disc uses slightly more CPU due to animation
 
+settings-modules-media-hide-when-inactive = Hide When Inactive
+    .description = Hide the module when no active media player is available
+
 settings-modules-media-player-icons = Player Icons
     .description = Custom player-to-icon mappings (glob pattern to icon name)
 

--- a/crates/wayle-i18n/locales/fr/config/modules/_media.ftl
+++ b/crates/wayle-i18n/locales/fr/config/modules/_media.ftl
@@ -5,6 +5,9 @@
 settings-modules-media-icon-type = Type d'icône
     .description = Mode d'affichage de l'icône (par défaut, application, disque tournant, application associée). Le disque tournant utilise légèrement plus de processeur en raison de l'animation
 
+settings-modules-media-hide-when-inactive = Masquer si inactif
+    .description = Masque le module lorsqu'aucun lecteur multimédia actif n'est disponible
+
 settings-modules-media-player-icons = Icônes de lecteur
     .description = Correspondances personnalisées lecteur-icône (motif glob vers nom d'icône)
 

--- a/crates/wayle-settings/src/pages/modules/media.rs
+++ b/crates/wayle-settings/src/pages/modules/media.rs
@@ -3,7 +3,7 @@
 use wayle_config::Config;
 
 use crate::{
-    editors::{enum_select::enum_select, text::text, toml_editor::toml_editor},
+    editors::{enum_select::enum_select, text::text, toggle::toggle, toml_editor::toml_editor},
     pages::{
         nav::LeafEntry,
         sections::bar_button::{
@@ -43,6 +43,7 @@ pub(crate) fn entry(config: &Config) -> LeafEntry {
                 SectionSpec {
                     title_key: "settings-section-general",
                     items: vec![
+                        toggle(&module.hide_when_inactive),
                         enum_select(&module.icon_type),
                         text(&module.format),
                         text(&module.icon_name),

--- a/crates/wayle-shell/src/shell/bar/modules/media/messages.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/media/messages.rs
@@ -29,4 +29,5 @@ pub(crate) enum MediaCmd {
     PlaybackStateChanged,
     UpdateIcon(String),
     IconTypeChanged,
+    HideWhenInactiveChanged,
 }

--- a/crates/wayle-shell/src/shell/bar/modules/media/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/media/mod.rs
@@ -30,6 +30,7 @@ use crate::shell::bar::dropdowns::{self, DropdownRegistry};
 pub(crate) struct MediaModule {
     bar_button: Controller<BarButton>,
     config: Arc<ConfigService>,
+    visible: ConfigProperty<bool>,
     active_player_watcher_token: WatcherToken,
     media: Arc<MediaService>,
     dropdowns: Rc<DropdownRegistry>,
@@ -59,6 +60,13 @@ impl Component for MediaModule {
         let config = init.config.config();
         let media_config = &config.modules.media;
 
+        let visible = if media_config.hide_when_inactive.get() {
+            init.media.active_player().is_some()
+        } else {
+            true
+        };
+        let visible = ConfigProperty::new(visible);
+
         let bar_button = BarButton::builder()
             .launch(BarButtonInit {
                 icon: media_config.icon_name.get().clone(),
@@ -77,7 +85,7 @@ impl Component for MediaModule {
                     show_icon: media_config.icon_show.clone(),
                     show_label: media_config.label_show.clone(),
                     show_border: media_config.border_show.clone(),
-                    visible: ConfigProperty::new(true),
+                    visible: visible.clone(),
                 },
                 settings: init.settings,
             })
@@ -94,6 +102,7 @@ impl Component for MediaModule {
         let model = Self {
             bar_button,
             config: init.config,
+            visible,
             active_player_watcher_token: WatcherToken::new(),
             media: init.media,
             dropdowns: init.dropdowns,
@@ -128,6 +137,10 @@ impl Component for MediaModule {
                 Self::update_disc_mode(root, use_disc);
 
                 if let Some(player) = player {
+                    if media_config.hide_when_inactive.get() {
+                        self.visible.set(true);
+                    }
+
                     let label = helpers::build_label(media_config, &player);
                     self.bar_button.emit(BarButtonInput::SetLabel(label));
 
@@ -140,6 +153,10 @@ impl Component for MediaModule {
                     let token = self.active_player_watcher_token.reset();
                     watchers::spawn_player_watchers(&sender, &player, token);
                 } else {
+                    if media_config.hide_when_inactive.get() {
+                        self.visible.set(false);
+                    }
+
                     self.bar_button
                         .emit(BarButtonInput::SetLabel(String::from("--")));
                     self.bar_button
@@ -175,6 +192,14 @@ impl Component for MediaModule {
 
                     let state = player.playback_state.get();
                     Self::update_spinning_state(root, state);
+                }
+            }
+            MediaCmd::HideWhenInactiveChanged => {
+                let no_player = self.media.active_player().is_none();
+                if media_config.hide_when_inactive.get() && no_player {
+                    self.visible.set(false);
+                } else {
+                    self.visible.set(true);
                 }
             }
         }

--- a/crates/wayle-shell/src/shell/bar/modules/media/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/media/watchers.rs
@@ -42,6 +42,11 @@ pub(super) fn spawn_watchers(
     watch!(sender, [config.icon_type.watch()], |out| {
         let _ = out.send(MediaCmd::IconTypeChanged);
     });
+
+    let hide_when_inactive = config.hide_when_inactive.clone();
+    watch!(sender, [hide_when_inactive.watch()], |out| {
+        let _ = out.send(MediaCmd::HideWhenInactiveChanged);
+    });
 }
 
 pub(super) fn spawn_player_watchers(


### PR DESCRIPTION
<!--
- Link to a related issue with "Fixes #123" if one exists
- For visual changes, include before/after screenshots
- Ensure `cargo fmt` and `cargo clippy --workspace` pass
-->

## Objective

I found that media is always showing even when there is no media player running, which is a little strange to me.
## Solution

I added this config for media module:
```toml
[modules.media]
hide-when-inactive = true
```
And add this config to `wayle-settings` as well:
<img width="1262" height="1375" alt="图片" src="https://github.com/user-attachments/assets/11aedbcd-de05-4473-a66c-c73ee96600cd" />

## Test Plan

Tested in cargo build (debug mode), works fine.