### PR TITLE
feat: configurable calendar week start day

### DIFF
--- a/crates/wayle-config/src/schemas/modules/clock/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/clock/mod.rs
@@ -1,11 +1,31 @@
 use schemars::schema_for;
-use wayle_derive::wayle_config;
+use wayle_derive::{wayle_config, wayle_enum};
 
 use crate::{
     ClickAction, ConfigProperty,
     docs::{ConfigGroup, GroupDefaults, ModuleInfo, ModuleInfoProvider},
     schemas::styling::{ColorValue, CssToken},
 };
+
+/// First day of the week shown in the calendar dropdown.
+#[wayle_enum(default)]
+pub enum WeekStart {
+    /// Week starts on Monday.
+    Monday,
+    /// Week starts on Tuesday.
+    Tuesday,
+    /// Week starts on Wednesday.
+    Wednesday,
+    /// Week starts on Thursday.
+    Thursday,
+    /// Week starts on Friday.
+    Friday,
+    /// Week starts on Saturday.
+    Saturday,
+    /// Week starts on Sunday.
+    #[default]
+    Sunday,
+}
 
 /// Time display with a calendar dropdown.
 #[wayle_config(bar_button, i18n_prefix = "settings-modules-clock")]
@@ -113,6 +133,11 @@ pub struct ClockConfig {
     #[serde(rename = "dropdown-show-seconds")]
     #[default(false)]
     pub dropdown_show_seconds: ConfigProperty<bool>,
+
+    /// First day of the week in the calendar dropdown.
+    #[serde(rename = "dropdown-week-start")]
+    #[default(WeekStart::Sunday)]
+    pub dropdown_week_start: ConfigProperty<WeekStart>,
 }
 
 impl ModuleInfoProvider for ClockConfig {

--- a/crates/wayle-config/src/schemas/modules/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/mod.rs
@@ -38,7 +38,7 @@ pub use cava::{
     BarCount as CavaBarCount, CavaConfig, CavaDirection, CavaInput, CavaStyle,
     Framerate as CavaFramerate, FrequencyHz,
 };
-pub use clock::ClockConfig;
+pub use clock::{ClockConfig, WeekStart};
 pub use cpu::CpuConfig;
 pub use custom::{CustomModuleDefinition, ExecutionMode, RestartDelay, RestartPolicy};
 pub use dashboard::DashboardConfig;

--- a/crates/wayle-i18n/locales/en-US/config/_modules.ftl
+++ b/crates/wayle-i18n/locales/en-US/config/_modules.ftl
@@ -35,3 +35,12 @@ enum-temperature-unit-imperial = Imperial
 ## TimeFormat variants
 enum-time-format-twelve-hour = 12 Hour
 enum-time-format-twenty-four-hour = 24 Hour
+
+## WeekStart variants
+enum-week-start-monday = Monday
+enum-week-start-tuesday = Tuesday
+enum-week-start-wednesday = Wednesday
+enum-week-start-thursday = Thursday
+enum-week-start-friday = Friday
+enum-week-start-saturday = Saturday
+enum-week-start-sunday = Sunday

--- a/crates/wayle-i18n/locales/en-US/config/modules/_clock.ftl
+++ b/crates/wayle-i18n/locales/en-US/config/modules/_clock.ftl
@@ -52,3 +52,6 @@ settings-modules-clock-scroll-down = Scroll Down
 
 settings-modules-clock-dropdown-show-seconds = Show Seconds
     .description = Show seconds in the calendar dropdown clock display
+
+settings-modules-clock-dropdown-week-start = Week Start
+    .description = First day of the week in the calendar dropdown

--- a/crates/wayle-i18n/locales/fr/config/_modules.ftl
+++ b/crates/wayle-i18n/locales/fr/config/_modules.ftl
@@ -35,3 +35,12 @@ enum-temperature-unit-imperial = Impérial
 ## Variantes de TimeFormat
 enum-time-format-twelve-hour = 12 heures
 enum-time-format-twenty-four-hour = 24 heures
+
+## Variantes de WeekStart
+enum-week-start-monday = Lundi
+enum-week-start-tuesday = Mardi
+enum-week-start-wednesday = Mercredi
+enum-week-start-thursday = Jeudi
+enum-week-start-friday = Vendredi
+enum-week-start-saturday = Samedi
+enum-week-start-sunday = Dimanche

--- a/crates/wayle-i18n/locales/fr/config/modules/_clock.ftl
+++ b/crates/wayle-i18n/locales/fr/config/modules/_clock.ftl
@@ -52,3 +52,6 @@ settings-modules-clock-scroll-down = Défilement vers le bas
 
 settings-modules-clock-dropdown-show-seconds = Afficher les secondes
     .description = Afficher les secondes dans l'horloge du calendrier déroulant
+
+settings-modules-clock-dropdown-week-start = Début de semaine
+    .description = Premier jour de la semaine dans le calendrier déroulant

--- a/crates/wayle-settings/src/pages/modules/clock.rs
+++ b/crates/wayle-settings/src/pages/modules/clock.rs
@@ -3,7 +3,7 @@
 use wayle_config::Config;
 
 use crate::{
-    editors::{text::text, toggle::toggle},
+    editors::{enum_select::enum_select, text::text, toggle::toggle},
     pages::{
         nav::LeafEntry,
         sections::bar_button::{
@@ -46,7 +46,10 @@ pub(crate) fn entry(config: &Config) -> LeafEntry {
                 },
                 SectionSpec {
                     title_key: "settings-section-dropdown",
-                    items: vec![toggle(&module.dropdown_show_seconds)],
+                    items: vec![
+                        toggle(&module.dropdown_show_seconds),
+                        enum_select(&module.dropdown_week_start),
+                    ],
                 },
                 bar_display_section(&fields),
                 colors_section(&fields),

--- a/crates/wayle-shell/src/shell/bar/dropdowns/calendar/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/calendar/helpers.rs
@@ -1,6 +1,19 @@
-use chrono::{DateTime, Datelike, Local};
+use chrono::{DateTime, Datelike, Local, Weekday};
+use wayle_config::schemas::modules::WeekStart;
 
 use crate::i18n::t;
+
+pub(super) fn week_start_to_weekday(week_start: WeekStart) -> Weekday {
+    match week_start {
+        WeekStart::Monday => Weekday::Mon,
+        WeekStart::Tuesday => Weekday::Tue,
+        WeekStart::Wednesday => Weekday::Wed,
+        WeekStart::Thursday => Weekday::Thu,
+        WeekStart::Friday => Weekday::Fri,
+        WeekStart::Saturday => Weekday::Sat,
+        WeekStart::Sunday => Weekday::Sun,
+    }
+}
 
 pub(super) fn is_12h_format(format_str: &str) -> bool {
     format_str.contains("%I") || format_str.contains("%p")

--- a/crates/wayle-shell/src/shell/bar/dropdowns/calendar/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/calendar/mod.rs
@@ -13,7 +13,9 @@ use wayle_widgets::{
 
 pub(super) use self::factory::Factory;
 use self::{
-    helpers::{day_names_array, format_date_rest, months_array, weekdays_array},
+    helpers::{
+        day_names_array, format_date_rest, months_array, week_start_to_weekday, weekdays_array,
+    },
     messages::{CalendarDropdownCmd, CalendarDropdownInit},
 };
 use crate::{i18n::t, shell::bar::dropdowns::scaled_dimension};
@@ -162,12 +164,14 @@ impl Component for CalendarDropdown {
         let format_str = clock_config.format.get();
         let use_12h = helpers::is_12h_format(&format_str);
         let show_seconds = clock_config.dropdown_show_seconds.get();
+        let first_weekday = week_start_to_weekday(clock_config.dropdown_week_start.get());
 
         let months = months_array();
 
         let calendar = Calendar::builder()
             .launch(CalendarInit {
                 today,
+                first_weekday,
                 labels: CalendarLabels {
                     today: t!("cal-today"),
                     weekdays: weekdays_array(),

--- a/crates/wayle-widgets/src/components/calendar/helpers.rs
+++ b/crates/wayle-widgets/src/components/calendar/helpers.rs
@@ -22,11 +22,15 @@ pub fn build_month_grid(
     month: NaiveDate,
     today: NaiveDate,
     selected: Option<NaiveDate>,
+    first_weekday: Weekday,
 ) -> Vec<DayCell> {
     let first_of_month = month.with_day(1).unwrap_or(month);
     let target_month = first_of_month.month();
 
-    let leading_days = first_of_month.weekday().num_days_from_sunday();
+    // Days between the configured first weekday and the weekday the month
+    // starts on, i.e. how many leading cells from the previous month to show.
+    let first_offset = first_weekday.num_days_from_sunday();
+    let leading_days = (first_of_month.weekday().num_days_from_sunday() + 7 - first_offset) % 7;
     let grid_start = first_of_month - Duration::days(i64::from(leading_days));
 
     (0..GRID_CELLS)
@@ -62,28 +66,34 @@ mod tests {
         NaiveDate::from_ymd_opt(year, month, day).unwrap()
     }
 
+    /// Builds a grid with the default Sunday week start, for tests that
+    /// predate the configurable first weekday.
+    fn grid_from(month: NaiveDate, today: NaiveDate, selected: Option<NaiveDate>) -> Vec<DayCell> {
+        build_month_grid(month, today, selected, Weekday::Sun)
+    }
+
     #[test]
     fn always_produces_42_cells() {
-        let march = build_month_grid(date(2026, 3, 1), date(2026, 3, 5), None);
+        let march = grid_from(date(2026, 3, 1), date(2026, 3, 5), None);
         assert_eq!(march.len(), 42);
 
-        let august = build_month_grid(date(2026, 8, 1), date(2026, 3, 5), None);
+        let august = grid_from(date(2026, 8, 1), date(2026, 3, 5), None);
         assert_eq!(august.len(), 42);
 
-        let february = build_month_grid(date(2026, 2, 1), date(2026, 3, 5), None);
+        let february = grid_from(date(2026, 2, 1), date(2026, 3, 5), None);
         assert_eq!(february.len(), 42);
     }
 
     #[test]
     fn march_2026_starts_on_sunday() {
-        let grid = build_month_grid(date(2026, 3, 1), date(2026, 3, 5), None);
+        let grid = grid_from(date(2026, 3, 1), date(2026, 3, 5), None);
         assert_eq!(grid[0].date, date(2026, 3, 1));
         assert_eq!(grid[0].date.weekday(), Weekday::Sun);
     }
 
     #[test]
     fn march_2026_trailing_days_are_other_month() {
-        let grid = build_month_grid(date(2026, 3, 1), date(2026, 3, 5), None);
+        let grid = grid_from(date(2026, 3, 1), date(2026, 3, 5), None);
         assert!(grid[30].is_current_month);
         assert_eq!(grid[30].date, date(2026, 3, 31));
         assert!(!grid[31].is_current_month);
@@ -92,7 +102,7 @@ mod tests {
 
     #[test]
     fn august_2026_starts_with_leading_days() {
-        let grid = build_month_grid(date(2026, 8, 1), date(2026, 3, 5), None);
+        let grid = grid_from(date(2026, 8, 1), date(2026, 3, 5), None);
         assert_eq!(grid[0].date, date(2026, 7, 26));
         assert!(!grid[0].is_current_month);
     }
@@ -100,7 +110,7 @@ mod tests {
     #[test]
     fn today_is_highlighted() {
         let today = date(2026, 3, 5);
-        let grid = build_month_grid(date(2026, 3, 1), today, None);
+        let grid = grid_from(date(2026, 3, 1), today, None);
         let march_5 = grid.iter().find(|c| c.date == today).unwrap();
         assert!(march_5.is_today);
         assert!(march_5.is_current_month);
@@ -109,14 +119,14 @@ mod tests {
     #[test]
     fn selected_day_is_marked() {
         let selected = date(2026, 3, 20);
-        let grid = build_month_grid(date(2026, 3, 1), date(2026, 3, 5), Some(selected));
+        let grid = grid_from(date(2026, 3, 1), date(2026, 3, 5), Some(selected));
         let march_20 = grid.iter().find(|c| c.date == selected).unwrap();
         assert!(march_20.is_selected);
     }
 
     #[test]
     fn weekends_are_marked() {
-        let grid = build_month_grid(date(2026, 3, 1), date(2026, 3, 5), None);
+        let grid = grid_from(date(2026, 3, 1), date(2026, 3, 5), None);
         assert!(grid[0].is_weekend);
         assert!(!grid[1].is_weekend);
         assert!(grid[6].is_weekend);
@@ -124,7 +134,7 @@ mod tests {
 
     #[test]
     fn february_2026_has_28_current_month_days() {
-        let grid = build_month_grid(date(2026, 2, 1), date(2026, 3, 5), None);
+        let grid = grid_from(date(2026, 2, 1), date(2026, 3, 5), None);
         assert_eq!(grid[0].date, date(2026, 2, 1));
         let feb_cells: Vec<_> = grid.iter().filter(|cell| cell.is_current_month).collect();
         assert_eq!(feb_cells.len(), 28);
@@ -132,27 +142,27 @@ mod tests {
 
     #[test]
     fn today_in_different_month_not_highlighted() {
-        let grid = build_month_grid(date(2026, 4, 1), date(2026, 3, 5), None);
+        let grid = grid_from(date(2026, 4, 1), date(2026, 3, 5), None);
         assert!(grid.iter().all(|c| !c.is_today));
     }
 
     #[test]
     fn any_day_in_month_selects_correct_month() {
-        let from_mid = build_month_grid(date(2026, 3, 15), date(2026, 3, 5), None);
-        let from_first = build_month_grid(date(2026, 3, 1), date(2026, 3, 5), None);
+        let from_mid = grid_from(date(2026, 3, 15), date(2026, 3, 5), None);
+        let from_first = grid_from(date(2026, 3, 1), date(2026, 3, 5), None);
         assert_eq!(from_mid, from_first);
     }
 
     #[test]
     fn leap_year_february_has_29_days() {
-        let grid = build_month_grid(date(2028, 2, 1), date(2028, 2, 15), None);
+        let grid = grid_from(date(2028, 2, 1), date(2028, 2, 15), None);
         let feb_cells: Vec<_> = grid.iter().filter(|cell| cell.is_current_month).collect();
         assert_eq!(feb_cells.len(), 29);
     }
 
     #[test]
     fn december_year_boundary() {
-        let grid = build_month_grid(date(2026, 12, 1), date(2026, 12, 25), None);
+        let grid = grid_from(date(2026, 12, 1), date(2026, 12, 25), None);
         let dec_cells: Vec<_> = grid.iter().filter(|cell| cell.is_current_month).collect();
         assert_eq!(dec_cells.len(), 31);
 
@@ -168,7 +178,7 @@ mod tests {
 
     #[test]
     fn january_year_boundary() {
-        let grid = build_month_grid(date(2027, 1, 1), date(2027, 1, 10), None);
+        let grid = grid_from(date(2027, 1, 1), date(2027, 1, 10), None);
         let jan_cells: Vec<_> = grid.iter().filter(|cell| cell.is_current_month).collect();
         assert_eq!(jan_cells.len(), 31);
     }
@@ -176,7 +186,7 @@ mod tests {
     #[test]
     fn first_column_is_always_sunday() {
         for month in 1..=12 {
-            let grid = build_month_grid(date(2026, month, 1), date(2026, 1, 1), None);
+            let grid = grid_from(date(2026, month, 1), date(2026, 1, 1), None);
             assert_eq!(
                 grid[0].date.weekday(),
                 Weekday::Sun,
@@ -187,6 +197,45 @@ mod tests {
                 Weekday::Sat,
                 "month {month} col 6 not Saturday"
             );
+        }
+    }
+
+    #[test]
+    fn monday_start_reorders_first_column() {
+        // March 2026 starts on a Sunday; with a Monday week start the grid's
+        // first column is the preceding Monday and Sunday moves to column 6.
+        let grid = build_month_grid(date(2026, 3, 1), date(2026, 3, 5), None, Weekday::Mon);
+        assert_eq!(grid.len(), 42);
+        assert_eq!(grid[0].date.weekday(), Weekday::Mon);
+        assert_eq!(grid[0].date, date(2026, 2, 23));
+        assert_eq!(grid[6].date.weekday(), Weekday::Sun);
+        assert_eq!(grid[6].date, date(2026, 3, 1));
+    }
+
+    #[test]
+    fn saturday_start_reorders_first_column() {
+        let grid = build_month_grid(date(2026, 3, 1), date(2026, 3, 5), None, Weekday::Sat);
+        assert_eq!(grid.len(), 42);
+        assert_eq!(grid[0].date.weekday(), Weekday::Sat);
+        assert_eq!(grid[0].date, date(2026, 2, 28));
+        assert_eq!(grid[6].date.weekday(), Weekday::Fri);
+    }
+
+    #[test]
+    fn monday_start_keeps_current_month_day_count() {
+        // Reordering must not change which days belong to the month.
+        let grid = build_month_grid(date(2026, 2, 1), date(2026, 3, 5), None, Weekday::Mon);
+        let feb_cells = grid.iter().filter(|c| c.is_current_month).count();
+        assert_eq!(feb_cells, 28);
+    }
+
+    #[test]
+    fn weekend_marking_is_independent_of_week_start() {
+        // Weekend stays Saturday/Sunday regardless of the chosen first day.
+        let grid = build_month_grid(date(2026, 3, 1), date(2026, 3, 5), None, Weekday::Mon);
+        for cell in &grid {
+            let expected = matches!(cell.date.weekday(), Weekday::Sat | Weekday::Sun);
+            assert_eq!(cell.is_weekend, expected);
         }
     }
 

--- a/crates/wayle-widgets/src/components/calendar/messages.rs
+++ b/crates/wayle-widgets/src/components/calendar/messages.rs
@@ -1,4 +1,4 @@
-use chrono::NaiveDate;
+use chrono::{NaiveDate, Weekday};
 
 /// Localized strings for the calendar widget.
 pub struct CalendarLabels {
@@ -19,6 +19,8 @@ pub struct CalendarLabels {
 pub struct CalendarInit {
     /// Date to highlight as "today".
     pub today: NaiveDate,
+    /// First day of the week (leftmost column).
+    pub first_weekday: Weekday,
     /// Localized strings for weekdays, months, and navigation.
     pub labels: CalendarLabels,
 }

--- a/crates/wayle-widgets/src/components/calendar/methods.rs
+++ b/crates/wayle-widgets/src/components/calendar/methods.rs
@@ -1,4 +1,4 @@
-use chrono::Datelike;
+use chrono::{Datelike, Weekday};
 use gtk::prelude::*;
 use relm4::{ComponentSender, gtk};
 
@@ -10,12 +10,13 @@ use crate::components::calendar::{
 impl Calendar {
     pub(super) fn rebuild_grid(&self, sender: &ComponentSender<Self>) {
         clear_grid(&self.grid);
-        attach_weekday_headers(&self.grid, &self.weekdays);
+        attach_weekday_headers(&self.grid, &self.weekdays, self.first_weekday);
         attach_day_cells(
             &self.grid,
             self.displayed_month,
             self.today,
             self.selected_day,
+            self.first_weekday,
             sender,
         );
     }
@@ -27,13 +28,19 @@ fn clear_grid(grid: &gtk::Grid) {
     }
 }
 
-fn attach_weekday_headers(grid: &gtk::Grid, weekdays: &[String; 7]) {
-    for (col, weekday_name) in weekdays.iter().enumerate() {
-        let label = gtk::Label::new(Some(weekday_name));
+fn attach_weekday_headers(grid: &gtk::Grid, weekdays: &[String; 7], first_weekday: Weekday) {
+    // `weekdays` is canonically ordered from Sunday (index 0). Rotate by the
+    // first weekday's offset so the leftmost column matches the configured day.
+    let first_offset = first_weekday.num_days_from_sunday() as usize;
+
+    for col in 0..7 {
+        let day_index = (first_offset + col) % 7;
+        let label = gtk::Label::new(Some(&weekdays[day_index]));
         label.add_css_class("cal-weekday");
         label.set_hexpand(true);
 
-        let is_weekend = col == 0 || col == 6;
+        // Weekend is Sunday (0) or Saturday (6), independent of column position.
+        let is_weekend = day_index == 0 || day_index == 6;
         if is_weekend {
             label.add_css_class("weekend");
         }
@@ -47,9 +54,10 @@ fn attach_day_cells(
     displayed_month: chrono::NaiveDate,
     today: chrono::NaiveDate,
     selected_day: Option<chrono::NaiveDate>,
+    first_weekday: Weekday,
     sender: &ComponentSender<Calendar>,
 ) {
-    let cells = build_month_grid(displayed_month, today, selected_day);
+    let cells = build_month_grid(displayed_month, today, selected_day, first_weekday);
 
     for (idx, cell) in cells.iter().enumerate() {
         let col = (idx % 7) as i32;

--- a/crates/wayle-widgets/src/components/calendar/mod.rs
+++ b/crates/wayle-widgets/src/components/calendar/mod.rs
@@ -4,7 +4,7 @@ pub mod helpers;
 pub mod messages;
 mod methods;
 
-use chrono::{Datelike, Months, NaiveDate};
+use chrono::{Datelike, Months, NaiveDate, Weekday};
 use gtk::prelude::*;
 use relm4::{gtk, prelude::*};
 
@@ -21,6 +21,7 @@ pub struct Calendar {
     months: [String; 12],
     month_year_pattern: String,
     weekdays: [String; 7],
+    first_weekday: Weekday,
     grid: gtk::Grid,
 }
 
@@ -112,6 +113,7 @@ impl Component for Calendar {
             months: init.labels.months,
             month_year_pattern,
             weekdays: init.labels.weekdays,
+            first_weekday: init.first_weekday,
             grid: grid.clone(),
         };
 


### PR DESCRIPTION
Fixes #25

## Objective
The calendar dropdown's week start is hardcoded to Sunday. This makes it configurable.

## Solution
Add a `dropdown-week-start` option to the clock module (`monday`…`sunday`, default `sunday`, so existing behavior is unchanged). The calendar widget takes a `first_weekday` and rotates both the weekday header row and the day-grid offset; weekend shading stays Saturday/Sunday and is derived per weekday rather than by column position. Wired into the settings GUI (Clock → Dropdown) with en-US and fr strings.

```toml
[modules.clock]
dropdown-week-start = "monday"
```

## Screenshots
Calendar: Sunday (before) → Monday (after). Settings → Clock → Dropdown gains a **Week Start** control.

<!-- drag the before/after images here -->

## Test Plan
- `cargo test --workspace` — including 4 new grid tests (Monday/Saturday reorder, day-count invariant, weekend independence)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo +nightly fmt --all --check` — clean
- Verified live on Hyprland
