### PR TITLE
fix(settings): open on the active workspace instead of first workspace

### DIFF
--- a/crates/wayle-settings/src/main.rs
+++ b/crates/wayle-settings/src/main.rs
@@ -14,6 +14,7 @@ mod sidebar;
 
 use std::{env, process};
 
+use relm4::gtk::prelude::*;
 use tokio::runtime::Runtime;
 use tracing_subscriber::EnvFilter;
 use wayle_config::{ConfigService, PersistenceWatcher};
@@ -72,7 +73,18 @@ fn main() {
         }
     };
 
-    let relm_app = relm4::RelmApp::new("com.wayle.settings");
+    let app = relm4::main_application();
+    app.set_application_id(Some("com.wayle.settings"));
+
+    // Raise the existing window when launched again; relm4 only calls
+    // set_visible, which is a no-op once the window is already shown.
+    app.connect_activate(|app| {
+        if let Some(window) = app.active_window() {
+            window.present();
+        }
+    });
+
+    let relm_app = relm4::RelmApp::from_app(app);
 
     relm_app.run::<app::SettingsApp>(config_service);
 }

--- a/crates/wayle-shell/src/shell/bar/dropdowns/dashboard/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/dashboard/mod.rs
@@ -9,13 +9,11 @@ mod system_stats;
 mod user_session;
 mod watchers;
 
-use std::{
-    process::{Command, Stdio},
-    thread,
-};
-
 use gtk::prelude::*;
-use relm4::{gtk, prelude::*};
+use relm4::{
+    gtk::{self, gdk, gio},
+    prelude::*,
+};
 use wayle_widgets::prelude::*;
 
 pub(super) use self::factory::Factory;
@@ -33,21 +31,33 @@ use crate::{i18n::t, shell::bar::dropdowns::scaled_dimension};
 
 const BASE_WIDTH: f32 = 380.0;
 
+/// Launches the settings app on the active workspace.
+///
+/// Launching through GDK's [`AppLaunchContext`](gdk::AppLaunchContext) gives the
+/// child a fresh `XDG_ACTIVATION_TOKEN` instead of the stale startup id the shell
+/// inherited at login, which would otherwise pin the window to workspace 1.
 fn spawn_settings_app() {
-    match Command::new("wayle-settings")
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-    {
-        Ok(mut child) => {
-            thread::spawn(move || {
-                let _ = child.wait();
-            });
-        }
+    let Some(display) = gdk::Display::default() else {
+        tracing::warn!("no default display; cannot launch wayle-settings");
+        return;
+    };
+
+    let context = display.app_launch_context();
+
+    let app_info = match gio::AppInfo::create_from_commandline(
+        "wayle-settings",
+        Some("Wayle Settings"),
+        gio::AppInfoCreateFlags::NONE,
+    ) {
+        Ok(info) => info,
         Err(err) => {
-            tracing::warn!(error = %err, "failed to spawn wayle-settings");
+            tracing::warn!(error = %err, "failed to build wayle-settings launcher");
+            return;
         }
+    };
+
+    if let Err(err) = app_info.launch(&[], Some(&context)) {
+        tracing::warn!(error = %err, "failed to launch wayle-settings");
     }
 }
 
@@ -262,8 +272,9 @@ impl Component for DashboardDropdown {
                 self.media.emit(MediaSectionInput::SetActive(visible));
             }
             DashboardDropdownMsg::OpenSettings => {
-                root.popdown();
+                // Launch before popdown so the activation token anchors to the focused surface.
                 spawn_settings_app();
+                root.popdown();
             }
         }
     }


### PR DESCRIPTION
### Current behavior
Opening Settings from the dashboard gear icon always placed the window on workspace 1, regardless of which workspace you were actually on. 
On top of that, clicking the gear again while Settings was already open currently did nothing.

### Cause
The shell spawned wayle-settings as a bare child process, so it inherited the stale Wayland activation token (XDG_ACTIVATION_TOKEN / DESKTOP_STARTUP_ID) that the shell itself received when it was started at login. The compositor honored that old token and placed the window where the shell originally started — workspace 1.

### Fix
* Launch through GDK's AppLaunchContext instead of a raw process spawn. GDK mints a fresh activation token anchored to the currently focused surface and injects it into the child's environment, so the compositor places and focuses Settings on the active workspace.
* Present the existing window on relaunch: we handle the application's activate signal with window.present(), since relm4's default handler only calls set_visible(true) (a no-op for an already-shown window). Combined with the forwarded token, this raises/focuses the open window instead of doing nothing. 
**This means that trying to open a new Wayle Settings window while that's already open on another workspace will now activate that window, which, for example on Hyprland, will show as that workspace blinking for attention.***

### Testing
Tested on Hyprland on my machine, everything works correctly.



