### PR TITLE
fix: use absolute path for /bin/sh

### DIFF
--- a/crates/wayle-shell/src/process.rs
+++ b/crates/wayle-shell/src/process.rs
@@ -9,7 +9,7 @@ use tracing::warn;
 fn spawn_quiet(cmd: &str) -> io::Result<()> {
     use std::process::Stdio;
 
-    let child = Command::new("sh")
+    let child = Command::new("/bin/sh")
         .arg("-c")
         .arg(cmd)
         .stdout(Stdio::null())

--- a/crates/wayle-shell/src/shell/bar/modules/custom/watchers/command.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/custom/watchers/command.rs
@@ -75,7 +75,7 @@ fn map_exec_outcome(module_id: &str, outcome: ExecOutcome) -> CustomCmd {
 }
 
 async fn run_command(command: &str) -> Result<String, std::io::Error> {
-    let output = Command::new("sh")
+    let output = Command::new("/bin/sh")
         .arg("-c")
         .arg(command)
         .stdout(Stdio::piped())

--- a/crates/wayle-shell/src/shell/bar/modules/custom/watchers/supervisor.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/custom/watchers/supervisor.rs
@@ -135,7 +135,7 @@ async fn run_child(
 }
 
 fn spawn_child(command: &str) -> Result<tokio::process::Child, std::io::Error> {
-    Command::new("sh")
+    Command::new("/bin/sh")
         .arg("-c")
         .arg(command)
         .stdout(Stdio::piped())
@@ -212,7 +212,7 @@ mod tests {
     }
 
     fn exit_status(code: i32) -> ExitStatus {
-        std::process::Command::new("sh")
+        std::process::Command::new("/bin/sh")
             .arg("-c")
             .arg(format!("exit {code}"))
             .status()


### PR DESCRIPTION
Previously Wayle would resolve `sh` from the `$PATH`, which was problematic when in minimal environments (i.e. run from a systemd service). For this reason, the most common---and generally best---practice is to call the standardized FHS absolute path (`/bin/sh`) directly.