### PR TITLE
feat: --config flag to pass config.toml path to wayle shell

### DIFF
--- a/crates/wayle-config/src/infrastructure/service.rs
+++ b/crates/wayle-config/src/infrastructure/service.rs
@@ -1,5 +1,6 @@
 use std::{
     io,
+    path::{Path, PathBuf},
     sync::{Arc, RwLock},
 };
 
@@ -28,19 +29,21 @@ use crate::{
 pub struct ConfigService {
     config: Arc<Config>,
     watcher: Arc<RwLock<Option<FileWatcher>>>,
+    main_config_path: Arc<PathBuf>,
 }
 
 impl ConfigService {
     /// Loads configuration from TOML files and starts file watcher.
     ///
-    /// Applies `config.toml` to the config layer and `runtime.toml` to
-    /// the runtime layer, then starts hot-reload file watching.
+    /// Applies `config.toml` (or `config_override`, if given) to the config
+    /// layer and `runtime.toml` to the runtime layer, then starts hot-reload
+    /// file watching. `config_override` changes only the main config file path.
     ///
     /// # Errors
     ///
     /// Returns error if config files cannot be loaded or parsed.
     #[instrument]
-    pub async fn load() -> Result<Arc<Self>, Error> {
+    pub async fn load(config_override: Option<PathBuf>) -> Result<Arc<Self>, Error> {
         info!("Loading configuration");
 
         if let Ok(config_dir) = ConfigPaths::config_dir() {
@@ -48,8 +51,9 @@ impl ConfigService {
         }
 
         let config = Config::default();
-        let config_path = ConfigPaths::main_config();
+        let main_config_path = config_override.unwrap_or_else(ConfigPaths::main_config);
 
+        let config_path = main_config_path.clone();
         let config_result =
             tokio::task::spawn_blocking(move || Config::load_toml_with_imports(&config_path))
                 .await
@@ -80,6 +84,7 @@ impl ConfigService {
         let service = Arc::new(Self {
             config: Arc::new(config),
             watcher: Arc::new(RwLock::new(None)),
+            main_config_path: Arc::new(main_config_path),
         });
 
         let themes_dir = ConfigPaths::themes_dir();
@@ -99,6 +104,12 @@ impl ConfigService {
     /// Reference to the config root.
     pub fn config(&self) -> &Config {
         &self.config
+    }
+
+    /// Path to the effective main config file (the `--config` override if one
+    /// was given, otherwise the XDG default).
+    pub fn main_config_path(&self) -> &Path {
+        &self.main_config_path
     }
 
     /// Drops every runtime override and deletes `runtime.toml` from disk.

--- a/crates/wayle-config/src/infrastructure/watcher.rs
+++ b/crates/wayle-config/src/infrastructure/watcher.rs
@@ -1,4 +1,8 @@
-use std::{path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 
 use notify::{
     Event, RecommendedWatcher, RecursiveMode, Watcher as NotifyWatcher, event::EventKind,
@@ -61,6 +65,8 @@ impl FileWatcher {
 
         info!(?config_dir, "Config directory watcher started");
 
+        watch_override_dir(&mut watcher, &config_dir, config_service.main_config_path());
+
         let file_watcher = Self {
             config_service,
             secrets_tx,
@@ -117,7 +123,7 @@ impl FileWatcher {
     async fn reload_main_config(&self) -> Result<(), Error> {
         let config = self.config_service.config();
 
-        let config_path = ConfigPaths::main_config();
+        let config_path = self.config_service.main_config_path().to_path_buf();
         let toml_value =
             tokio::task::spawn_blocking(move || Config::load_toml_with_imports(&config_path))
                 .await
@@ -160,6 +166,18 @@ impl FileWatcher {
         config.commit_config_reload();
 
         Ok(())
+    }
+}
+
+/// Watches a `--config` override file that lives outside the (already
+/// recursively-watched) config dir, so it hot-reloads like the default.
+/// Watching its parent dir survives editor atomic-save/rename; failure is
+/// non-fatal (the initial load already succeeded).
+fn watch_override_dir(watcher: &mut RecommendedWatcher, config_dir: &Path, main_config: &Path) {
+    if let Some(parent) = main_config.parent()
+        && !parent.starts_with(config_dir)
+    {
+        let _ = watcher.watch(parent, RecursiveMode::NonRecursive);
     }
 }
 

--- a/crates/wayle-settings/src/main.rs
+++ b/crates/wayle-settings/src/main.rs
@@ -56,7 +56,7 @@ fn main() {
 
     let _guard = runtime.enter();
 
-    let config_service = match runtime.block_on(ConfigService::load()) {
+    let config_service = match runtime.block_on(ConfigService::load(None)) {
         Ok(service) => service,
         Err(err) => {
             eprintln!("cannot load config: {err}");

--- a/crates/wayle-shell/src/bootstrap/mod.rs
+++ b/crates/wayle-shell/src/bootstrap/mod.rs
@@ -6,6 +6,7 @@ mod weather;
 use std::{
     error::Error,
     fmt::Display,
+    path::PathBuf,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -112,7 +113,9 @@ pub async fn is_already_running() -> bool {
     result
 }
 
-pub async fn init_services() -> Result<(StartupTimer, ShellServices), Box<dyn Error>> {
+pub async fn init_services(
+    config_override: Option<PathBuf>,
+) -> Result<(StartupTimer, ShellServices), Box<dyn Error>> {
     let mut timer = StartupTimer::new();
 
     if let Err(e) = timer
@@ -122,7 +125,9 @@ pub async fn init_services() -> Result<(StartupTimer, ShellServices), Box<dyn Er
         warn!(error = %e, "Could not write schema file");
     }
 
-    let config_service = timer.time("Config", ConfigService::load()).await?;
+    let config_service = timer
+        .time("Config", ConfigService::load(config_override))
+        .await?;
 
     let bluetooth: DeferredService<BluetoothService> = DeferredService::new(None);
     let power_profiles: DeferredService<PowerProfilesService> = DeferredService::new(None);

--- a/crates/wayle-shell/src/lib.rs
+++ b/crates/wayle-shell/src/lib.rs
@@ -1,6 +1,6 @@
 //! Wayle desktop shell - a GTK4/Relm4 status bar for Wayland compositors.
 
-use std::{env, error::Error};
+use std::{env, error::Error, path::PathBuf};
 
 use relm4::RelmApp;
 use tokio::runtime::Runtime;
@@ -25,11 +25,14 @@ use shell::{Shell, ShellInit};
 /// Creates its own tokio runtime internally, so this must not be called
 /// from within an existing tokio context (it will panic).
 ///
+/// `config_override` points the main config file at a path other than the
+/// default `~/.config/wayle/config.toml`; other config files are unaffected.
+///
 /// # Errors
 ///
 /// Returns error on tracing init failure, runtime creation failure,
 /// or service bootstrap failure.
-pub fn run() -> Result<(), Box<dyn Error>> {
+pub fn run(config_override: Option<PathBuf>) -> Result<(), Box<dyn Error>> {
     if env::var_os("GSK_RENDERER").is_none() {
         #[allow(unsafe_code)]
         // SAFETY: single-threaded, called before any runtime or GTK init
@@ -49,7 +52,7 @@ pub fn run() -> Result<(), Box<dyn Error>> {
         return Ok(());
     }
 
-    let (timer, services) = runtime.block_on(bootstrap::init_services())?;
+    let (timer, services) = runtime.block_on(bootstrap::init_services(config_override))?;
     info!("Services initialized");
 
     let app = RelmApp::new("com.wayle.shell")

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -10,6 +10,16 @@ wayle panel restart
 wayle panel settings
 ```
 
+Run the shell with a config file outside the default location:
+
+```sh
+wayle shell --config /path/to/config.toml
+```
+
+`--config` (`-c`) is valid only on `wayle shell` — other subcommands reject it. It moves
+only the main config file; other files stay under `~/.config/wayle`. See
+[Editing config](/guide/editing-config#custom-config-location).
+
 Read and edit config values from the command line:
 
 ```sh

--- a/docs/guide/editing-config.md
+++ b/docs/guide/editing-config.md
@@ -24,6 +24,19 @@ format = "%H:%M"
 
 Every supported key is documented in the [config reference](/config/).
 
+## Custom config location
+
+By default the main config file is `~/.config/wayle/config.toml`. Launch the shell with
+`--config` (short `-c`) to read it from elsewhere:
+
+```sh
+wayle shell --config /path/to/config.toml
+```
+
+Only the main config file moves; `runtime.toml`, themes, `.env` files, and `schema.json`
+still resolve under `~/.config/wayle`, and the overridden file is watched and hot-reloaded
+like the default. `--config` is valid only on `wayle shell`; other subcommands reject it.
+
 ## Imports
 
 `config.toml` may declare a top-level `imports` array to load additional TOML files. Files referenced through `imports` may themselves declare `imports`, forming a chain:

--- a/wayle/src/cli/app.rs
+++ b/wayle/src/cli/app.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{io, path::PathBuf};
 
 use clap::{
     CommandFactory, Parser, Subcommand,
@@ -99,7 +99,12 @@ pub enum Commands {
         command: IdleCommands,
     },
     /// Run the desktop shell in the foreground
-    Shell,
+    Shell {
+        /// Read the main config from this file instead of the default
+        /// ~/.config/wayle/config.toml (does not affect runtime.toml or other files).
+        #[arg(short = 'c', long = "config", value_name = "PATH")]
+        config: Option<PathBuf>,
+    },
     /// Generate shell completions
     Completions {
         /// Shell to generate completions for.

--- a/wayle/src/cli/config/get.rs
+++ b/wayle/src/cli/config/get.rs
@@ -8,7 +8,7 @@ use crate::{
 /// # Errors
 /// Returns error if config loading fails or path cannot be resolved.
 pub async fn execute(path: String) -> CliAction {
-    let config_service = ConfigService::load()
+    let config_service = ConfigService::load(None)
         .await
         .map_err(|e| format!("Failed to load config: {e}"))?;
 

--- a/wayle/src/cli/config/reset.rs
+++ b/wayle/src/cli/config/reset.rs
@@ -9,7 +9,7 @@ use crate::{
 ///
 /// Returns error if config loading fails or the path is invalid.
 pub async fn execute(path: String) -> CliAction {
-    let config_service = ConfigService::load()
+    let config_service = ConfigService::load(None)
         .await
         .map_err(|e| format!("cannot load config: {e}"))?;
 

--- a/wayle/src/cli/config/set.rs
+++ b/wayle/src/cli/config/set.rs
@@ -8,7 +8,7 @@ use crate::{
 /// # Errors
 /// Returns error if config loading fails, value parsing fails, or path cannot be set.
 pub async fn execute(path: String, value: String) -> CliAction {
-    let config_service = ConfigService::load()
+    let config_service = ConfigService::load(None)
         .await
         .map_err(|e| format!("Failed to load config: {e}"))?;
 

--- a/wayle/src/cli/icons/sync.rs
+++ b/wayle/src/cli/icons/sync.rs
@@ -14,7 +14,7 @@ use crate::{cli::CliAction, config::ConfigService};
 /// Returns error if the config fails to load, fails to serialize, or the
 /// icon manager cannot be constructed.
 pub async fn execute(dry_run: bool) -> CliAction {
-    let config_service = ConfigService::load()
+    let config_service = ConfigService::load(None)
         .await
         .map_err(|err| format!("Failed to load config: {err}"))?;
 

--- a/wayle/src/main.rs
+++ b/wayle/src/main.rs
@@ -4,7 +4,7 @@
 //! The `shell` subcommand runs the GUI directly and manages its own
 //! tokio runtime. All other commands share a single runtime.
 
-use std::process;
+use std::{path::PathBuf, process};
 
 use clap::Parser;
 use tokio::runtime::Runtime;
@@ -17,7 +17,7 @@ fn main() {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Shell => return run_shell(),
+        Commands::Shell { config } => return run_shell(config),
         Commands::Completions { shell } => {
             cli::app::generate_completions(shell);
             return;
@@ -50,7 +50,7 @@ fn main() {
             Commands::Systray { command } => cli::systray::execute(command).await,
             Commands::Wallpaper { command } => cli::wallpaper::execute(command).await,
             Commands::Idle { command } => cli::idle::execute(command).await,
-            Commands::Shell | Commands::Completions { .. } => unreachable!(),
+            Commands::Shell { .. } | Commands::Completions { .. } => unreachable!(),
         }
     });
 
@@ -60,8 +60,8 @@ fn main() {
     }
 }
 
-fn run_shell() {
-    if let Err(err) = wayle_shell::run() {
+fn run_shell(config_override: Option<PathBuf>) {
+    if let Err(err) = wayle_shell::run(config_override) {
         eprintln!("Error: {err}");
         process::exit(1);
     }


### PR DESCRIPTION
Closes #271. Flag only applies to `wayle shell` (not `wayle panel` etc.).