### PR TITLE
fix(systray): show local menu on left-click when ItemIsMenu is true

### DIFF
--- a/crates/wayle-shell/src/shell/bar/modules/systray/item/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/systray/item/mod.rs
@@ -138,23 +138,21 @@ impl FactoryComponent for SystrayItem {
     fn update(&mut self, msg: Self::Input, _sender: relm4::prelude::FactorySender<Self>) {
         match msg {
             SystrayItemMsg::LeftClick => {
-                let item = self.item.clone();
-                let item_is_menu = item.item_is_menu.get();
-                tokio::spawn(async move {
-                    let result = if item_is_menu {
-                        item.context_menu(Coordinates::new(0, 0)).await
-                    } else {
-                        item.activate(Coordinates::new(0, 0)).await
-                    };
-                    if let Err(error) = result {
-                        warn!(
-                            id = %item.id.get(),
-                            bus_name = %item.bus_name.get(),
-                            error = %error,
-                            "systray activate failed"
-                        );
-                    }
-                });
+                if self.item.item_is_menu.get() {
+                    self.request_menu_show(&_sender);
+                } else {
+                    let item = self.item.clone();
+                    tokio::spawn(async move {
+                        if let Err(error) = item.activate(Coordinates::new(0, 0)).await {
+                            warn!(
+                                id = %item.id.get(),
+                                bus_name = %item.bus_name.get(),
+                                error = %error,
+                                "systray activate failed"
+                            );
+                        }
+                    });
+                }
             }
             SystrayItemMsg::RightClick => {
                 self.request_menu_show(&_sender);


### PR DESCRIPTION
## Objective

For items with ItemIsMenu=true, left-click was calling the D-Bus ContextMenu() method on the item instead of rendering the popover from the DBusMenu. Apps that export a menu via the standard Menu property but don't implement ContextMenu (e.g. fyne.io/systray apps like tailscale) returned UnknownMethod, so left-click did nothing.

## Solution

Mirror the right-click behavior in this case: render the popover locally from the DBusMenu. Apps with ItemIsMenu=false still get Activate() on left-click.

fwiw, this is consistent with waybar (https://github.com/Alexays/Waybar/blob/05945748dccce28bf96d26d8f64a9e69a8dd49ba/src/modules/sni/item.cpp#L561-L562) and probably other bars.

## Test Plan

Manually tested with Tailscale systray (where I initially discovered the problem) as well as KeepassXC, as an example of a systray app that has ItemIsMenu=false.