### PR TITLE
fix(dropdowns): reset keyboard mode before reparenting popover

### DIFF
--- a/crates/wayle-shell/src/shell/bar/dropdowns/registry.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/registry.rs
@@ -166,6 +166,9 @@ impl DropdownInstance {
             return;
         }
         if self.popover.parent().is_some() {
+            // Reparenting skips `connect_closed`, so the old window's layer-shell
+            // surface would otherwise stay stuck in OnDemand keyboard mode forever.
+            set_bar_keyboard_mode(&self.popover, KeyboardMode::None);
             self.popover.unparent();
         }
         self.popover.set_parent(target);


### PR DESCRIPTION
## Summary
- `reparent_and_show()` / `ensure_parent()` move a dropdown's popover to a new anchor widget without calling `popdown()`, so `connect_closed()` — the only place that resets `KeyboardMode` to `None` — never fires for the old window.
- The old window's layer-shell surface stays stuck in `KeyboardMode::OnDemand` indefinitely after the dropdown is reparented elsewhere, which can interfere with the compositor's keyboard focus handling for unrelated toplevels (observed on Sway: stray keystrokes routed to a stale focused window after interacting with a bar dropdown).
- Fix: reset `KeyboardMode::None` on the popover's current window before unparenting it in `ensure_parent()`.

## Test plan
- [x] `cargo build --release -p wayle-shell -p wayle`
- [x] Deployed to a live Sway session, exercised dropdowns (network/bluetooth) across multiple anchors and confirmed no more lingering `OnDemand` keyboard mode