### PR TITLE
fix: prevent runtime.toml data loss from corrupt or stale state

### DIFF
--- a/crates/wayle-derive/src/derives.rs
+++ b/crates/wayle-derive/src/derives.rs
@@ -105,8 +105,14 @@ pub fn apply_config_layer(input: TokenStream) -> TokenStream {
 }
 
 /// Generates `ApplyRuntimeLayer`. Works like [`apply_config_layer`] but for
-/// runtime.toml (GUI overrides). Returns `Err` if a field rejects the value,
-/// so bad overrides get caught before they propagate.
+/// runtime.toml (GUI overrides).
+///
+/// A field that rejects its value is logged and skipped rather than
+/// propagated with `?`: this struct is itself one field of a parent struct,
+/// and an early return here would abort every *sibling* field still waiting
+/// in the parent's loop, silently dropping unrelated, perfectly valid
+/// runtime overrides. One bad value must never wipe out the rest of the
+/// config.
 pub fn apply_runtime_layer(input: TokenStream) -> TokenStream {
     let derive_input = parse_macro_input!(input as DeriveInput);
     let struct_name = &derive_input.ident;
@@ -124,7 +130,15 @@ pub fn apply_runtime_layer(input: TokenStream) -> TokenStream {
             let field_ident = &field.ident;
             lookup_loop(
                 field,
-                quote! { self.#field_ident.apply_runtime_layer(field_value, &child_path)?; },
+                quote! {
+                    if let Err(err) = self.#field_ident.apply_runtime_layer(field_value, &child_path) {
+                        ::tracing::warn!(
+                            field = %child_path,
+                            error = %err,
+                            "invalid runtime value; ignoring this field, keeping the rest",
+                        );
+                    }
+                },
             )
         });
 

--- a/crates/wayle-settings/src/editors/bar_layout/card/mod.rs
+++ b/crates/wayle-settings/src/editors/bar_layout/card/mod.rs
@@ -95,6 +95,7 @@ impl FactoryComponent for LayoutCard {
                     add_css_class: "layout-monitor-input",
                     set_placeholder_text: Some("DP-1"),
                     set_hexpand: false,
+                    set_text: &self.monitor,
                     connect_changed => LayoutCardMsg::MonitorChanged,
                 },
 
@@ -108,6 +109,7 @@ impl FactoryComponent for LayoutCard {
                     add_css_class: "layout-extends-input",
                     set_placeholder_text: Some(&t("settings-layout-extends-none")),
                     set_hexpand: false,
+                    set_text: self.extends.as_deref().unwrap_or(""),
                     connect_changed => LayoutCardMsg::ExtendsChanged,
                 },
 
@@ -121,6 +123,7 @@ impl FactoryComponent for LayoutCard {
                     add_css_class: "layout-show-toggle",
                     set_valign: gtk::Align::Center,
                     set_cursor_from_name: Some("pointer"),
+                    set_active: self.show,
                     connect_state_set[sender] => move |_switch, active| {
                         sender.input(LayoutCardMsg::ShowToggled(active));
                         glib::Propagation::Proceed
@@ -175,12 +178,6 @@ impl FactoryComponent for LayoutCard {
         sender: FactorySender<Self>,
     ) -> Self::Widgets {
         let widgets = view_output!();
-
-        widgets.monitor_entry.set_text(&self.monitor);
-        widgets
-            .extends_entry
-            .set_text(self.extends.as_deref().unwrap_or(""));
-        widgets.show_switch.set_active(self.show);
 
         self.monitor_entry = widgets.monitor_entry.clone();
         self.extends_entry = widgets.extends_entry.clone();

--- a/wayle/src/cli/panel/settings.rs
+++ b/wayle/src/cli/panel/settings.rs
@@ -9,6 +9,21 @@ use tracing::info;
 
 use crate::cli::CliAction;
 
+/// Resolves the `wayle-settings` binary next to the running `wayle`
+/// executable, falling back to `$PATH` when that lookup fails.
+///
+/// Prevents a custom/dev build of `wayle` from silently launching an
+/// unrelated, possibly schema-incompatible `wayle-settings` found earlier on
+/// `$PATH` (e.g. a system package), which can corrupt `runtime.toml` when the
+/// two builds disagree on the config schema.
+fn settings_binary_path() -> std::path::PathBuf {
+    std::env::current_exe()
+        .ok()
+        .and_then(|exe| exe.parent().map(|dir| dir.join("wayle-settings")))
+        .filter(|path| path.is_file())
+        .unwrap_or_else(|| std::path::PathBuf::from("wayle-settings"))
+}
+
 /// Launches the settings application.
 ///
 /// # Errors
@@ -17,7 +32,7 @@ use crate::cli::CliAction;
 pub async fn execute() -> CliAction {
     info!("Launching Wayle settings");
 
-    Command::new("wayle-settings")
+    Command::new(settings_binary_path())
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())


### PR DESCRIPTION
## Summary
- `ApplyRuntimeLayer`'s derive used `?` to propagate a single field's parse error, aborting every sibling field still waiting in the parent's loop. One bad/unknown value could wipe out an entire branch of valid config. Now logs and skips the offending field instead.
- The settings panel launcher (`wayle panel settings`) resolved `wayle-settings` via `$PATH`, which can silently pick up an unrelated, schema-incompatible build (e.g. a system package) ahead of a custom build. Now resolves the binary next to the running `wayle` executable first, falling back to `$PATH`.
- `LayoutCard`'s `view!` macro wired `connect_changed`/`connect_state_set` before setting the widget's initial value, so GTK fired a spurious "user changed this" event at construction time, marking fields dirty and persisting unintended changes. Initial values are now set before the signal handlers are connected.

## Test plan
- [x] Reproduced all three bugs locally (unknown field truncating `runtime.toml`, settings panel launching a stale system binary, spurious dirty-field writes on settings panel open)
- [x] Verified fixes with a clean release build: opening/closing the settings panel no longer truncates or mutates `runtime.toml`