### PR TITLE
fix: remove unnecessary netstat NetworkManager dependency

### DIFF
--- a/crates/wayle-shell/src/shell/bar/dropdowns/dashboard/network_section/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/dashboard/network_section/helpers.rs
@@ -1,8 +1,23 @@
+use wayle_sysinfo::types::NetworkData;
+
 const BYTES_PER_KB: f64 = 1024.0;
 
 pub(super) struct FormattedSpeed {
     pub value: String,
     pub is_megabytes: bool,
+}
+
+/// Infers whether the machine has an active network connection from sysinfo
+/// interface data.
+///
+/// Used as a fallback when NetworkManager is unavailable (for example on
+/// systemd-networkd systems), where connection state cannot be queried over
+/// D-Bus. Any non-loopback interface that has carried traffic is treated as a
+/// live connection.
+pub(super) fn infer_connected(interfaces: &[NetworkData]) -> bool {
+    interfaces.iter().any(|iface| {
+        !iface.interface.starts_with("lo") && (iface.rx_bytes > 0 || iface.tx_bytes > 0)
+    })
 }
 
 /// Formats bytes per second into a human-readable speed value and unit flag.
@@ -19,5 +34,49 @@ pub(super) fn format_speed(bytes_per_sec: u64) -> FormattedSpeed {
             value: format!("{mbps:.1}"),
             is_megabytes: true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn net_data(interface: &str, rx_bytes: u64, tx_bytes: u64) -> NetworkData {
+        NetworkData {
+            interface: interface.to_string(),
+            rx_bytes,
+            tx_bytes,
+            rx_bytes_per_sec: 0,
+            tx_bytes_per_sec: 0,
+        }
+    }
+
+    #[test]
+    fn infer_connected_true_for_interface_with_traffic() {
+        let interfaces = vec![net_data("lo", 5000, 5000), net_data("eth0", 1000, 0)];
+        assert!(infer_connected(&interfaces));
+    }
+
+    #[test]
+    fn infer_connected_counts_transmit_only_interface() {
+        let interfaces = vec![net_data("wlan0", 0, 42)];
+        assert!(infer_connected(&interfaces));
+    }
+
+    #[test]
+    fn infer_connected_ignores_loopback() {
+        let interfaces = vec![net_data("lo", 999_999, 999_999)];
+        assert!(!infer_connected(&interfaces));
+    }
+
+    #[test]
+    fn infer_connected_false_for_idle_interfaces() {
+        let interfaces = vec![net_data("eth0", 0, 0), net_data("wg0", 0, 0)];
+        assert!(!infer_connected(&interfaces));
+    }
+
+    #[test]
+    fn infer_connected_false_for_empty_list() {
+        assert!(!infer_connected(&[]));
     }
 }

--- a/crates/wayle-shell/src/shell/bar/dropdowns/dashboard/network_section/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/dashboard/network_section/watchers.rs
@@ -19,6 +19,11 @@ pub(super) fn spawn(
     sysinfo: &Arc<SysinfoService>,
     token: CancellationToken,
 ) {
+    // When NetworkManager is unavailable (e.g. systemd-networkd systems),
+    // connection state is inferred from sysinfo interface activity instead so
+    // the speed readout is not permanently gated off.
+    let has_network_manager = network.is_some();
+
     if let Some(network) = network {
         let primary = network.primary.clone();
         let wifi = network.wifi.clone();
@@ -55,6 +60,12 @@ pub(super) fn spawn(
             download: download.value,
             download_is_megabytes: download.is_megabytes,
         });
+
+        if !has_network_manager {
+            let _ = out.send(NetworkSectionCmd::ConnectionChanged {
+                connected: helpers::infer_connected(&data),
+            });
+        }
     });
 }
 


### PR DESCRIPTION
Previously the `netstat` module did not display any information unless NetworkManager was in use. This PR adds a fallback option for `systemd-networkd` systems.