### PR TITLE
feat: add configuration option to disable notifications (#186)

### DIFF
--- a/crates/wayle-config/src/schemas/modules/notification/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/notification/mod.rs
@@ -18,6 +18,10 @@ use crate::{
 /// Notification center: icon in the bar, dropdown with history, DND toggle.
 #[wayle_config(bar_button, i18n_prefix = "settings-modules-notifications")]
 pub struct NotificationConfig {
+    /// Enable the notifications service and module.
+    #[default(true)]
+    pub enabled: ConfigProperty<bool>,
+
     /// Icon shown when no notifications and DND is off.
     #[serde(rename = "icon-name")]
     #[default(String::from("ld-bell-symbolic"))]

--- a/crates/wayle-i18n/locales/en-US/config/modules/_notification.ftl
+++ b/crates/wayle-i18n/locales/en-US/config/modules/_notification.ftl
@@ -1,6 +1,9 @@
-### Wayle Configuration - Notification Module
+### Wayle Configuration - Notifications Module
 
-## Notification Module Configuration
+## Notifications Module Configuration
+
+settings-modules-notifications-enabled = Enabled
+    .description = Enable the notifications service and module
 
 settings-modules-notifications-icon-name = Default Icon
     .description = Icon shown when no notifications

--- a/crates/wayle-i18n/locales/fr/config/modules/_notification.ftl
+++ b/crates/wayle-i18n/locales/fr/config/modules/_notification.ftl
@@ -1,6 +1,9 @@
-### Configuration Wayle - Module Notification
+### Configuration Wayle - Module Notifications
 
-## Configuration du module Notification
+## Configuration du module Notifications
+
+settings-modules-notifications-enabled = Activé
+    .description = Activer le service et le module de notifications
 
 settings-modules-notifications-icon-name = Icône par défaut
     .description = Icône affichée en l'absence de notifications

--- a/crates/wayle-settings/src/pages/notifications/mod.rs
+++ b/crates/wayle-settings/src/pages/notifications/mod.rs
@@ -27,6 +27,10 @@ pub(crate) fn entry(config: &Config) -> LeafEntry {
             "settings-page-notifications",
             vec![
                 SectionSpec {
+                    title_key: "settings-section-general",
+                    items: vec![toggle(&notif.enabled)],
+                },
+                SectionSpec {
                     title_key: "settings-section-popup-display",
                     items: vec![
                         enum_select(&notif.popup_position),

--- a/crates/wayle-shell/src/bootstrap/mod.rs
+++ b/crates/wayle-shell/src/bootstrap/mod.rs
@@ -319,7 +319,7 @@ async fn init_daemon_services(
                 .blocklist(blocklist)
                 .build(),
         );
-        try_service!(timer, "Notification", spawned(notification_task), no_wrap).await
+        try_service!(timer, "Notification", spawned(notification_task), no_wrap)
     } else {
         None
     };

--- a/crates/wayle-shell/src/bootstrap/mod.rs
+++ b/crates/wayle-shell/src/bootstrap/mod.rs
@@ -303,13 +303,6 @@ async fn init_daemon_services(
             .priority_players(priority)
             .build(),
     );
-    let blocklist = Property::new(modules.notifications.blocklist.get());
-    let notification_task = tokio::spawn(
-        NotificationService::builder()
-            .with_daemon()
-            .blocklist(blocklist)
-            .build(),
-    );
     let systray_task = tokio::spawn(
         SystemTrayService::builder()
             .with_daemon()
@@ -317,10 +310,23 @@ async fn init_daemon_services(
             .build(),
     );
 
-    let (audio, media, notification, systray) = tokio::join!(
+    // Conditionally initialize notification service
+    let notification = if modules.notifications.enabled.get() {
+        let blocklist = Property::new(modules.notifications.blocklist.get());
+        let notification_task = tokio::spawn(
+            NotificationService::builder()
+                .with_daemon()
+                .blocklist(blocklist)
+                .build(),
+        );
+        try_service!(timer, "Notification", spawned(notification_task), no_wrap).await
+    } else {
+        None
+    };
+
+    let (audio, media, systray) = tokio::join!(
         async { try_service!(timer, "Audio", spawned(audio_task), no_wrap) },
         async { try_service!(timer, "Media", spawned(media_task), no_wrap) },
-        async { try_service!(timer, "Notification", spawned(notification_task), no_wrap) },
         async { try_service!(timer, "SystemTray", spawned(systray_task), no_wrap) },
     );
 

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/factory.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/factory.rs
@@ -10,16 +10,20 @@ pub(crate) struct Factory;
 
 impl DropdownFactory for Factory {
     fn create(services: &ShellServices) -> Option<DropdownInstance> {
+        let notification_enabled = services.config.config().modules.notifications.enabled.get();
         let notification = require_service(
             "notification",
             "notification",
             services.notification.clone(),
         )?;
-        let config = services.config.clone();
+
+        if !notification_enabled {
+            return None;
+        }
 
         let init = NotificationDropdownInit {
             notification,
-            config,
+            config: services.config.clone(),
         };
         let controller = NotificationDropdown::builder().launch(init).detach();
 

--- a/crates/wayle-shell/src/shell/bar/modules/notification/factory.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/notification/factory.rs
@@ -21,11 +21,16 @@ impl ModuleFactory for Factory {
         dropdowns: &Rc<DropdownRegistry>,
         class: Option<String>,
     ) -> Option<ModuleInstance> {
+        let notification_enabled = services.config.config().modules.notifications.enabled.get();
         let notification = require_service(
             "notification",
             "notification",
             services.notification.clone(),
         )?;
+
+        if !notification_enabled {
+            return None;
+        }
 
         let init = NotificationInit {
             settings: settings.clone(),

--- a/crates/wayle-shell/src/shell/mod.rs
+++ b/crates/wayle-shell/src/shell/mod.rs
@@ -94,14 +94,7 @@ impl Component for Shell {
 
         init.timer.finish();
 
-        let notification_popup = init.services.notification.as_ref().map(|notification| {
-            NotificationPopupHost::builder()
-                .launch(PopupHostInit {
-                    notification: notification.clone(),
-                    config: init.services.config.clone(),
-                })
-                .detach()
-        });
+        let notification_popup = create_notification_popup(&init.services);
 
         let osd = create_osd(&init.services);
 
@@ -210,4 +203,24 @@ fn create_osd(services: &ShellServices) -> Option<Controller<Osd>> {
 fn trigger_layer_shell_reconfigure(window: &gtk::Window) {
     window.set_default_size(1, 1);
     window.set_default_size(0, 0);
+}
+
+fn create_notification_popup(
+    services: &ShellServices,
+) -> Option<Controller<NotificationPopupHost>> {
+    let notification_enabled = services.config.config().modules.notifications.enabled.get();
+    let notification = services.notification.as_ref()?;
+
+    if !notification_enabled {
+        return None;
+    }
+
+    Some(
+        NotificationPopupHost::builder()
+            .launch(PopupHostInit {
+                notification: notification.clone(),
+                config: services.config.clone(),
+            })
+            .detach(),
+    )
 }

--- a/crates/wayle-shell/src/watchers/notification.rs
+++ b/crates/wayle-shell/src/watchers/notification.rs
@@ -9,9 +9,14 @@ use crate::shell::ShellServices;
 
 /// Syncs the notification blocklist from config to the service on change.
 pub fn spawn(services: &ShellServices) {
+    let notification_enabled = services.config.config().modules.notifications.enabled.get();
     let Some(notification) = &services.notification else {
         return;
     };
+
+    if !notification_enabled {
+        return;
+    }
 
     let config = services.config.config();
     spawn_blocklist_watcher(&config.modules.notifications, notification);


### PR DESCRIPTION
## Summary
Adds a configuration option to disable the notifications service and module, addressing issue #186.

## Changes
- **Config**: Added `enabled` option to `NotificationConfig` (default: `true`)
- **Bootstrap**: Conditionally initializes notification service based on config
- **Shell**: Conditionally creates notification popup, module, and dropdown
- **Settings GUI**: Added "Enabled" toggle in Notifications → General section
- **i18n**: English and French translations for the new option

## Usage
Users can disable notifications via:
- Config file:
  ```toml
  [modules.notifications]
  enabled = false
  ```
- Settings GUI: Notifications page → General → Enabled toggle

## Testing
- Verified config compiles and schema generates correctly
- Verified all existing notification functionality works when enabled
- Verified notification service is not initialized when disabled
- Verified settings GUI toggle appears and works