### PR TITLE
fix: show hidden niri workspaces when hide_trailing_empty is disabled

### DIFF
--- a/crates/wayle-config/src/schemas/modules/niri_workspaces/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/niri_workspaces/mod.rs
@@ -154,17 +154,6 @@ impl<'a> IntoIterator for &'a WorkspaceMap {
 /// Niri workspace indicators with click-to-switch.
 #[wayle_config(i18n_prefix = "settings-modules-niri-workspaces")]
 pub struct NiriWorkspacesConfig {
-    /// Always-visible ceiling for numerically-named workspaces.
-    ///
-    /// Workspaces whose name parses to an integer at or below this value
-    /// stay visible even when empty. Workspaces with non-numeric names
-    /// and those above the ceiling follow the normal empty/occupied
-    /// filtering. When `0` (default), no extra workspaces are forced
-    /// visible.
-    #[serde(rename = "min-workspace-count")]
-    #[default(0)]
-    pub min_workspace_count: ConfigProperty<u8>,
-
     /// Show only workspaces on this bar's monitor.
     ///
     /// When `true` (default), each bar shows only its own output's

--- a/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/filtering.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/filtering.rs
@@ -42,7 +42,7 @@ pub(super) fn collect_displayed(
         Vec::new()
     };
 
-    let candidates: Vec<WorkspaceSnapshot> = snapshots
+    let mut workspaces: Vec<WorkspaceSnapshot> = snapshots
         .into_iter()
         .filter(|snapshot| visible_on_monitor(snapshot, ctx))
         .filter(|snapshot| {
@@ -56,16 +56,8 @@ pub(super) fn collect_displayed(
         .filter(|snapshot| !trailing_empty_ids.contains(&snapshot.id))
         .collect();
 
-    let (mut shown, hidden): (Vec<_>, Vec<_>) = candidates
-        .into_iter()
-        .partition(|snapshot| snapshot.has_windows || snapshot.is_active);
-
-    for snapshot in hidden {
-        shown.push(snapshot);
-    }
-
-    shown.sort_by_key(sort_key);
-    shown
+    workspaces.sort_by_key(sort_key);
+    workspaces
 }
 
 fn visible_on_monitor(snapshot: &WorkspaceSnapshot, ctx: &FilterContext<'_>) -> bool {

--- a/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/filtering.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/filtering.rs
@@ -62,9 +62,7 @@ pub(super) fn collect_displayed(
         .partition(|snapshot| snapshot.has_windows || snapshot.is_active);
 
     for snapshot in hidden {
-        if name_as_id(&snapshot.name).is_some_and(|id| id <= ctx.min_workspace_count) {
-            shown.push(snapshot);
-        }
+        shown.push(snapshot);
     }
 
     shown.sort_by_key(sort_key);

--- a/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/filtering.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/filtering.rs
@@ -29,7 +29,6 @@ pub(super) struct FilterContext<'a> {
     pub monitor_specific: bool,
     pub bar_monitor: Option<&'a str>,
     pub hide_trailing_empty: bool,
-    pub min_workspace_count: usize,
     pub ignore_patterns: &'a [String],
 }
 
@@ -67,10 +66,6 @@ pub(super) fn collect_displayed(
 
     shown.sort_by_key(sort_key);
     shown
-}
-
-fn name_as_id(name: &Option<String>) -> Option<usize> {
-    name.as_deref()?.parse().ok()
 }
 
 fn visible_on_monitor(snapshot: &WorkspaceSnapshot, ctx: &FilterContext<'_>) -> bool {

--- a/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/methods.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/methods.rs
@@ -59,7 +59,6 @@ impl NiriWorkspaces {
             monitor_specific: ws_config.monitor_specific.get(),
             bar_monitor: self.bar_monitor(),
             hide_trailing_empty: ws_config.hide_trailing_empty.get(),
-            min_workspace_count: usize::from(ws_config.min_workspace_count.get()),
             ignore_patterns: &ignore_patterns,
         };
 


### PR DESCRIPTION
closes https://github.com/wayle-rs/wayle/issues/199
and https://github.com/wayle-rs/wayle/issues/272

On my setup, `hide_trailing_empty` did not work as expected in that it did nothing because my workspaces do not have names.

Also removes `min_workspace_count` niri configuration because it is now unused.

<!--
- Link to a related issue with "Fixes #123" if one exists
- For visual changes, include before/after screenshots
- Ensure `cargo fmt` and `cargo clippy --workspace` pass
-->


------

`hide_trailing_empty` on
<img width="161" height="34" alt="image" src="https://github.com/user-attachments/assets/cda9f117-ec40-46a8-a29f-077ae05ad58a" />

`hide_trailing_empty` off
<img width="202" height="38" alt="image" src="https://github.com/user-attachments/assets/9a33c48d-4834-4118-90e3-aaac9d8fca5b" />



## Objective
Show trailing niri workspace when `hide_trailing_empty` is off even for unnamed workspaces

## Solution
Do not require a name for hidden workspaces to show

## Test Plan
