### PR TITLE
feat: make user session actions configurable

### DIFF
--- a/crates/wayle-config/src/schemas/bar/dropdowns/dashboard/mod.rs
+++ b/crates/wayle-config/src/schemas/bar/dropdowns/dashboard/mod.rs
@@ -1,0 +1,2 @@
+/// User session types
+pub mod user_session;

--- a/crates/wayle-config/src/schemas/bar/dropdowns/dashboard/user_session.rs
+++ b/crates/wayle-config/src/schemas/bar/dropdowns/dashboard/user_session.rs
@@ -1,0 +1,19 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// One action the dashboard session actions
+#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub enum SessionAction {
+    /// Lock the session
+    #[serde(rename = "lock")]
+    Lock,
+    /// Logout of the current session
+    #[serde(rename = "log-out")]
+    Logout,
+    /// Reboot the machine
+    #[serde(rename = "reboot")]
+    Reboot,
+    /// Power off the machine
+    #[serde(rename = "power-off")]
+    PowerOff,
+}

--- a/crates/wayle-config/src/schemas/bar/dropdowns/mod.rs
+++ b/crates/wayle-config/src/schemas/bar/dropdowns/mod.rs
@@ -1,0 +1,2 @@
+/// Dashboard types
+pub mod dashboard;

--- a/crates/wayle-config/src/schemas/bar/mod.rs
+++ b/crates/wayle-config/src/schemas/bar/mod.rs
@@ -1,3 +1,5 @@
+/// Schema for types in dropdowns
+pub mod dropdowns;
 mod types;
 
 use schemars::schema_for;

--- a/crates/wayle-config/src/schemas/modules/dashboard/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/dashboard/mod.rs
@@ -4,7 +4,10 @@ use wayle_derive::wayle_config;
 use crate::{
     ClickAction, ConfigProperty,
     docs::{ConfigGroup, GroupDefaults, ModuleInfo, ModuleInfoProvider},
-    schemas::styling::{ColorValue, CssToken},
+    schemas::{
+        bar::dropdowns::dashboard::user_session::SessionAction,
+        styling::{ColorValue, CssToken},
+    },
 };
 
 /// Quick-access button with a distro icon; opens the dashboard dropdown.
@@ -80,6 +83,10 @@ pub struct DashboardConfig {
     #[default(String::from("systemctl poweroff"))]
     pub dropdown_poweroff_command: ConfigProperty<String>,
 
+    /// User session configuration
+    #[serde(rename = "user-session")]
+    pub user_session: UserSessionConfig,
+
     /// Hidden: icon always shown.
     #[serde(skip)]
     #[schemars(skip)]
@@ -136,4 +143,35 @@ impl ModuleInfoProvider for DashboardConfig {
     }
 }
 
+/// Settings for user session the in dashboard
+/// ## Examples
+///
+/// ```toml
+/// [modules.dashboard.user-session]
+/// actions = [ "lock", "log-out", "reboot", "power-off" ]
+/// ```
+#[wayle_config(i18n_prefix = "settings-modules-dashboard-user-session")]
+pub struct UserSessionConfig {
+    /// Session actions to show on dashboard
+    #[serde(rename = "actions")]
+    #[default(vec![SessionAction::Lock, SessionAction::Logout, SessionAction::Reboot, SessionAction::PowerOff])]
+    pub actions: ConfigProperty<Vec<SessionAction>>,
+}
+
+impl ModuleInfoProvider for UserSessionConfig {
+    fn module_info() -> ModuleInfo {
+        ModuleInfo {
+            name: String::from("dropdown-dashboard-user-session"),
+            schema: || schema_for!(UserSessionConfig),
+            layout_id: Some(String::from("user-session")),
+            array_entry: false,
+        }
+    }
+
+    fn groups() -> Vec<ConfigGroup> {
+        GroupDefaults::bar_button()
+    }
+}
+
+crate::register_module!(UserSessionConfig);
 crate::register_module!(DashboardConfig);

--- a/crates/wayle-shell/src/shell/bar/dropdowns/dashboard/user_session/factory.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/dashboard/user_session/factory.rs
@@ -1,0 +1,113 @@
+//! Session action factory for creating session action buttons in dashboard dropdown.
+
+use gtk::prelude::*;
+use relm4::prelude::*;
+use wayle_config::schemas::bar::dropdowns::dashboard::user_session::SessionAction;
+use wayle_widgets::primitives::buttons::IconButton;
+
+use crate::{i18n::t, shell::bar::dropdowns::dashboard::user_session::messages::UserSessionInput};
+
+pub(crate) struct SessionActionFactoryInit {
+    pub(crate) session_action: SessionAction,
+}
+
+pub(crate) struct SessionActionFactory {
+    #[allow(dead_code)]
+    session_action: SessionAction,
+    action_button: IconButton,
+}
+
+#[relm4::factory(pub(crate))]
+impl FactoryComponent for SessionActionFactory {
+    type Init = SessionActionFactoryInit;
+    type Input = ();
+    type Output = UserSessionInput;
+    type CommandOutput = ();
+    type ParentWidget = gtk::Box;
+
+    view! {
+        #[root]
+        gtk::Box {
+            add_css_class: "bar-item",
+        }
+    }
+
+    fn init_model(init: Self::Init, _index: &DynamicIndex, sender: FactorySender<Self>) -> Self {
+        let action_button = match &init.session_action {
+            SessionAction::Lock => make_session_btn(
+                "ld-lock-symbolic",
+                &t!("dropdown-dashboard-lock"),
+                &["session-btn"],
+                move || {
+                    sender.output(UserSessionInput::Lock).ok();
+                },
+            ),
+            SessionAction::Logout => make_session_btn(
+                "ld-log-out-symbolic",
+                &t!("dropdown-dashboard-logout"),
+                &["session-btn"],
+                move || {
+                    sender.output(UserSessionInput::Logout).ok();
+                },
+            ),
+            SessionAction::Reboot => make_session_btn(
+                "ld-refresh-cw-symbolic",
+                &t!("dropdown-dashboard-reboot"),
+                &["session-btn"],
+                move || {
+                    sender.output(UserSessionInput::Reboot).ok();
+                },
+            ),
+            SessionAction::PowerOff => make_session_btn(
+                "ld-power-symbolic",
+                &t!("dropdown-dashboard-power-off"),
+                &["session-btn"],
+                move || {
+                    sender.output(UserSessionInput::PowerOff).ok();
+                },
+            ),
+        };
+
+        Self {
+            session_action: init.session_action,
+            action_button,
+        }
+    }
+
+    fn init_widgets(
+        &mut self,
+        _index: &DynamicIndex,
+        root: Self::Root,
+        _returned_widget: &<Self::ParentWidget as relm4::factory::FactoryView>::ReturnedWidget,
+        _sender: FactorySender<Self>,
+    ) -> Self::Widgets {
+        let widgets = view_output!();
+
+        root.append(self.action_button.widget_ref());
+
+        widgets
+    }
+}
+
+fn make_session_btn(
+    icon: &str,
+    tooltip: &str,
+    extra_classes: &[&str],
+    on_click: impl Fn() + 'static,
+) -> IconButton {
+    let btn_template = IconButton::init(());
+    let btn: &gtk::Button = &btn_template;
+
+    for class in extra_classes {
+        btn.add_css_class(class);
+    }
+    btn.set_tooltip_text(Some(tooltip));
+
+    btn.connect_clicked(move |_| on_click());
+
+    let image = gtk::Image::new();
+    image.set_icon_name(Some(icon));
+    btn.set_child(Some(&image));
+
+    btn_template
+}

--- a/crates/wayle-shell/src/shell/bar/dropdowns/dashboard/user_session/messages.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/dashboard/user_session/messages.rs
@@ -7,7 +7,7 @@ pub(crate) struct UserSessionInit {
     pub config: Arc<ConfigService>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub(crate) enum UserSessionInput {
     Lock,
     Logout,

--- a/crates/wayle-shell/src/shell/bar/dropdowns/dashboard/user_session/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/dashboard/user_session/mod.rs
@@ -1,3 +1,4 @@
+mod factory;
 mod messages;
 mod watchers;
 
@@ -5,12 +6,21 @@ use std::{env, path::PathBuf, sync::Arc};
 
 use gtk::{CssProvider, gdk::Display, prelude::*, style_context_add_provider_for_display};
 use relm4::{gtk, prelude::*};
-use wayle_config::ConfigService;
-use wayle_widgets::prelude::IconButton;
+use wayle_config::{
+    ConfigService, schemas::bar::dropdowns::dashboard::user_session::SessionAction,
+};
 
 pub(crate) use self::messages::UserSessionInit;
 use self::messages::{UserSessionCmd, UserSessionInput};
-use crate::{i18n::t, process, shell::helpers::COMPONENT_CSS_PRIORITY};
+use crate::{
+    process,
+    shell::{
+        bar::dropdowns::dashboard::user_session::factory::{
+            SessionActionFactory, SessionActionFactoryInit,
+        },
+        helpers::COMPONENT_CSS_PRIORITY,
+    },
+};
 
 pub(crate) struct UserSessionSection {
     username: String,
@@ -18,6 +28,7 @@ pub(crate) struct UserSessionSection {
     face_path: PathBuf,
     face_css_provider: CssProvider,
     config: Arc<ConfigService>,
+    session_actions: FactoryVecDeque<SessionActionFactory>,
 }
 
 impl UserSessionSection {
@@ -29,6 +40,15 @@ impl UserSessionSection {
             String::from(".user-avatar { background-image: none; }")
         };
         self.face_css_provider.load_from_string(&css);
+    }
+
+    fn update_session_actions(&mut self, actions: &[SessionAction]) {
+        let mut guard = self.session_actions.guard();
+        guard.clear();
+
+        for (i, session_action) in actions.iter().copied().enumerate() {
+            guard.insert(i, SessionActionFactoryInit { session_action });
+        }
     }
 }
 
@@ -90,54 +110,6 @@ impl Component for UserSessionSection {
                     add_css_class: "session-actions",
                     set_hexpand: true,
                     set_halign: gtk::Align::End,
-
-                    #[template]
-                    #[name = "lock_btn"]
-                    IconButton {
-                        add_css_class: "session-btn",
-                        set_tooltip_text: Some(&t!("dropdown-dashboard-lock")),
-                        connect_clicked => UserSessionInput::Lock,
-
-                        gtk::Image {
-                            set_icon_name: Some("ld-lock-symbolic"),
-                        },
-                    },
-
-                    #[template]
-                    #[name = "logout_btn"]
-                    IconButton {
-                        add_css_class: "session-btn",
-                        set_tooltip_text: Some(&t!("dropdown-dashboard-logout")),
-                        connect_clicked => UserSessionInput::Logout,
-
-                        gtk::Image {
-                            set_icon_name: Some("ld-log-out-symbolic"),
-                        },
-                    },
-
-                    #[template]
-                    #[name = "reboot_btn"]
-                    IconButton {
-                        add_css_class: "session-btn",
-                        set_tooltip_text: Some(&t!("dropdown-dashboard-reboot")),
-                        connect_clicked => UserSessionInput::Reboot,
-
-                        gtk::Image {
-                            set_icon_name: Some("ld-refresh-cw-symbolic"),
-                        },
-                    },
-
-                    #[template]
-                    #[name = "power_off_btn"]
-                    IconButton {
-                        set_css_classes: &["icon", "session-btn", "danger"],
-                        set_tooltip_text: Some(&t!("dropdown-dashboard-power-off")),
-                        connect_clicked => UserSessionInput::PowerOff,
-
-                        gtk::Image {
-                            set_icon_name: Some("ld-power-symbolic"),
-                        },
-                    },
                 },
             },
         }
@@ -166,17 +138,37 @@ impl Component for UserSessionSection {
 
         watchers::spawn_face_watcher(&sender, &face_path);
 
-        let model = Self {
+        let session_actions = FactoryVecDeque::builder()
+            .launch(gtk::Box::default())
+            .detach();
+
+        let user_session_actions = init
+            .config
+            .config()
+            .modules
+            .dashboard
+            .user_session
+            .actions
+            .get();
+
+        let mut model = Self {
             username: init.username,
             has_face,
             face_path,
             face_css_provider,
             config: init.config,
+            session_actions,
         };
 
         model.update_face_css();
+        model.update_session_actions(&user_session_actions);
 
         let widgets = view_output!();
+
+        widgets
+            .session_actions
+            .append(model.session_actions.widget());
+
         ComponentParts { model, widgets }
     }
 


### PR DESCRIPTION
<!--
- Link to a related issue with "Fixes #123" if one exists
- For visual changes, include before/after screenshots
- Ensure `cargo fmt` and `cargo clippy --workspace` pass
-->

I'm quite new to GTK but I have given a go at making the user session buttons in the dashboard drop-down configurable.

I have not made it auto-reload on change and the only  configuration I have added for them is the buttons to show, but maybe this can be expanded in the future. 

Its working towards resolving https://github.com/wayle-rs/wayle/issues/273

**before**

<img width="363" height="271" alt="image" src="https://github.com/user-attachments/assets/98642986-582a-455b-88cb-9ef0a300c81a" />


**with config**
```
[modules.dashboard.user-session]
actions = [ "log-out" ]
```
<img width="363" height="271" alt="image" src="https://github.com/user-attachments/assets/ec1a30f9-3ce5-468c-9b63-15380594148a" />


## Objective

Make the session actions in the dashboard user session section configurable

## Solution



## Test Plan
