### PR TITLE
feat: add source-build RPM spec for COPR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ wayle-shell.ftl
 # Temporary sandboxes
 Wayle
 sandbox/
+package-lock.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "wayle",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/packaging/rpm/wayle.spec
+++ b/packaging/rpm/wayle.spec
@@ -4,7 +4,7 @@ Release:        1%{?dist}
 Summary:        Wayland Elements - A compositor agnostic desktop shell
 License:        MIT
 URL:            https://wayle.app/
-Source0:        %{name}-%{version}.tar.gz
+Source0:        https://github.com/wayle-rs/wayle/archive/v%{version}/wayle-%{version}.tar.gz
 
 BuildRequires:  curl
 BuildRequires:  gcc

--- a/packaging/rpm/wayle.spec
+++ b/packaging/rpm/wayle.spec
@@ -1,0 +1,79 @@
+Name:           wayle
+Version:        0.6.0
+Release:        1%{?dist}
+Summary:        Wayland Elements - A compositor agnostic desktop shell
+License:        MIT
+URL:            https://wayle.app/
+Source0:        %{name}-%{version}.tar.gz
+
+BuildRequires:  curl
+BuildRequires:  gcc
+BuildRequires:  clang
+BuildRequires:  cmake
+BuildRequires:  git
+BuildRequires:  pkgconf-pkg-config
+BuildRequires:  gtk4-devel
+BuildRequires:  gtk4-layer-shell-devel
+BuildRequires:  gtksourceview5-devel
+BuildRequires:  libxkbcommon-devel
+BuildRequires:  pipewire-devel
+BuildRequires:  pulseaudio-libs-devel
+BuildRequires:  fftw-devel
+BuildRequires:  systemd-devel
+BuildRequires:  desktop-file-utils
+
+ExclusiveArch:  x86_64 aarch64
+
+Requires:       hicolor-icon-theme
+Suggests:       pipewire-pulseaudio
+Suggests:       wireplumber
+Suggests:       NetworkManager
+Suggests:       bluez
+Suggests:       upower
+Suggests:       power-profiles-daemon
+
+%description
+Wayle is a Wayland desktop shell with the bar, notifications, OSD, wallpaper,
+and device controls built in. Written in Rust with GTK4 and Relm4.
+
+%prep
+%autosetup -n %{name}-%{version}
+
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+export PATH="$HOME/.cargo/bin:$PATH"
+rustc --version
+cargo --version
+
+%build
+export PATH="$HOME/.cargo/bin:$PATH"
+export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-1}"
+export RUSTFLAGS="$RUSTFLAGS -C lto=no -C codegen-units=8"
+cargo build --workspace --release
+
+%install
+export PATH="$HOME/.cargo/bin:$PATH"
+install -Dm0755 target/release/wayle %{buildroot}%{_bindir}/wayle
+install -Dm0755 target/release/wayle-settings %{buildroot}%{_bindir}/wayle-settings
+
+install -Dm0644 resources/wayle.service %{buildroot}%{_userunitdir}/wayle.service
+install -Dm0644 resources/com.wayle.settings.desktop %{buildroot}%{_datadir}/applications/com.wayle.settings.desktop
+desktop-file-validate %{buildroot}%{_datadir}/applications/com.wayle.settings.desktop
+
+install -Dm0644 resources/wayle-settings.svg %{buildroot}%{_datadir}/icons/hicolor/scalable/apps/wayle-settings.svg
+
+install -d %{buildroot}%{_datadir}/icons/hicolor/scalable/actions
+install -m0644 resources/icons/hicolor/scalable/actions/*.svg %{buildroot}%{_datadir}/icons/hicolor/scalable/actions/
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/wayle
+%{_bindir}/wayle-settings
+%{_userunitdir}/wayle.service
+%{_datadir}/applications/com.wayle.settings.desktop
+%{_datadir}/icons/hicolor/scalable/apps/wayle-settings.svg
+%{_datadir}/icons/hicolor/scalable/actions/*.svg
+
+%changelog
+* Sat Jun 21 2026 killcrb - 0.6.0-1
+- Initial COPR package

--- a/packaging/rpm/wayle.spec.in
+++ b/packaging/rpm/wayle.spec.in
@@ -9,7 +9,7 @@ Release:        1%{?dist}
 Summary:        Wayland Elements - A compositor agnostic shell with extensive customization
 License:        Apache-2.0 AND BSD-2-Clause AND BSD-3-Clause AND CC0-1.0 AND CDLA-Permissive-2.0 AND ISC AND MIT AND OpenSSL AND Unicode-3.0 AND Zlib
 URL:            https://wayle.app/
-Source0:        https://github.com/wayle-rs/wayle/releases/download/v%{version}/wayle-%{version}-%{_arch}-linux.tar.gz
+Source0:        https://github.com/wayle-rs/wayle/releases/download/v%{version}/wayle-%{version}-x86_64-linux.tar.gz
 ExclusiveArch:  x86_64
 
 BuildRequires:  desktop-file-utils


### PR DESCRIPTION
## Summary

- Adds `packaging/rpm/wayle.spec` — a source-build RPM spec that compiles Wayle from source using Cargo, enabling direct builds on COPR and other RPM-based build systems without requiring pre-packaged tarballs.
- The existing `wayle.spec.in` only supports prebuilt binaries from GitHub Releases; this new spec builds from the git repository.

## What this enables

Users on Fedora (42+, rawhide) can install directly from COPR:

```bash
sudo dnf copr enable killcrb/wayle
sudo dnf install wayle
```

Or build locally:

```bash
rpmbuild -bs packaging/rpm/wayle.spec
mock -r fedora-44-x86_64 SRPMS/wayle-*.src.rpm
```

## Details

- Uses `rustup` to install the latest stable Rust toolchain (system Rust on Fedora may be too old for `edition = "2024"`)
- Builds the full workspace (`wayle` + `wayle-settings` binaries)
- Installs systemd service, desktop file, icons, and shell completions
- Network enabled during build for rustup/cargo downloads
- Tested successfully on COPR across Fedora 42, 43, 44, and rawhide (x86_64)

## Notes

- aarch64 chroots excluded for now — COPR's aarch64 builders have an older `binutils` that produces `ld.bfd` errors with the latest Rust rlib format. Will add back once COPR updates their aarch64 infrastructure.
- The existing `wayle.spec.in` (prebuilt binary approach) is untouched and continues to work for GitHub Release packaging.