### PR TITLE
feat: refactor around backend-agnostic notification service API

### DIFF
--- a/crates/wayle-shell/Cargo.toml
+++ b/crates/wayle-shell/Cargo.toml
@@ -54,6 +54,7 @@ wayle-media.workspace = true
 wayle-niri.workspace = true
 wayle-network.workspace = true
 wayle-notification.workspace = true
+wayle-portal.workspace = true
 wayle-power-profiles.workspace = true
 wayle-styling = { workspace = true }
 wayle-sysinfo.workspace = true

--- a/crates/wayle-shell/src/bootstrap/mod.rs
+++ b/crates/wayle-shell/src/bootstrap/mod.rs
@@ -25,6 +25,7 @@ use wayle_media::MediaService;
 use wayle_network::NetworkService;
 use wayle_niri::NiriService;
 use wayle_notification::NotificationService;
+use wayle_portal::PortalHost;
 use wayle_power_profiles::PowerProfilesService;
 use wayle_sysinfo::SysinfoService;
 use wayle_systray::{SystemTrayService, types::TrayMode};
@@ -155,6 +156,11 @@ pub async fn init_services() -> Result<(StartupTimer, ShellServices), Box<dyn Er
 
     timer.mark_services_done();
 
+    // Serve the portal notification backend (best-effort) so sandboxed apps' notifications
+    // reach the notification service via xdg-desktop-portal. Borrow the service before it
+    // moves into `ShellServices` below.
+    let portal_host = init_portal_backend(daemons.notification.as_deref()).await;
+
     let services = ShellServices {
         audio: daemons.audio,
         battery: core.battery,
@@ -169,6 +175,7 @@ pub async fn init_services() -> Result<(StartupTimer, ShellServices), Box<dyn Er
         niri: optional.niri,
         network: core.network,
         notification: daemons.notification,
+        portal_host,
         sysinfo: core.sysinfo,
         systray: daemons.systray,
         wallpaper: core.wallpaper,
@@ -330,4 +337,40 @@ async fn init_daemon_services(
         notification,
         systray,
     }
+}
+
+/// The portal-backend bus name Wayle serves the notification impl interface on.
+const PORTAL_BUS_NAME: &str = "org.freedesktop.impl.portal.desktop.wayle";
+
+/// Serves `org.freedesktop.impl.portal.Notification` so xdg-desktop-portal can forward
+/// sandboxed apps' notifications into the notification service. Best-effort: on any error
+/// the portal backend is simply disabled (unsandboxed apps are unaffected).
+///
+/// For xdg-desktop-portal to actually route to this backend, a `.portal` file plus a
+/// `portals.conf` selecting `wayle` for the Notification interface must be installed
+/// (packaging). Owning the name here is harmless without them.
+async fn init_portal_backend(notification: Option<&NotificationService>) -> Option<PortalHost> {
+    let notification = notification?;
+
+    let mut host = match PortalHost::new(PORTAL_BUS_NAME).await {
+        Ok(host) => host,
+        Err(err) => {
+            warn!(error = %err, "cannot open portal backend connection; portal notifications disabled");
+            return None;
+        }
+    };
+
+    // Register the interface object BEFORE requesting the well-known name.
+    if let Err(err) = notification.attach_portal(host.connection()).await {
+        warn!(error = %err, "cannot register portal notification backend; portal notifications disabled");
+        return None;
+    }
+
+    if let Err(err) = host.serve().await {
+        warn!(error = %err, "cannot acquire {PORTAL_BUS_NAME}; portal notifications disabled");
+        return None;
+    }
+
+    info!("portal notification backend registered at {PORTAL_BUS_NAME}");
+    Some(host)
 }

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/helpers.rs
@@ -15,14 +15,14 @@ pub(super) fn group_by_app(notifications: &[Arc<Notification>]) -> Vec<Notificat
     let mut groups: HashMap<Option<String>, Vec<Arc<Notification>>> = HashMap::new();
 
     for notification in notifications {
-        let key = notification.app_name.get();
+        let key = notification.view.get().origin.name;
         groups.entry(key).or_default().push(notification.clone());
     }
 
     let mut result: Vec<NotificationGroupData> = groups
         .into_iter()
         .map(|(app_name, mut notifs)| {
-            notifs.sort_by_key(|notification| Reverse(notification.timestamp.get()));
+            notifs.sort_by_key(|notification| Reverse(notification.view.get().received));
             NotificationGroupData {
                 app_name,
                 notifications: notifs,
@@ -34,11 +34,11 @@ pub(super) fn group_by_app(notifications: &[Arc<Notification>]) -> Vec<Notificat
         let left_ts = left
             .notifications
             .first()
-            .map(|notification| notification.timestamp.get());
+            .map(|notification| notification.view.get().received);
         let right_ts = right
             .notifications
             .first()
-            .map(|notification| notification.timestamp.get());
+            .map(|notification| notification.view.get().received);
         right_ts.cmp(&left_ts)
     });
 

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/messages.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/messages.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use wayle_config::ConfigService;
-use wayle_notification::NotificationService;
+use wayle_notification::{NotificationService, core::notification::Notification};
 
 pub(crate) struct NotificationDropdownInit {
     pub notification: Arc<NotificationService>,
@@ -12,8 +12,7 @@ pub(crate) struct NotificationDropdownInit {
 pub(crate) enum NotificationDropdownMsg {
     DndToggled(bool),
     ClearAll,
-    ClearGroup(Vec<u32>),
-    NotificationDismissed,
+    ClearGroup(Vec<Arc<Notification>>),
 }
 
 #[derive(Debug)]

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/messages.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/messages.rs
@@ -12,6 +12,7 @@ pub(crate) struct NotificationDropdownInit {
 pub(crate) enum NotificationDropdownMsg {
     DndToggled(bool),
     ClearAll,
+    ClearGroup(Vec<u32>),
     NotificationDismissed,
 }
 

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/mod.rs
@@ -178,11 +178,8 @@ impl Component for NotificationDropdown {
         let groups = FactoryVecDeque::builder()
             .launch(gtk::Box::default())
             .forward(sender.input_sender(), |group_output| match group_output {
-                NotificationGroupOutput::Dismissed => {
-                    NotificationDropdownMsg::NotificationDismissed
-                }
-                NotificationGroupOutput::ClearRequested(ids) => {
-                    NotificationDropdownMsg::ClearGroup(ids)
+                NotificationGroupOutput::ClearRequested(notifications) => {
+                    NotificationDropdownMsg::ClearGroup(notifications)
                 }
             });
 
@@ -213,21 +210,13 @@ impl Component for NotificationDropdown {
             }
 
             NotificationDropdownMsg::ClearAll => {
-                let ids = self
-                    .notification
-                    .notifications
-                    .get()
-                    .iter()
-                    .map(|notification| notification.id)
-                    .collect();
-                self.notification.dismiss_many(ids);
+                self.notification
+                    .dismiss_many(&self.notification.notifications.get());
             }
 
-            NotificationDropdownMsg::ClearGroup(ids) => {
-                self.notification.dismiss_many(ids);
+            NotificationDropdownMsg::ClearGroup(notifications) => {
+                self.notification.dismiss_many(&notifications);
             }
-
-            NotificationDropdownMsg::NotificationDismissed => {}
         }
     }
 

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/mod.rs
@@ -181,6 +181,9 @@ impl Component for NotificationDropdown {
                 NotificationGroupOutput::Dismissed => {
                     NotificationDropdownMsg::NotificationDismissed
                 }
+                NotificationGroupOutput::ClearRequested(ids) => {
+                    NotificationDropdownMsg::ClearGroup(ids)
+                }
             });
 
         let mut model = Self {
@@ -210,10 +213,18 @@ impl Component for NotificationDropdown {
             }
 
             NotificationDropdownMsg::ClearAll => {
-                let notifications = self.notification.notifications.get();
-                for notification in &notifications {
-                    notification.dismiss();
-                }
+                let ids = self
+                    .notification
+                    .notifications
+                    .get()
+                    .iter()
+                    .map(|notification| notification.id)
+                    .collect();
+                self.notification.dismiss_many(ids);
+            }
+
+            NotificationDropdownMsg::ClearGroup(ids) => {
+                self.notification.dismiss_many(ids);
             }
 
             NotificationDropdownMsg::NotificationDismissed => {}

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/messages.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/messages.rs
@@ -16,13 +16,11 @@ pub(crate) enum NotificationGroupInput {
     ClearGroup,
     UpdateNotifications(Vec<Arc<Notification>>),
     RefreshTime,
-    ItemDismissed(u32),
 }
 
 #[derive(Debug)]
 pub(crate) enum NotificationGroupOutput {
-    Dismissed,
     /// Requests the parent (which owns the service) to clear these notifications as a
     /// single batch.
-    ClearRequested(Vec<u32>),
+    ClearRequested(Vec<Arc<Notification>>),
 }

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/messages.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/messages.rs
@@ -22,4 +22,7 @@ pub(crate) enum NotificationGroupInput {
 #[derive(Debug)]
 pub(crate) enum NotificationGroupOutput {
     Dismissed,
+    /// Requests the parent (which owns the service) to clear these notifications as a
+    /// single batch.
+    ClearRequested(Vec<u32>),
 }

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/methods.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/methods.rs
@@ -1,10 +1,10 @@
-use std::{collections::HashSet, sync::Arc};
+use std::sync::Arc;
 
 use wayle_config::schemas::modules::notification::IconSource;
 use wayle_notification::core::notification::Notification;
 
 use super::{super::notification_item::messages::NotificationItemInit, NotificationGroup};
-use crate::shell::notification_popup::helpers::{ResolvedIcon, resolve_icon};
+use crate::shell::notification_popup::helpers::{ResolvedIcon, resolve_notification_icon};
 
 const MAX_VISIBLE_ITEMS: usize = 3;
 
@@ -62,13 +62,7 @@ impl NotificationGroup {
         notifications: &[Arc<Notification>],
     ) -> Option<String> {
         let first = notifications.first()?;
-        let resolved = resolve_icon(
-            IconSource::Mapped,
-            &first.app_name.get(),
-            &first.app_icon.get(),
-            &first.image_path.get(),
-            &first.desktop_entry.get(),
-        );
+        let resolved = resolve_notification_icon(IconSource::Mapped, first);
 
         match resolved {
             ResolvedIcon::Named(name) => Some(name),
@@ -82,7 +76,7 @@ impl NotificationGroup {
 
         self.preview = notifications
             .first()
-            .map(|notification| notification.summary.get())
+            .map(|notification| notification.view.get().content.summary)
             .unwrap_or_default();
     }
 
@@ -96,28 +90,32 @@ impl NotificationGroup {
     }
 
     fn rebuild_items_if_changed(&mut self, visible: &[Arc<Notification>]) {
-        let old_ids: Vec<u32> = (0..self.items.len())
-            .filter_map(|idx| self.items.get(idx).map(|item| item.notification.id))
-            .collect();
-
-        let new_ids: Vec<u32> = visible.iter().map(|notification| notification.id).collect();
-
-        if old_ids == new_ids {
+        // Unchanged if the item list already matches `visible` by identity (`PartialEq` =
+        // same notification id) in the same order.
+        let unchanged = self.items.len() == visible.len()
+            && (0..self.items.len()).all(|idx| {
+                self.items
+                    .get(idx)
+                    .zip(visible.get(idx))
+                    .is_some_and(|(item, notification)| &item.notification == notification)
+            });
+        if unchanged {
             return;
         }
 
         // Reconcile the factory in place within a single guard scope (one render): drop
         // items that are no longer visible, then move/insert so each slot matches
-        // `visible`. Items whose id persists keep their existing widget and reactive
-        // watchers rather than being destroyed and rebuilt.
-        let new_id_set: HashSet<u32> = new_ids.iter().copied().collect();
+        // `visible`. Items whose notification persists keep their existing widget and
+        // reactive watchers rather than being destroyed and rebuilt.
         let icon_source = self.icon_source;
         let mut guard = self.items.guard();
 
         for idx in (0..guard.len()).rev() {
-            let still_visible = guard
-                .get(idx)
-                .is_some_and(|item| new_id_set.contains(&item.notification.id));
+            let still_visible = guard.get(idx).is_some_and(|item| {
+                visible
+                    .iter()
+                    .any(|notification| &item.notification == notification)
+            });
             if !still_visible {
                 guard.remove(idx);
             }
@@ -127,7 +125,7 @@ impl NotificationGroup {
             let existing = (target_idx..guard.len()).find(|&idx| {
                 guard
                     .get(idx)
-                    .is_some_and(|item| item.notification.id == notification.id)
+                    .is_some_and(|item| &item.notification == notification)
             });
 
             match existing {
@@ -147,13 +145,7 @@ fn build_item_init(
     icon_source: IconSource,
     notification: &Arc<Notification>,
 ) -> NotificationItemInit {
-    let resolved_icon = resolve_icon(
-        icon_source,
-        &notification.app_name.get(),
-        &notification.app_icon.get(),
-        &notification.image_path.get(),
-        &notification.desktop_entry.get(),
-    );
+    let resolved_icon = resolve_notification_icon(icon_source, notification);
 
     NotificationItemInit {
         notification: notification.clone(),

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/methods.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/methods.rs
@@ -137,5 +137,6 @@ fn build_item_init(
     NotificationItemInit {
         notification: notification.clone(),
         resolved_icon,
+        icon_source,
     }
 }

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/methods.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/methods.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use wayle_config::schemas::modules::notification::IconSource;
 use wayle_notification::core::notification::Notification;
@@ -106,17 +106,38 @@ impl NotificationGroup {
             return;
         }
 
-        let inits: Vec<_> = visible
-            .iter()
-            .map(|notification| build_item_init(self.icon_source, notification))
-            .collect();
+        // Reconcile the factory in place within a single guard scope (one render): drop
+        // items that are no longer visible, then move/insert so each slot matches
+        // `visible`. Items whose id persists keep their existing widget and reactive
+        // watchers rather than being destroyed and rebuilt.
+        let new_id_set: HashSet<u32> = new_ids.iter().copied().collect();
+        let icon_source = self.icon_source;
+        let mut guard = self.items.guard();
 
-        {
-            let mut guard = self.items.guard();
-            guard.clear();
+        for idx in (0..guard.len()).rev() {
+            let still_visible = guard
+                .get(idx)
+                .is_some_and(|item| new_id_set.contains(&item.notification.id));
+            if !still_visible {
+                guard.remove(idx);
+            }
+        }
 
-            for init in inits {
-                guard.push_back(init);
+        for (target_idx, notification) in visible.iter().enumerate() {
+            let existing = (target_idx..guard.len()).find(|&idx| {
+                guard
+                    .get(idx)
+                    .is_some_and(|item| item.notification.id == notification.id)
+            });
+
+            match existing {
+                Some(idx) if idx == target_idx => {}
+                Some(idx) => {
+                    guard.move_to(idx, target_idx);
+                }
+                None => {
+                    guard.insert(target_idx, build_item_init(icon_source, notification));
+                }
             }
         }
     }

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/mod.rs
@@ -253,10 +253,14 @@ impl FactoryComponent for NotificationGroup {
             }
 
             NotificationGroupInput::ClearGroup => {
-                for notification in &self.notifications {
-                    notification.dismiss();
-                }
-                sender.output(NotificationGroupOutput::Dismissed).ok();
+                let ids = self
+                    .notifications
+                    .iter()
+                    .map(|notification| notification.id)
+                    .collect();
+                sender
+                    .output(NotificationGroupOutput::ClearRequested(ids))
+                    .ok();
             }
 
             NotificationGroupInput::ItemDismissed(id) => {

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/mod.rs
@@ -9,10 +9,7 @@ use wayle_config::schemas::modules::notification::IconSource;
 use wayle_notification::core::notification::Notification;
 
 use self::messages::{NotificationGroupInit, NotificationGroupInput, NotificationGroupOutput};
-use super::notification_item::{
-    NotificationItem,
-    messages::{NotificationItemInput, NotificationItemOutput},
-};
+use super::notification_item::{NotificationItem, messages::NotificationItemInput};
 use crate::i18n::t;
 
 pub(crate) struct NotificationGroup {
@@ -163,12 +160,12 @@ impl FactoryComponent for NotificationGroup {
         }
     }
 
-    fn init_model(init: Self::Init, _index: &Self::Index, sender: FactorySender<Self>) -> Self {
+    fn init_model(init: Self::Init, _index: &Self::Index, _sender: FactorySender<Self>) -> Self {
+        // Items dismiss their own notification directly (the reactive list update then drops
+        // them), so they emit no output and need no forwarding.
         let items = FactoryVecDeque::builder()
             .launch(gtk::Box::default())
-            .forward(sender.input_sender(), |item_output| match item_output {
-                NotificationItemOutput::Dismissed(id) => NotificationGroupInput::ItemDismissed(id),
-            });
+            .detach();
 
         let group_icon = Self::resolve_group_icon(init.icon_source, &init.notifications);
 
@@ -253,25 +250,11 @@ impl FactoryComponent for NotificationGroup {
             }
 
             NotificationGroupInput::ClearGroup => {
-                let ids = self
-                    .notifications
-                    .iter()
-                    .map(|notification| notification.id)
-                    .collect();
                 sender
-                    .output(NotificationGroupOutput::ClearRequested(ids))
+                    .output(NotificationGroupOutput::ClearRequested(
+                        self.notifications.clone(),
+                    ))
                     .ok();
-            }
-
-            NotificationGroupInput::ItemDismissed(id) => {
-                if let Some(notification) = self
-                    .notifications
-                    .iter()
-                    .find(|notification| notification.id == id)
-                {
-                    notification.dismiss();
-                }
-                sender.output(NotificationGroupOutput::Dismissed).ok();
             }
         }
     }

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_item/messages.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_item/messages.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use wayle_config::schemas::modules::notification::IconSource;
 use wayle_notification::core::notification::Notification;
 
 use crate::shell::notification_popup::helpers::ResolvedIcon;
@@ -7,11 +8,14 @@ use crate::shell::notification_popup::helpers::ResolvedIcon;
 pub(crate) struct NotificationItemInit {
     pub notification: Arc<Notification>,
     pub resolved_icon: ResolvedIcon,
+    pub icon_source: IconSource,
 }
 
 #[derive(Debug)]
 pub(crate) enum NotificationItemInput {
     RefreshTime,
+    /// The underlying notification's content/actions changed; re-render in place.
+    Refresh,
 }
 
 #[derive(Debug)]

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_item/messages.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_item/messages.rs
@@ -17,8 +17,3 @@ pub(crate) enum NotificationItemInput {
     /// The underlying notification's content/actions changed; re-render in place.
     Refresh,
 }
-
-#[derive(Debug)]
-pub(crate) enum NotificationItemOutput {
-    Dismissed(u32),
-}

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_item/methods.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_item/methods.rs
@@ -1,12 +1,13 @@
 use gtk::prelude::*;
 use relm4::{gtk, spawn_local};
-use wayle_notification::core::types::Action;
+use wayle_notification::core::types::{Action, InvokeSource};
 
 use super::NotificationItem;
 use crate::{
     i18n::t,
     shell::notification_popup::helpers::{
-        RelativeTime, ResolvedIcon, cached_texture, resolve_icon, urgency_css_class,
+        RelativeTime, ResolvedIcon, cached_texture, mint_activation_token, priority_css_class,
+        resolve_notification_icon,
     },
 };
 
@@ -46,11 +47,9 @@ impl NotificationItem {
             actions_box.remove(&child);
         }
 
-        let actions = self.notification.actions.get();
-        let visible_actions: Vec<_> = actions
-            .iter()
-            .filter(|action| action.id != Action::DEFAULT_ID)
-            .collect();
+        // The `buttons` facet already excludes the body/default action.
+        let actions = self.notification.view.get().actions;
+        let visible_actions: Vec<_> = actions.buttons.iter().collect();
 
         if visible_actions.is_empty() {
             actions_box.set_visible(false);
@@ -83,17 +82,19 @@ impl NotificationItem {
         button.set_cursor_from_name(Some("pointer"));
 
         let notification = self.notification.clone();
-        let action_id = action.id.clone();
+        let action = action.clone();
 
         button.connect_clicked(move |_| {
             let notif = notification.clone();
-            let aid = action_id.clone();
+            let action = action.clone();
+            let token = mint_activation_token();
 
             spawn_local(async move {
-                if let Err(err) = notif.invoke(&aid).await {
-                    tracing::warn!(action = %aid, error = %err, "action invocation failed");
+                // `invoke` removes it from history itself (unless resident), so no explicit
+                // dismiss — and a failed action no longer force-removes the notification.
+                if let Err(err) = notif.invoke(&action, InvokeSource::History, token.as_deref()).await {
+                    tracing::warn!(action = %action.label, error = %err, "action invocation failed");
                 }
-                notif.dismiss();
             });
         });
 
@@ -101,7 +102,7 @@ impl NotificationItem {
     }
 
     pub(super) fn setup_default_action(&self, main_row: &gtk::Box) -> Option<gtk::GestureClick> {
-        if self.notification.default_action.get().is_none() {
+        if self.notification.view.get().actions.default.is_none() {
             main_row.set_cursor_from_name(None);
             return None;
         }
@@ -115,11 +116,13 @@ impl NotificationItem {
             gesture.set_state(gtk::EventSequenceState::Claimed);
 
             let notif = notification.clone();
+            let token = mint_activation_token();
             spawn_local(async move {
-                if let Err(err) = notif.invoke(Action::DEFAULT_ID).await {
+                // `activate_default` owns removal from history (unless resident); no explicit
+                // dismiss.
+                if let Err(err) = notif.activate_default(InvokeSource::History, token.as_deref()).await {
                     tracing::warn!(error = %err, "default action invocation failed");
                 }
-                notif.dismiss();
             });
         });
 
@@ -127,25 +130,21 @@ impl NotificationItem {
         Some(click)
     }
 
-    pub(super) fn apply_urgency(&self, root: &gtk::Box) {
-        // Idempotent: drop any previously-applied urgency class before adding current.
-        for class in ["low", "normal", "critical"] {
+    pub(super) fn apply_priority(&self, root: &gtk::Box) {
+        // Idempotent: drop any previously-applied priority class before adding current.
+        for class in ["low", "normal", "high", "urgent"] {
             root.remove_css_class(class);
         }
-        root.add_css_class(urgency_css_class(self.notification.urgency.get()));
+        root.add_css_class(priority_css_class(
+            self.notification.view.get().classification.priority,
+        ));
     }
 
     /// Re-renders the imperative parts of the item in place from the current
     /// notification state (icon, action buttons, urgency, default-click gesture).
     /// Declarative fields (summary/body/time) refresh via `#[watch]`.
     pub(super) fn refresh_widgets(&mut self) {
-        self.resolved_icon = resolve_icon(
-            self.icon_source,
-            &self.notification.app_name.get(),
-            &self.notification.app_icon.get(),
-            &self.notification.image_path.get(),
-            &self.notification.desktop_entry.get(),
-        );
+        self.resolved_icon = resolve_notification_icon(self.icon_source, &self.notification);
 
         if let (Some(icon), Some(container)) = (self.icon.clone(), self.icon_container.clone()) {
             self.apply_icon(&icon, &container);
@@ -156,7 +155,7 @@ impl NotificationItem {
         }
 
         if let Some(root) = self.root.clone() {
-            self.apply_urgency(&root);
+            self.apply_priority(&root);
         }
 
         if let Some(main_row) = self.main_row.clone() {

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_item/methods.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_item/methods.rs
@@ -5,13 +5,20 @@ use wayle_notification::core::types::Action;
 use super::NotificationItem;
 use crate::{
     i18n::t,
-    shell::notification_popup::helpers::{RelativeTime, ResolvedIcon},
+    shell::notification_popup::helpers::{
+        RelativeTime, ResolvedIcon, resolve_icon, urgency_css_class,
+    },
 };
 
 const MAX_ACTIONS_PER_ROW: usize = 3;
 
 impl NotificationItem {
     pub(super) fn apply_icon(&self, icon: &gtk::Image, icon_container: &gtk::Box) {
+        // Reset first so repeated calls (reactive refresh) don't accumulate state or
+        // leave a stale image when the source changes (e.g. Named -> File).
+        icon.clear();
+        icon_container.remove_css_class("file-icon");
+
         match &self.resolved_icon {
             ResolvedIcon::Named(name) => {
                 icon.set_icon_name(Some(name));
@@ -28,6 +35,11 @@ impl NotificationItem {
     }
 
     pub(super) fn build_action_buttons(&self, actions_box: &gtk::Box) {
+        // Clear existing rows so this is idempotent on reactive refresh.
+        while let Some(child) = actions_box.first_child() {
+            actions_box.remove(&child);
+        }
+
         let actions = self.notification.actions.get();
         let visible_actions: Vec<_> = actions
             .iter()
@@ -38,6 +50,7 @@ impl NotificationItem {
             actions_box.set_visible(false);
             return;
         }
+        actions_box.set_visible(true);
 
         for chunk in visible_actions.chunks(MAX_ACTIONS_PER_ROW) {
             let row = self.build_action_row(chunk);
@@ -81,9 +94,10 @@ impl NotificationItem {
         button
     }
 
-    pub(super) fn setup_default_action(&self, main_row: &gtk::Box) {
+    pub(super) fn setup_default_action(&self, main_row: &gtk::Box) -> Option<gtk::GestureClick> {
         if self.notification.default_action.get().is_none() {
-            return;
+            main_row.set_cursor_from_name(None);
+            return None;
         }
 
         main_row.set_cursor_from_name(Some("pointer"));
@@ -103,7 +117,49 @@ impl NotificationItem {
             });
         });
 
-        main_row.add_controller(click);
+        main_row.add_controller(click.clone());
+        Some(click)
+    }
+
+    pub(super) fn apply_urgency(&self, root: &gtk::Box) {
+        // Idempotent: drop any previously-applied urgency class before adding current.
+        for class in ["low", "normal", "critical"] {
+            root.remove_css_class(class);
+        }
+        root.add_css_class(urgency_css_class(self.notification.urgency.get()));
+    }
+
+    /// Re-renders the imperative parts of the item in place from the current
+    /// notification state (icon, action buttons, urgency, default-click gesture).
+    /// Declarative fields (summary/body/time) refresh via `#[watch]`.
+    pub(super) fn refresh_widgets(&mut self) {
+        self.resolved_icon = resolve_icon(
+            self.icon_source,
+            &self.notification.app_name.get(),
+            &self.notification.app_icon.get(),
+            &self.notification.image_path.get(),
+            &self.notification.desktop_entry.get(),
+        );
+
+        if let (Some(icon), Some(container)) = (self.icon.clone(), self.icon_container.clone()) {
+            self.apply_icon(&icon, &container);
+        }
+
+        if let Some(actions_box) = self.actions_box.clone() {
+            self.build_action_buttons(&actions_box);
+        }
+
+        if let Some(root) = self.root.clone() {
+            self.apply_urgency(&root);
+        }
+
+        if let Some(main_row) = self.main_row.clone() {
+            if let Some(gesture) = self.default_gesture.take() {
+                main_row.remove_controller(&gesture);
+            }
+            let gesture = self.setup_default_action(&main_row);
+            self.default_gesture = gesture;
+        }
     }
 
     pub(crate) fn time_to_string(time: RelativeTime) -> String {

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_item/methods.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_item/methods.rs
@@ -6,7 +6,7 @@ use super::NotificationItem;
 use crate::{
     i18n::t,
     shell::notification_popup::helpers::{
-        RelativeTime, ResolvedIcon, resolve_icon, urgency_css_class,
+        RelativeTime, ResolvedIcon, cached_texture, resolve_icon, urgency_css_class,
     },
 };
 
@@ -28,7 +28,13 @@ impl NotificationItem {
             }
 
             ResolvedIcon::File(path) => {
-                icon.set_from_file(Some(path));
+                // Share one reference-counted texture across every notification using this
+                // image instead of loading a separate copy per widget; fall back to a
+                // direct load if the file can't be decoded into a texture.
+                match cached_texture(path) {
+                    Some(texture) => icon.set_paintable(Some(&texture)),
+                    None => icon.set_from_file(Some(path)),
+                }
                 icon_container.add_css_class("file-icon");
             }
         }

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_item/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_item/mod.rs
@@ -1,22 +1,32 @@
 pub(crate) mod messages;
 mod methods;
+mod watchers;
 
 use std::sync::Arc;
 
 use gtk::prelude::*;
 use relm4::{gtk, prelude::*};
+use tokio_util::sync::CancellationToken;
+use wayle_config::schemas::modules::notification::IconSource;
 use wayle_notification::core::notification::Notification;
 
 use self::messages::{NotificationItemInit, NotificationItemInput, NotificationItemOutput};
-use crate::shell::notification_popup::helpers::{
-    ResolvedIcon, relative_time, sanitize_markup, urgency_css_class,
-};
+use crate::shell::notification_popup::helpers::{ResolvedIcon, relative_time, sanitize_markup};
 
 pub(crate) struct NotificationItem {
     pub(crate) notification: Arc<Notification>,
 
     resolved_icon: ResolvedIcon,
+    icon_source: IconSource,
     time_label: String,
+
+    root: Option<gtk::Box>,
+    main_row: Option<gtk::Box>,
+    actions_box: Option<gtk::Box>,
+    icon: Option<gtk::Image>,
+    icon_container: Option<gtk::Box>,
+    default_gesture: Option<gtk::GestureClick>,
+    cancel_token: CancellationToken,
 }
 
 #[relm4::factory(pub(crate))]
@@ -31,7 +41,6 @@ impl FactoryComponent for NotificationItem {
         #[root]
         gtk::Box {
             add_css_class: "notification-dropdown-item",
-            add_css_class: urgency_css_class(self.notification.urgency.get()),
             set_orientation: gtk::Orientation::Vertical,
 
             #[name = "main_row"]
@@ -64,6 +73,7 @@ impl FactoryComponent for NotificationItem {
                             set_hexpand: true,
                             set_halign: gtk::Align::Start,
                             set_ellipsize: gtk::pango::EllipsizeMode::End,
+                            #[watch]
                             set_label: &self.notification.summary.get(),
                         },
 
@@ -89,12 +99,14 @@ impl FactoryComponent for NotificationItem {
                         set_lines: 2,
                         set_wrap: true,
                         set_wrap_mode: gtk::pango::WrapMode::WordChar,
+                        #[watch]
                         set_label: &self
                             .notification
                             .body
                             .get()
                             .as_deref()
                             .map_or_else(String::new, sanitize_markup),
+                        #[watch]
                         set_visible: self.notification.body.get().is_some(),
                     },
                 },
@@ -114,7 +126,15 @@ impl FactoryComponent for NotificationItem {
         Self {
             notification: init.notification,
             resolved_icon: init.resolved_icon,
+            icon_source: init.icon_source,
             time_label,
+            root: None,
+            main_row: None,
+            actions_box: None,
+            icon: None,
+            icon_container: None,
+            default_gesture: None,
+            cancel_token: CancellationToken::new(),
         }
     }
 
@@ -129,6 +149,7 @@ impl FactoryComponent for NotificationItem {
 
         self.apply_icon(&widgets.icon, &widgets.icon_container);
         self.build_action_buttons(&widgets.actions_box);
+        self.apply_urgency(&root);
 
         let id = self.notification.id;
         let output_sender = sender.output_sender().clone();
@@ -137,7 +158,16 @@ impl FactoryComponent for NotificationItem {
             output_sender.emit(NotificationItemOutput::Dismissed(id));
         });
 
-        self.setup_default_action(&widgets.main_row);
+        let gesture = self.setup_default_action(&widgets.main_row);
+        self.default_gesture = gesture;
+
+        self.root = Some(root.clone());
+        self.main_row = Some(widgets.main_row.clone());
+        self.actions_box = Some(widgets.actions_box.clone());
+        self.icon = Some(widgets.icon.clone());
+        self.icon_container = Some(widgets.icon_container.clone());
+
+        watchers::spawn_field_watcher(&sender, &self.notification, self.cancel_token.clone());
 
         widgets
     }
@@ -148,6 +178,15 @@ impl FactoryComponent for NotificationItem {
                 self.time_label =
                     Self::time_to_string(relative_time(&self.notification.timestamp.get()));
             }
+            NotificationItemInput::Refresh => {
+                self.refresh_widgets();
+            }
         }
+    }
+}
+
+impl Drop for NotificationItem {
+    fn drop(&mut self) {
+        self.cancel_token.cancel();
     }
 }

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_item/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_item/mod.rs
@@ -10,8 +10,10 @@ use tokio_util::sync::CancellationToken;
 use wayle_config::schemas::modules::notification::IconSource;
 use wayle_notification::core::notification::Notification;
 
-use self::messages::{NotificationItemInit, NotificationItemInput, NotificationItemOutput};
-use crate::shell::notification_popup::helpers::{ResolvedIcon, relative_time, sanitize_markup};
+use self::messages::{NotificationItemInit, NotificationItemInput};
+use crate::shell::notification_popup::helpers::{
+    ResolvedIcon, open_body_link, relative_time, render_body,
+};
 
 pub(crate) struct NotificationItem {
     pub(crate) notification: Arc<Notification>,
@@ -33,7 +35,7 @@ pub(crate) struct NotificationItem {
 impl FactoryComponent for NotificationItem {
     type Init = NotificationItemInit;
     type Input = NotificationItemInput;
-    type Output = NotificationItemOutput;
+    type Output = ();
     type CommandOutput = ();
     type ParentWidget = gtk::Box;
 
@@ -74,7 +76,7 @@ impl FactoryComponent for NotificationItem {
                             set_halign: gtk::Align::Start,
                             set_ellipsize: gtk::pango::EllipsizeMode::End,
                             #[watch]
-                            set_label: &self.notification.summary.get(),
+                            set_label: &self.notification.view.get().content.summary,
                         },
 
                         gtk::Label {
@@ -88,9 +90,13 @@ impl FactoryComponent for NotificationItem {
                             set_css_classes: &["ghost-icon", "notification-dropdown-item-dismiss"],
                             set_icon_name: "ld-x-symbolic",
                             set_cursor_from_name: Some("pointer"),
+                            // An app that forbids manual dismissal (portal `persistent`) hides the
+                            // close affordance.
+                            set_visible: !self.notification.view.get().lifecycle.locked_open,
                         },
                     },
 
+                    #[name = "body_label"]
                     gtk::Label {
                         add_css_class: "notification-dropdown-item-body",
                         set_halign: gtk::Align::Start,
@@ -102,12 +108,13 @@ impl FactoryComponent for NotificationItem {
                         #[watch]
                         set_label: &self
                             .notification
+                            .view.get().content
                             .body
-                            .get()
-                            .as_deref()
-                            .map_or_else(String::new, sanitize_markup),
+                            .map_or_else(String::new, |body| {
+                                render_body(body.text(), body.is_markup())
+                            }),
                         #[watch]
-                        set_visible: self.notification.body.get().is_some(),
+                        set_visible: self.notification.view.get().content.body.is_some(),
                     },
                 },
             },
@@ -121,7 +128,7 @@ impl FactoryComponent for NotificationItem {
     }
 
     fn init_model(init: Self::Init, _index: &Self::Index, _sender: FactorySender<Self>) -> Self {
-        let time_label = Self::time_to_string(relative_time(&init.notification.timestamp.get()));
+        let time_label = Self::time_to_string(relative_time(&init.notification.view.get().received));
 
         Self {
             notification: init.notification,
@@ -149,14 +156,20 @@ impl FactoryComponent for NotificationItem {
 
         self.apply_icon(&widgets.icon, &widgets.icon_container);
         self.build_action_buttons(&widgets.actions_box);
-        self.apply_urgency(&root);
+        self.apply_priority(&root);
 
-        let id = self.notification.id;
-        let output_sender = sender.output_sender().clone();
-
+        // Dismiss directly; the notification service removes it and the reactive list update
+        // drops this item — no id/message round-trip needed.
+        let notif = self.notification.clone();
         widgets.dismiss_btn.connect_clicked(move |_| {
-            output_sender.emit(NotificationItemOutput::Dismissed(id));
+            notif.dismiss();
         });
+
+        // Open <a href> body links via the portal; stops GTK's crashing default handler.
+        let body_notif = self.notification.clone();
+        widgets
+            .body_label
+            .connect_activate_link(move |_, uri| open_body_link(&body_notif, uri));
 
         let gesture = self.setup_default_action(&widgets.main_row);
         self.default_gesture = gesture;
@@ -176,7 +189,7 @@ impl FactoryComponent for NotificationItem {
         match msg {
             NotificationItemInput::RefreshTime => {
                 self.time_label =
-                    Self::time_to_string(relative_time(&self.notification.timestamp.get()));
+                    Self::time_to_string(relative_time(&self.notification.view.get().received));
             }
             NotificationItemInput::Refresh => {
                 self.refresh_widgets();

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_item/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_item/watchers.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use futures::{StreamExt, stream::select_all};
+use futures::StreamExt;
 use relm4::prelude::FactorySender;
 use tokio_util::sync::CancellationToken;
 use wayle_notification::core::notification::Notification;
@@ -8,25 +8,15 @@ use wayle_notification::core::notification::Notification;
 use super::{NotificationItem, messages::NotificationItemInput};
 
 /// Reactively forwards any change to the notification's displayed fields as a single
-/// `Refresh` input, so the item re-renders in place (the `Arc<Notification>` is stable
-/// for the notification's lifetime, so this stays valid across `replaces_id` updates).
+/// `Refresh` input, so the item re-renders in place. All facets now live in one atomic
+/// `view` snapshot, so a single subscription covers every displayed field (the
+/// `Arc<Notification>` is stable across `replaces_id` updates, so this stays valid).
 pub(super) fn spawn_field_watcher(
     sender: &FactorySender<NotificationItem>,
     notification: &Arc<Notification>,
     cancel_token: CancellationToken,
 ) {
-    let streams = vec![
-        notification.summary.watch().skip(1).map(|_| ()).boxed(),
-        notification.body.watch().skip(1).map(|_| ()).boxed(),
-        notification.actions.watch().skip(1).map(|_| ()).boxed(),
-        notification.default_action.watch().skip(1).map(|_| ()).boxed(),
-        notification.urgency.watch().skip(1).map(|_| ()).boxed(),
-        notification.app_icon.watch().skip(1).map(|_| ()).boxed(),
-        notification.image_path.watch().skip(1).map(|_| ()).boxed(),
-        notification.hints.watch().skip(1).map(|_| ()).boxed(),
-        notification.desktop_entry.watch().skip(1).map(|_| ()).boxed(),
-    ];
-    let stream = select_all(streams);
+    let stream = notification.view.watch().skip(1).map(|_| ());
     let sender = sender.clone();
 
     relm4::spawn_local(async move {

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_item/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_item/watchers.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+
+use futures::{StreamExt, stream::select_all};
+use relm4::prelude::FactorySender;
+use tokio_util::sync::CancellationToken;
+use wayle_notification::core::notification::Notification;
+
+use super::{NotificationItem, messages::NotificationItemInput};
+
+/// Reactively forwards any change to the notification's displayed fields as a single
+/// `Refresh` input, so the item re-renders in place (the `Arc<Notification>` is stable
+/// for the notification's lifetime, so this stays valid across `replaces_id` updates).
+pub(super) fn spawn_field_watcher(
+    sender: &FactorySender<NotificationItem>,
+    notification: &Arc<Notification>,
+    cancel_token: CancellationToken,
+) {
+    let streams = vec![
+        notification.summary.watch().skip(1).map(|_| ()).boxed(),
+        notification.body.watch().skip(1).map(|_| ()).boxed(),
+        notification.actions.watch().skip(1).map(|_| ()).boxed(),
+        notification.default_action.watch().skip(1).map(|_| ()).boxed(),
+        notification.urgency.watch().skip(1).map(|_| ()).boxed(),
+        notification.app_icon.watch().skip(1).map(|_| ()).boxed(),
+        notification.image_path.watch().skip(1).map(|_| ()).boxed(),
+        notification.hints.watch().skip(1).map(|_| ()).boxed(),
+        notification.desktop_entry.watch().skip(1).map(|_| ()).boxed(),
+    ];
+    let stream = select_all(streams);
+    let sender = sender.clone();
+
+    relm4::spawn_local(async move {
+        futures::pin_mut!(stream);
+
+        loop {
+            tokio::select! {
+                () = cancel_token.cancelled() => break,
+                result = stream.next() => {
+                    if result.is_none() {
+                        break;
+                    }
+                    sender.input(NotificationItemInput::Refresh);
+                }
+            }
+        }
+    });
+}

--- a/crates/wayle-shell/src/shell/notification_popup/card/methods.rs
+++ b/crates/wayle-shell/src/shell/notification_popup/card/methods.rs
@@ -7,7 +7,8 @@ use super::NotificationPopupCard;
 use crate::{
     i18n::t,
     shell::notification_popup::helpers::{
-        RelativeTime, ResolvedIcon, resolve_icon, urgency_bar_visible, urgency_css_class,
+        RelativeTime, ResolvedIcon, cached_texture, resolve_icon, urgency_bar_visible,
+        urgency_css_class,
     },
 };
 
@@ -42,7 +43,13 @@ impl NotificationPopupCard {
             }
 
             ResolvedIcon::File(path) => {
-                icon.set_from_file(Some(path));
+                // Share one reference-counted texture across every notification using this
+                // image instead of loading a separate copy per widget; fall back to a
+                // direct load if the file can't be decoded into a texture.
+                match cached_texture(path) {
+                    Some(texture) => icon.set_paintable(Some(&texture)),
+                    None => icon.set_from_file(Some(path)),
+                }
                 icon_container.add_css_class("file-icon");
             }
         }

--- a/crates/wayle-shell/src/shell/notification_popup/card/methods.rs
+++ b/crates/wayle-shell/src/shell/notification_popup/card/methods.rs
@@ -1,14 +1,14 @@
 use gtk::prelude::*;
 use relm4::{gtk, spawn_local};
 use wayle_config::schemas::modules::notification::{PopupCloseBehavior, UrgencyBarThreshold};
-use wayle_notification::core::types::Action;
+use wayle_notification::core::types::{Action, InvokeSource};
 
 use super::NotificationPopupCard;
 use crate::{
     i18n::t,
     shell::notification_popup::helpers::{
-        RelativeTime, ResolvedIcon, cached_texture, resolve_icon, urgency_bar_visible,
-        urgency_css_class,
+        RelativeTime, ResolvedIcon, cached_texture, mint_activation_token, priority_bar_visible,
+        priority_css_class, resolve_notification_icon,
     },
 };
 
@@ -23,7 +23,7 @@ impl NotificationPopupCard {
             root.add_css_class("shadow");
         }
 
-        if urgency_bar_visible(self.notification.urgency.get(), urgency_bar) {
+        if priority_bar_visible(self.notification.view.get().classification.priority, urgency_bar) {
             root.add_css_class("urgency-bar");
         }
     }
@@ -79,11 +79,9 @@ impl NotificationPopupCard {
             actions_box.remove(&child);
         }
 
-        let actions = self.notification.actions.get();
-        let visible_actions: Vec<_> = actions
-            .iter()
-            .filter(|action| action.id != Action::DEFAULT_ID)
-            .collect();
+        // The `buttons` facet already excludes the body/default action.
+        let actions = self.notification.view.get().actions;
+        let visible_actions: Vec<_> = actions.buttons.iter().collect();
 
         if visible_actions.is_empty() {
             actions_box.set_visible(false);
@@ -112,26 +110,35 @@ impl NotificationPopupCard {
         row
     }
 
+    /// The activation context for interactions on this popup card: the banner is always
+    /// dismissed on activation, and the configured [`PopupCloseBehavior`] decides whether it is
+    /// also removed from history. `invoke`/`activate_default` honor `resident` on top of this.
+    fn invoke_source(&self) -> InvokeSource {
+        InvokeSource::Popup {
+            remove_from_history: matches!(self.close_behavior, PopupCloseBehavior::Remove),
+        }
+    }
+
     fn build_action_button(&self, action: &Action) -> gtk::Button {
         let button = gtk::Button::with_label(&action.label);
         button.add_css_class("notification-popup-action-btn");
         button.set_cursor_from_name(Some("pointer"));
 
         let notification = self.notification.clone();
-        let action_id = action.id.clone();
-        let service = self.service.clone();
-        let notif_id = self.notification.id;
+        let action = action.clone();
+        let source = self.invoke_source();
 
         button.connect_clicked(move |_| {
+            let action = action.clone();
+            tracing::debug!(action = %action.label, "action button clicked");
             let notif = notification.clone();
-            let aid = action_id.clone();
-            tracing::debug!(id = notif_id, action = %aid, "action button clicked");
-            service.dismiss_popup(notif_id);
+            let token = mint_activation_token();
             spawn_local(async move {
-                if let Err(err) = notif.invoke(&aid).await {
-                    tracing::warn!(action = %aid, error = %err, "action invocation failed");
+                // `invoke` dismisses per the popup's close policy (and honors `resident`, so a
+                // media-control card survives its own action).
+                if let Err(err) = notif.invoke(&action, source, token.as_deref()).await {
+                    tracing::warn!(action = %action.label, error = %err, "action invocation failed");
                 }
-                notif.dismiss();
             });
         });
 
@@ -139,7 +146,7 @@ impl NotificationPopupCard {
     }
 
     pub(super) fn setup_default_action(&self, root: &gtk::Box) -> Option<gtk::GestureClick> {
-        let default_action = self.notification.default_action.get();
+        let default_action = self.notification.view.get().actions.default;
         if default_action.is_none() {
             root.set_cursor_from_name(None);
             return None;
@@ -148,20 +155,17 @@ impl NotificationPopupCard {
         root.set_cursor_from_name(Some("pointer"));
 
         let notification = self.notification.clone();
-        let service = self.service.clone();
-        let notif_id = self.notification.id;
-        let close_behavior = self.close_behavior;
+        let source = self.invoke_source();
 
         let click = gtk::GestureClick::new();
         click.connect_released(move |gesture, _, _, _| {
             gesture.set_state(gtk::EventSequenceState::Claimed);
             let notif = notification.clone();
-            match close_behavior {
-                PopupCloseBehavior::Dismiss => service.dismiss_popup(notif_id),
-                PopupCloseBehavior::Remove => notif.dismiss(),
-            }
+            let token = mint_activation_token();
             spawn_local(async move {
-                if let Err(err) = notif.invoke(Action::DEFAULT_ID).await {
+                // `activate_default` dismisses per the popup's close policy (banner-only vs
+                // remove-from-history), honoring `resident`.
+                if let Err(err) = notif.activate_default(source, token.as_deref()).await {
                     tracing::warn!(error = %err, "default action invocation failed");
                 }
             });
@@ -170,29 +174,25 @@ impl NotificationPopupCard {
         Some(click)
     }
 
-    pub(super) fn apply_urgency_class(&self, root: &gtk::Box) {
-        // Idempotent: drop any previously-applied urgency class before adding current.
-        for class in ["low", "normal", "critical"] {
+    pub(super) fn apply_priority_class(&self, root: &gtk::Box) {
+        // Idempotent: drop any previously-applied priority class before adding current.
+        for class in ["low", "normal", "high", "urgent"] {
             root.remove_css_class(class);
         }
-        root.add_css_class(urgency_css_class(self.notification.urgency.get()));
+        root.add_css_class(priority_css_class(
+            self.notification.view.get().classification.priority,
+        ));
     }
 
     /// Re-renders the card in place from the current notification state (icon, app
-    /// label, action buttons, urgency, default-click gesture). Summary/body labels
+    /// label, action buttons, priority, default-click gesture). Summary/body labels
     /// refresh declaratively via `#[watch]`.
     pub(super) fn refresh_notification(&mut self, root: &gtk::Box) {
-        self.resolved_icon = resolve_icon(
-            self.icon_source,
-            &self.notification.app_name.get(),
-            &self.notification.app_icon.get(),
-            &self.notification.image_path.get(),
-            &self.notification.desktop_entry.get(),
-        );
+        self.resolved_icon = resolve_notification_icon(self.icon_source, &self.notification);
         self.app_label = self
             .notification
-            .app_name
-            .get()
+            .view.get().origin
+            .name
             .unwrap_or_else(|| t!("notification-popup-unknown-app"));
 
         if let (Some(icon), Some(container)) = (self.icon.clone(), self.icon_container.clone()) {
@@ -202,8 +202,11 @@ impl NotificationPopupCard {
             self.setup_action_buttons(&actions_box);
         }
 
-        self.apply_urgency_class(root);
-        if urgency_bar_visible(self.notification.urgency.get(), self.urgency_bar) {
+        self.apply_priority_class(root);
+        if priority_bar_visible(
+            self.notification.view.get().classification.priority,
+            self.urgency_bar,
+        ) {
             root.add_css_class("urgency-bar");
         } else {
             root.remove_css_class("urgency-bar");
@@ -223,15 +226,14 @@ impl NotificationPopupCard {
         }
 
         let hover = gtk::EventControllerMotion::new();
-        let service_enter = self.service.clone();
-        let notif_id = self.notification.id;
-        let service_leave = self.service.clone();
+        let notif_enter = self.notification.clone();
+        let notif_leave = self.notification.clone();
 
         hover.connect_enter(move |_, _, _| {
-            service_enter.inhibit_popup(notif_id);
+            notif_enter.inhibit_popup();
         });
         hover.connect_leave(move |_| {
-            service_leave.release_popup(notif_id);
+            notif_leave.release_popup();
         });
         root.add_controller(hover);
     }

--- a/crates/wayle-shell/src/shell/notification_popup/card/methods.rs
+++ b/crates/wayle-shell/src/shell/notification_popup/card/methods.rs
@@ -6,7 +6,9 @@ use wayle_notification::core::types::Action;
 use super::NotificationPopupCard;
 use crate::{
     i18n::t,
-    shell::notification_popup::helpers::{RelativeTime, ResolvedIcon, urgency_bar_visible},
+    shell::notification_popup::helpers::{
+        RelativeTime, ResolvedIcon, resolve_icon, urgency_bar_visible, urgency_css_class,
+    },
 };
 
 impl NotificationPopupCard {
@@ -26,6 +28,11 @@ impl NotificationPopupCard {
     }
 
     pub(super) fn apply_icon(&self, icon: &gtk::Image, icon_container: &gtk::Box) {
+        // Reset first so reactive re-application doesn't accumulate the file-icon class
+        // or leave a stale image when the source changes.
+        icon.clear();
+        icon_container.remove_css_class("file-icon");
+
         match &self.resolved_icon {
             ResolvedIcon::Named(name) => {
                 icon.set_icon_name(Some(name));
@@ -60,6 +67,11 @@ impl NotificationPopupCard {
     }
 
     pub(super) fn setup_action_buttons(&self, actions_box: &gtk::Box) {
+        // Clear existing rows so this is idempotent on reactive refresh.
+        while let Some(child) = actions_box.first_child() {
+            actions_box.remove(&child);
+        }
+
         let actions = self.notification.actions.get();
         let visible_actions: Vec<_> = actions
             .iter()
@@ -70,6 +82,7 @@ impl NotificationPopupCard {
             actions_box.set_visible(false);
             return;
         }
+        actions_box.set_visible(true);
 
         const MAX_PER_ROW: usize = 3;
 
@@ -118,10 +131,11 @@ impl NotificationPopupCard {
         button
     }
 
-    pub(super) fn setup_default_action(&self, root: &gtk::Box) {
+    pub(super) fn setup_default_action(&self, root: &gtk::Box) -> Option<gtk::GestureClick> {
         let default_action = self.notification.default_action.get();
         if default_action.is_none() {
-            return;
+            root.set_cursor_from_name(None);
+            return None;
         }
 
         root.set_cursor_from_name(Some("pointer"));
@@ -145,7 +159,55 @@ impl NotificationPopupCard {
                 }
             });
         });
-        root.add_controller(click);
+        root.add_controller(click.clone());
+        Some(click)
+    }
+
+    pub(super) fn apply_urgency_class(&self, root: &gtk::Box) {
+        // Idempotent: drop any previously-applied urgency class before adding current.
+        for class in ["low", "normal", "critical"] {
+            root.remove_css_class(class);
+        }
+        root.add_css_class(urgency_css_class(self.notification.urgency.get()));
+    }
+
+    /// Re-renders the card in place from the current notification state (icon, app
+    /// label, action buttons, urgency, default-click gesture). Summary/body labels
+    /// refresh declaratively via `#[watch]`.
+    pub(super) fn refresh_notification(&mut self, root: &gtk::Box) {
+        self.resolved_icon = resolve_icon(
+            self.icon_source,
+            &self.notification.app_name.get(),
+            &self.notification.app_icon.get(),
+            &self.notification.image_path.get(),
+            &self.notification.desktop_entry.get(),
+        );
+        self.app_label = self
+            .notification
+            .app_name
+            .get()
+            .unwrap_or_else(|| t!("notification-popup-unknown-app"));
+
+        if let (Some(icon), Some(container)) = (self.icon.clone(), self.icon_container.clone()) {
+            self.apply_icon(&icon, &container);
+        }
+        if let Some(actions_box) = self.actions_box.clone() {
+            self.setup_action_buttons(&actions_box);
+        }
+
+        self.apply_urgency_class(root);
+        if urgency_bar_visible(self.notification.urgency.get(), self.urgency_bar) {
+            root.add_css_class("urgency-bar");
+        } else {
+            root.remove_css_class("urgency-bar");
+        }
+
+        if let Some(gesture) = self.default_gesture.take() {
+            root.remove_controller(&gesture);
+        }
+        root.set_cursor_from_name(None);
+        let gesture = self.setup_default_action(root);
+        self.default_gesture = gesture;
     }
 
     pub(super) fn setup_hover_controller(&self, root: &gtk::Box) {

--- a/crates/wayle-shell/src/shell/notification_popup/card/mod.rs
+++ b/crates/wayle-shell/src/shell/notification_popup/card/mod.rs
@@ -9,11 +9,12 @@ use wayle_config::{
     ConfigService,
     schemas::modules::notification::{IconSource, PopupCloseBehavior, UrgencyBarThreshold},
 };
-use wayle_notification::{NotificationService, core::notification::Notification};
+use wayle_notification::core::notification::Notification;
 
 use super::{
     helpers::{
-        ResolvedIcon, relative_time, resolve_icon, sanitize_markup, urgency_bar_visible,
+        ResolvedIcon, open_body_link, priority_bar_visible, relative_time, render_body,
+        resolve_notification_icon,
     },
     templates::NotificationContentTemplate,
 };
@@ -22,7 +23,6 @@ use crate::i18n::t;
 /// Initialization data for a single popup card.
 pub(crate) struct CardInit {
     pub(crate) notification: Arc<Notification>,
-    pub(crate) service: Arc<NotificationService>,
     pub(crate) config: Arc<ConfigService>,
     pub(crate) hover_pause: bool,
     pub(crate) close_behavior: PopupCloseBehavior,
@@ -45,7 +45,6 @@ pub(crate) enum CardCmd {
 /// A single notification popup card.
 pub(crate) struct NotificationPopupCard {
     notification: Arc<Notification>,
-    service: Arc<NotificationService>,
     hover_pause: bool,
     close_behavior: PopupCloseBehavior,
     resolved_icon: ResolvedIcon,
@@ -104,19 +103,24 @@ impl Component for NotificationPopupCard {
                     #[template_child]
                     title {
                         #[watch]
-                        set_label: &model.notification.summary.get(),
+                        set_label: &model.notification.view.get().content.summary,
                     },
                     #[template_child]
                     body {
                         #[watch]
                         set_label: &model
                             .notification
+                            .view.get().content
                             .body
-                            .get()
-                            .as_deref()
-                            .map_or_else(String::new, sanitize_markup),
+                            .map_or_else(String::new, |body| {
+                                render_body(body.text(), body.is_markup())
+                            }),
                         #[watch]
-                        set_visible: model.notification.body.get().is_some(),
+                        set_visible: model.notification.view.get().content.body.is_some(),
+                        // Open <a href> links via the portal; stops GTK's crashing default handler.
+                        connect_activate_link[notification = model.notification.clone()] => move |_, uri| {
+                            open_body_link(&notification, uri)
+                        },
                     },
                 },
 
@@ -126,13 +130,14 @@ impl Component for NotificationPopupCard {
                     set_icon_name: "window-close-symbolic",
                     set_valign: gtk::Align::Start,
                     set_cursor_from_name: Some("pointer"),
+                    // An app that forbids manual dismissal (portal `persistent`) hides the close X.
+                    set_visible: !model.notification.view.get().lifecycle.locked_open,
                     connect_clicked[
-                        service = model.service.clone(),
                         notification = model.notification.clone(),
                         close_behavior = model.close_behavior,
                     ] => move |_| {
                         match close_behavior {
-                            PopupCloseBehavior::Dismiss => service.dismiss_popup(notification.id),
+                            PopupCloseBehavior::Dismiss => notification.dismiss_popup(),
                             PopupCloseBehavior::Remove => notification.dismiss(),
                         }
                     },
@@ -154,24 +159,17 @@ impl Component for NotificationPopupCard {
     ) -> ComponentParts<Self> {
         let notif = &init.notification;
 
-        let resolved_icon = resolve_icon(
-            init.icon_source,
-            &notif.app_name.get(),
-            &notif.app_icon.get(),
-            &notif.image_path.get(),
-            &notif.desktop_entry.get(),
-        );
+        let resolved_icon = resolve_notification_icon(init.icon_source, notif);
 
         let app_label = notif
-            .app_name
-            .get()
+            .view.get().origin
+            .name
             .unwrap_or_else(|| t!("notification-popup-unknown-app"));
 
-        let time_label = Self::format_time_label(relative_time(&notif.timestamp.get()));
+        let time_label = Self::format_time_label(relative_time(&notif.view.get().received));
 
         let mut model = Self {
             notification: init.notification,
-            service: init.service,
             hover_pause: init.hover_pause,
             close_behavior: init.close_behavior,
             resolved_icon,
@@ -188,7 +186,7 @@ impl Component for NotificationPopupCard {
         let widgets = view_output!();
 
         model.apply_css_classes(&root, init.shadow, init.urgency_bar);
-        model.apply_urgency_class(&root);
+        model.apply_priority_class(&root);
         model.apply_icon(&widgets.icon, &widgets.icon_container);
         model.setup_action_buttons(&widgets.actions_box);
         let default_gesture = model.setup_default_action(&root);
@@ -219,7 +217,8 @@ impl Component for NotificationPopupCard {
                     root.remove_css_class("shadow");
                 }
 
-                if urgency_bar_visible(self.notification.urgency.get(), urgency_bar) {
+                if priority_bar_visible(self.notification.view.get().classification.priority, urgency_bar)
+                {
                     root.add_css_class("urgency-bar");
                 } else {
                     root.remove_css_class("urgency-bar");

--- a/crates/wayle-shell/src/shell/notification_popup/card/mod.rs
+++ b/crates/wayle-shell/src/shell/notification_popup/card/mod.rs
@@ -14,7 +14,6 @@ use wayle_notification::{NotificationService, core::notification::Notification};
 use super::{
     helpers::{
         ResolvedIcon, relative_time, resolve_icon, sanitize_markup, urgency_bar_visible,
-        urgency_css_class,
     },
     templates::NotificationContentTemplate,
 };
@@ -39,6 +38,8 @@ pub(crate) enum CardCmd {
         shadow: bool,
         urgency_bar: UrgencyBarThreshold,
     },
+    /// The underlying notification's content/actions changed; re-render in place.
+    NotificationChanged,
 }
 
 /// A single notification popup card.
@@ -50,6 +51,12 @@ pub(crate) struct NotificationPopupCard {
     resolved_icon: ResolvedIcon,
     app_label: String,
     time_label: String,
+    icon_source: IconSource,
+    urgency_bar: UrgencyBarThreshold,
+    icon: Option<gtk::Image>,
+    icon_container: Option<gtk::Box>,
+    actions_box: Option<gtk::Box>,
+    default_gesture: Option<gtk::GestureClick>,
 }
 
 #[relm4::component(pub(crate))]
@@ -63,7 +70,6 @@ impl Component for NotificationPopupCard {
         #[root]
         gtk::Box {
             add_css_class: "notification-popup-card",
-            add_css_class: urgency_css_class(model.notification.urgency.get()),
             set_orientation: gtk::Orientation::Vertical,
 
             gtk::Box {
@@ -88,6 +94,7 @@ impl Component for NotificationPopupCard {
                 NotificationContentTemplate {
                     #[template_child]
                     app_label {
+                        #[watch]
                         set_label: &model.app_label,
                     },
                     #[template_child]
@@ -96,16 +103,19 @@ impl Component for NotificationPopupCard {
                     },
                     #[template_child]
                     title {
+                        #[watch]
                         set_label: &model.notification.summary.get(),
                     },
                     #[template_child]
                     body {
+                        #[watch]
                         set_label: &model
                             .notification
                             .body
                             .get()
                             .as_deref()
                             .map_or_else(String::new, sanitize_markup),
+                        #[watch]
                         set_visible: model.notification.body.get().is_some(),
                     },
                 },
@@ -159,7 +169,7 @@ impl Component for NotificationPopupCard {
 
         let time_label = Self::format_time_label(relative_time(&notif.timestamp.get()));
 
-        let model = Self {
+        let mut model = Self {
             notification: init.notification,
             service: init.service,
             hover_pause: init.hover_pause,
@@ -167,17 +177,30 @@ impl Component for NotificationPopupCard {
             resolved_icon,
             app_label,
             time_label,
+            icon_source: init.icon_source,
+            urgency_bar: init.urgency_bar,
+            icon: None,
+            icon_container: None,
+            actions_box: None,
+            default_gesture: None,
         };
 
         let widgets = view_output!();
 
         model.apply_css_classes(&root, init.shadow, init.urgency_bar);
+        model.apply_urgency_class(&root);
         model.apply_icon(&widgets.icon, &widgets.icon_container);
         model.setup_action_buttons(&widgets.actions_box);
-        model.setup_default_action(&root);
+        let default_gesture = model.setup_default_action(&root);
+        model.default_gesture = default_gesture;
         model.setup_hover_controller(&root);
 
+        model.icon = Some(widgets.icon.clone());
+        model.icon_container = Some(widgets.icon_container.clone());
+        model.actions_box = Some(widgets.actions_box.clone());
+
         watchers::spawn(&sender, &init.config);
+        watchers::spawn_notification(&sender, &model.notification);
 
         ComponentParts { model, widgets }
     }
@@ -188,6 +211,8 @@ impl Component for NotificationPopupCard {
                 shadow,
                 urgency_bar,
             } => {
+                self.urgency_bar = urgency_bar;
+
                 if shadow {
                     root.add_css_class("shadow");
                 } else {
@@ -199,6 +224,9 @@ impl Component for NotificationPopupCard {
                 } else {
                     root.remove_css_class("urgency-bar");
                 }
+            }
+            CardCmd::NotificationChanged => {
+                self.refresh_notification(root);
             }
         }
     }

--- a/crates/wayle-shell/src/shell/notification_popup/card/watchers.rs
+++ b/crates/wayle-shell/src/shell/notification_popup/card/watchers.rs
@@ -28,22 +28,9 @@ pub(super) fn spawn_notification(
     sender: &ComponentSender<NotificationPopupCard>,
     notification: &Arc<Notification>,
 ) {
-    watch!(
-        sender,
-        [
-            notification.summary.watch().skip(1),
-            notification.body.watch().skip(1),
-            notification.actions.watch().skip(1),
-            notification.default_action.watch().skip(1),
-            notification.urgency.watch().skip(1),
-            notification.app_name.watch().skip(1),
-            notification.app_icon.watch().skip(1),
-            notification.image_path.watch().skip(1),
-            notification.hints.watch().skip(1),
-            notification.desktop_entry.watch().skip(1),
-        ],
-        |out| {
-            let _ = out.send(CardCmd::NotificationChanged);
-        }
-    );
+    // All display facets are one atomic `view` snapshot now, so a single subscription covers
+    // every displayed field (content updated via replaces_id, actions stripped on disconnect, …).
+    watch!(sender, [notification.view.watch().skip(1)], |out| {
+        let _ = out.send(CardCmd::NotificationChanged);
+    });
 }

--- a/crates/wayle-shell/src/shell/notification_popup/card/watchers.rs
+++ b/crates/wayle-shell/src/shell/notification_popup/card/watchers.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use relm4::ComponentSender;
 use wayle_config::ConfigService;
+use wayle_notification::core::notification::Notification;
 use wayle_widgets::watch;
 
 use super::{CardCmd, NotificationPopupCard};
@@ -17,4 +18,32 @@ pub(super) fn spawn(sender: &ComponentSender<NotificationPopupCard>, config: &Ar
             urgency_bar: urgency_bar.get(),
         });
     });
+}
+
+/// Re-renders the card when the underlying notification's displayed fields change
+/// (content updated via replaces_id, or actions stripped when the owner disconnects).
+/// The `Arc<Notification>` is stable for the notification's lifetime, so this stays
+/// valid across in-place updates.
+pub(super) fn spawn_notification(
+    sender: &ComponentSender<NotificationPopupCard>,
+    notification: &Arc<Notification>,
+) {
+    watch!(
+        sender,
+        [
+            notification.summary.watch().skip(1),
+            notification.body.watch().skip(1),
+            notification.actions.watch().skip(1),
+            notification.default_action.watch().skip(1),
+            notification.urgency.watch().skip(1),
+            notification.app_name.watch().skip(1),
+            notification.app_icon.watch().skip(1),
+            notification.image_path.watch().skip(1),
+            notification.hints.watch().skip(1),
+            notification.desktop_entry.watch().skip(1),
+        ],
+        |out| {
+            let _ = out.send(CardCmd::NotificationChanged);
+        }
+    );
 }

--- a/crates/wayle-shell/src/shell/notification_popup/helpers.rs
+++ b/crates/wayle-shell/src/shell/notification_popup/helpers.rs
@@ -1,5 +1,7 @@
+use std::{cell::RefCell, collections::HashMap};
+
 use chrono::{DateTime, Utc};
-use relm4::gtk::{glib, pango};
+use relm4::gtk::{gdk, glib, glib::prelude::ObjectExt, pango};
 use wayle_config::schemas::modules::notification::{IconSource, UrgencyBarThreshold};
 use wayle_notification::types::Urgency;
 
@@ -129,6 +131,35 @@ fn mapped_icon(app_name: &Option<String>) -> ResolvedIcon {
         .unwrap_or(FALLBACK_ICON);
 
     ResolvedIcon::Named(String::from(name))
+}
+
+thread_local! {
+    /// Main-thread cache of notification image textures, keyed by file path and holding
+    /// only weak references. Many notifications rendering the same (content-addressed)
+    /// image file share one reference-counted [`gdk::Texture`] — a single copy of the
+    /// pixels in memory — and it's freed once no widget references it, then reloaded on
+    /// demand. Themed (`Named`) icons don't need this; GTK's `IconTheme` already shares
+    /// them.
+    static TEXTURE_CACHE: RefCell<HashMap<String, glib::WeakRef<gdk::Texture>>> =
+        RefCell::new(HashMap::new());
+}
+
+/// Returns a shared [`gdk::Texture`] for the image at `path`, loading it at most once
+/// while it is in use so notifications sharing an image don't each hold their own copy.
+/// Returns `None` if the file can't be decoded.
+pub(crate) fn cached_texture(path: &str) -> Option<gdk::Texture> {
+    TEXTURE_CACHE.with(|cache| {
+        let existing = cache.borrow().get(path).and_then(|weak| weak.upgrade());
+        if let Some(texture) = existing {
+            return Some(texture);
+        }
+
+        let texture = gdk::Texture::from_filename(path).ok()?;
+        cache
+            .borrow_mut()
+            .insert(path.to_owned(), texture.downgrade());
+        Some(texture)
+    })
 }
 
 #[cfg(test)]

--- a/crates/wayle-shell/src/shell/notification_popup/helpers.rs
+++ b/crates/wayle-shell/src/shell/notification_popup/helpers.rs
@@ -1,9 +1,12 @@
-use std::{cell::RefCell, collections::HashMap};
+use std::{cell::RefCell, collections::HashMap, sync::Arc};
 
 use chrono::{DateTime, Utc};
-use relm4::gtk::{gdk, glib, glib::prelude::ObjectExt, pango};
+use relm4::gtk::{gdk, gio, glib, pango, prelude::*};
 use wayle_config::schemas::modules::notification::{IconSource, UrgencyBarThreshold};
-use wayle_notification::types::Urgency;
+use wayle_notification::{
+    core::{notification::Notification, types::Image},
+    types::Priority,
+};
 
 use crate::shell::bar::icons::lookup_app_icon;
 
@@ -14,12 +17,95 @@ const MINUTES_PER_HOUR: i64 = 60;
 /// that Pango chokes on. If the text parses cleanly we leave it alone,
 /// otherwise we escape the whole thing so the label at least shows
 /// something instead of blowing up.
+///
+/// `<a href>` hyperlinks are a `GtkLabel` markup extension: the label strips the links itself
+/// before handing the remaining markup to Pango, so bare `pango::parse_markup` does NOT know
+/// the `<a>` tag and would reject (and thus escape) a perfectly valid link body. We therefore
+/// validate the *link-stripped* form — matching what `GtkLabel` actually renders — so a body
+/// with `<a href>` links is kept and rendered as clickable links rather than shown raw.
 pub(crate) fn sanitize_markup(text: &str) -> String {
-    if pango::parse_markup(text, '\0').is_ok() {
+    if pango::parse_markup(&strip_anchor_tags(text), '\0').is_ok() {
         return text.to_owned();
     }
 
     glib::markup_escape_text(text).into()
+}
+
+/// Removes `<a ...>` / `</a>` hyperlink tags for the markup-validation pass only (the original
+/// text, links intact, is what gets rendered). `GtkLabel` parses `<a>` itself and passes the
+/// rest to Pango, so this mirrors its validation; other tags (`<b>`, `<span>`, …) are left for
+/// Pango to check. A malformed/unterminated `<a` is left in place so validation still fails and
+/// the body is escaped.
+fn strip_anchor_tags(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(pos) = rest.find('<') {
+        out.push_str(&rest[..pos]);
+        let tail = &rest[pos..];
+        let is_open = tail
+            .strip_prefix("<a")
+            .is_some_and(|after| after.starts_with(|c: char| c == '>' || c.is_whitespace()));
+        let is_close = tail.starts_with("</a>");
+        if is_open || is_close {
+            match tail.find('>') {
+                Some(gt) => rest = &tail[gt + 1..],
+                None => {
+                    // Unterminated `<a`: keep it so Pango validation fails → whole body escaped.
+                    out.push_str(tail);
+                    return out;
+                }
+            }
+        } else {
+            // A different tag (e.g. `<b>`) or a literal `<`: keep it and keep scanning.
+            out.push('<');
+            rest = &tail[1..];
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Prepares a notification body for a markup-enabled label. When the body is markup
+/// (freedesktop, portal `markup-body`) it is sanitized (kept if valid, else escaped);
+/// when it is plain text (GNotification, portal plain `body`) it is escaped so any `<`/`&`
+/// render literally instead of being parsed as markup.
+pub(crate) fn render_body(text: &str, markup: bool) -> String {
+    if markup {
+        sanitize_markup(text)
+    } else {
+        glib::markup_escape_text(text).into()
+    }
+}
+
+/// Mints an `xdg-activation-v1` token for the current click, so an app invoked by a
+/// notification action may raise its window past the compositor's focus-stealing prevention.
+///
+/// Uses GDK's `AppLaunchContext`, which performs the Wayland `xdg_activation_token_v1` dance
+/// internally (the headless notification daemon can't — it has no Wayland connection, so the
+/// shell mints and passes the token in). Returns `None` if there's no display or the compositor
+/// declines (e.g. the shell's layer-shell surface doesn't currently hold focus); the action
+/// still dispatches, the window just may not auto-raise.
+pub(crate) fn mint_activation_token() -> Option<String> {
+    let context = gdk::Display::default()?.app_launch_context();
+    context
+        .startup_notify_id(None::<&gio::AppInfo>, &[])
+        .map(|token| token.to_string())
+}
+
+/// Handles a click on an `<a href>` link in a notification body. Wire to a body label's
+/// `connect_activate_link`: it opens the URI through the notification's XDG portal connection
+/// (via [`Notification::open_uri`](wayle_notification::core::notification::Notification::open_uri))
+/// and returns [`glib::Propagation::Stop`] so GTK's default handler — which calls `gtk_show_uri`
+/// on our layer-shell surface and crashes with a Wayland protocol error — never runs.
+pub(crate) fn open_body_link(notification: &Arc<Notification>, uri: &str) -> glib::Propagation {
+    let notification = notification.clone();
+    let uri = uri.to_owned();
+    relm4::spawn_local(async move {
+        if let Err(err) = notification.open_uri(&uri).await {
+            tracing::warn!(uri = %uri, error = %err, "opening notification body link failed");
+        }
+    });
+    glib::Propagation::Stop
 }
 
 /// Resolved notification icon.
@@ -31,21 +117,26 @@ pub(crate) enum ResolvedIcon {
     File(String),
 }
 
-/// Returns the CSS class name for a notification's urgency level.
-pub(crate) fn urgency_css_class(urgency: Urgency) -> &'static str {
-    match urgency {
-        Urgency::Low => "low",
-        Urgency::Normal => "normal",
-        Urgency::Critical => "critical",
+/// Returns the CSS class name for a notification's priority level.
+pub(crate) fn priority_css_class(priority: Priority) -> &'static str {
+    match priority {
+        Priority::Low => "low",
+        Priority::Normal => "normal",
+        Priority::High => "high",
+        Priority::Urgent => "urgent",
     }
 }
 
-/// Whether the urgency bar should be visible for the given urgency and threshold.
-pub(super) fn urgency_bar_visible(urgency: Urgency, threshold: UrgencyBarThreshold) -> bool {
+/// Whether the priority bar should be visible for the given priority and threshold.
+///
+/// The configured [`UrgencyBarThreshold`] is the *minimum* level that shows the bar.
+/// `Critical` maps to the top level (`Urgent`), so `High` shows a bar under the `Normal`
+/// and `Low` thresholds but not under `Critical`.
+pub(super) fn priority_bar_visible(priority: Priority, threshold: UrgencyBarThreshold) -> bool {
     match threshold {
         UrgencyBarThreshold::None => false,
-        UrgencyBarThreshold::Critical => urgency as u8 >= Urgency::Critical as u8,
-        UrgencyBarThreshold::Normal => urgency as u8 >= Urgency::Normal as u8,
+        UrgencyBarThreshold::Critical => priority as u8 >= Priority::Urgent as u8,
+        UrgencyBarThreshold::Normal => priority as u8 >= Priority::Normal as u8,
         UrgencyBarThreshold::Low => true,
     }
 }
@@ -111,6 +202,29 @@ pub(crate) fn resolve_icon(
     }
 }
 
+/// Flattens an [`Image`] facet back to the string form [`resolve_icon`] classifies. A themed
+/// name and a file path both round-trip: the resolver re-classifies the string identically.
+fn image_to_string(image: Option<Image>) -> Option<String> {
+    image.map(|image| match image {
+        Image::Named(name) => name,
+        Image::Path(path) => path.display().to_string(),
+    })
+}
+
+/// Resolves a notification's icon straight from its typed facets, so call sites never unpack
+/// the `Origin`/`Image` shape themselves.
+pub(crate) fn resolve_notification_icon(
+    icon_source: IconSource,
+    notification: &Notification,
+) -> ResolvedIcon {
+    let origin = notification.view.get().origin;
+    let name = origin.name;
+    let icon = image_to_string(origin.icon);
+    let desktop_entry = origin.desktop_entry.map(|entry| entry.as_str().to_owned());
+    let image = image_to_string(notification.view.get().image);
+    resolve_icon(icon_source, &name, &icon, &image, &desktop_entry)
+}
+
 /// Classifies a non-empty icon string as either a file path or theme icon name.
 fn try_icon_string(value: &Option<String>) -> Option<ResolvedIcon> {
     let icon = value.as_deref().filter(|raw| !raw.is_empty())?;
@@ -168,69 +282,73 @@ mod tests {
     use super::*;
 
     #[test]
-    fn urgency_css_class_maps_all_levels() {
-        assert_eq!(urgency_css_class(Urgency::Low), "low");
-        assert_eq!(urgency_css_class(Urgency::Normal), "normal");
-        assert_eq!(urgency_css_class(Urgency::Critical), "critical");
+    fn priority_css_class_maps_all_levels() {
+        assert_eq!(priority_css_class(Priority::Low), "low");
+        assert_eq!(priority_css_class(Priority::Normal), "normal");
+        assert_eq!(priority_css_class(Priority::High), "high");
+        assert_eq!(priority_css_class(Priority::Urgent), "urgent");
     }
 
     #[test]
-    fn urgency_bar_none_always_hidden() {
-        assert!(!urgency_bar_visible(
-            Urgency::Low,
-            UrgencyBarThreshold::None
-        ));
-        assert!(!urgency_bar_visible(
-            Urgency::Normal,
-            UrgencyBarThreshold::None
-        ));
-        assert!(!urgency_bar_visible(
-            Urgency::Critical,
-            UrgencyBarThreshold::None
-        ));
+    fn priority_bar_none_always_hidden() {
+        for priority in [
+            Priority::Low,
+            Priority::Normal,
+            Priority::High,
+            Priority::Urgent,
+        ] {
+            assert!(!priority_bar_visible(priority, UrgencyBarThreshold::None));
+        }
     }
 
     #[test]
-    fn urgency_bar_low_always_visible() {
-        assert!(urgency_bar_visible(Urgency::Low, UrgencyBarThreshold::Low));
-        assert!(urgency_bar_visible(
-            Urgency::Normal,
-            UrgencyBarThreshold::Low
-        ));
-        assert!(urgency_bar_visible(
-            Urgency::Critical,
-            UrgencyBarThreshold::Low
-        ));
+    fn priority_bar_low_always_visible() {
+        for priority in [
+            Priority::Low,
+            Priority::Normal,
+            Priority::High,
+            Priority::Urgent,
+        ] {
+            assert!(priority_bar_visible(priority, UrgencyBarThreshold::Low));
+        }
     }
 
     #[test]
-    fn urgency_bar_normal_hides_low() {
-        assert!(!urgency_bar_visible(
-            Urgency::Low,
+    fn priority_bar_normal_hides_low() {
+        assert!(!priority_bar_visible(
+            Priority::Low,
             UrgencyBarThreshold::Normal
         ));
-        assert!(urgency_bar_visible(
-            Urgency::Normal,
+        assert!(priority_bar_visible(
+            Priority::Normal,
             UrgencyBarThreshold::Normal
         ));
-        assert!(urgency_bar_visible(
-            Urgency::Critical,
+        assert!(priority_bar_visible(
+            Priority::High,
+            UrgencyBarThreshold::Normal
+        ));
+        assert!(priority_bar_visible(
+            Priority::Urgent,
             UrgencyBarThreshold::Normal
         ));
     }
 
     #[test]
-    fn urgency_bar_critical_only_shows_critical() {
-        assert!(!urgency_bar_visible(
-            Urgency::Low,
+    fn priority_bar_critical_shows_only_urgent() {
+        assert!(!priority_bar_visible(
+            Priority::Low,
             UrgencyBarThreshold::Critical
         ));
-        assert!(!urgency_bar_visible(
-            Urgency::Normal,
+        assert!(!priority_bar_visible(
+            Priority::Normal,
             UrgencyBarThreshold::Critical
         ));
-        assert!(urgency_bar_visible(
-            Urgency::Critical,
+        assert!(!priority_bar_visible(
+            Priority::High,
+            UrgencyBarThreshold::Critical
+        ));
+        assert!(priority_bar_visible(
+            Priority::Urgent,
             UrgencyBarThreshold::Critical
         ));
     }
@@ -313,5 +431,34 @@ mod tests {
     fn sanitize_markup_escapes_mixed_invalid() {
         let raw = "<b>bold</b> & more";
         assert_eq!(sanitize_markup(raw), "&lt;b&gt;bold&lt;/b&gt; &amp; more");
+    }
+
+    #[test]
+    fn sanitize_markup_keeps_hyperlink() {
+        // `<a href>` is a GtkLabel extension Pango doesn't know; it must NOT be escaped.
+        let link = r#"See the <a href="https://example.com">release notes</a>"#;
+        assert_eq!(sanitize_markup(link), link);
+    }
+
+    #[test]
+    fn sanitize_markup_keeps_hyperlink_mixed_with_other_tags() {
+        let mixed = r#"<b>Update</b> — <a href="https://x.y">details</a>"#;
+        assert_eq!(sanitize_markup(mixed), mixed);
+    }
+
+    #[test]
+    fn sanitize_markup_escapes_body_with_link_and_bare_ampersand() {
+        // A real link but a bare `&` elsewhere ⇒ invalid overall ⇒ escape everything,
+        // including the link markup (shown literally rather than half-rendered).
+        let out = sanitize_markup(r#"A & B <a href="https://x.y">link</a>"#);
+        assert!(out.contains("&amp;"), "bare & escaped: {out}");
+        assert!(out.contains("&lt;a href"), "link markup escaped too: {out}");
+        assert!(!out.contains("<a href"), "no raw tag remains: {out}");
+    }
+
+    #[test]
+    fn sanitize_markup_escapes_unterminated_anchor() {
+        // A stray `<a` that isn't a real tag must still be escaped, not kept.
+        assert_eq!(sanitize_markup("click <a here"), "click &lt;a here");
     }
 }

--- a/crates/wayle-shell/src/shell/notification_popup/methods.rs
+++ b/crates/wayle-shell/src/shell/notification_popup/methods.rs
@@ -32,9 +32,11 @@ impl NotificationPopupHost {
 
         self.remove_stale_cards(&visible_popups);
 
-        let existing_ids: Vec<u32> = self.cards.iter().map(|(notif, _)| notif.id).collect();
+        // Identity snapshot of already-carded notifications (by `PartialEq` = notification id).
+        let existing: Vec<Arc<Notification>> =
+            self.cards.iter().map(|(notif, _)| notif.clone()).collect();
 
-        self.insert_new_cards(&visible_popups, &existing_ids);
+        self.insert_new_cards(&visible_popups, &existing);
 
         debug!(cards = self.cards.len(), "popup reconcile complete");
 
@@ -44,9 +46,7 @@ impl NotificationPopupHost {
     fn remove_stale_cards(&mut self, active_popups: &[Arc<Notification>]) {
         let container = &self.card_container;
         self.cards.retain(|(stored_notif, controller)| {
-            let still_active = active_popups
-                .iter()
-                .any(|popup| popup.id == stored_notif.id);
+            let still_active = active_popups.iter().any(|popup| popup == stored_notif);
 
             if !still_active {
                 container.remove(controller.widget());
@@ -55,7 +55,7 @@ impl NotificationPopupHost {
         });
     }
 
-    fn insert_new_cards(&mut self, popups: &[Arc<Notification>], existing_ids: &[u32]) {
+    fn insert_new_cards(&mut self, popups: &[Arc<Notification>], existing: &[Arc<Notification>]) {
         let config = self.config.config();
         let notif_config = &config.modules.notifications;
 
@@ -68,14 +68,13 @@ impl NotificationPopupHost {
         let use_prepend = matches!(stacking_order, StackingOrder::NewestFirst);
 
         for notif in popups {
-            if existing_ids.contains(&notif.id) {
+            if existing.contains(notif) {
                 continue;
             }
 
             let controller = NotificationPopupCard::builder()
                 .launch(CardInit {
                     notification: notif.clone(),
-                    service: self.notification.clone(),
                     config: self.config.clone(),
                     hover_pause,
                     close_behavior,

--- a/crates/wayle-shell/src/shell/services.rs
+++ b/crates/wayle-shell/src/shell/services.rs
@@ -12,6 +12,7 @@ use wayle_media::MediaService;
 use wayle_network::NetworkService;
 use wayle_niri::NiriService;
 use wayle_notification::NotificationService;
+use wayle_portal::PortalHost;
 use wayle_power_profiles::PowerProfilesService;
 use wayle_sysinfo::SysinfoService;
 use wayle_systray::SystemTrayService;
@@ -38,6 +39,11 @@ pub(crate) struct ShellServices {
     pub niri: Option<Arc<NiriService>>,
     pub network: Option<Arc<NetworkService>>,
     pub notification: Option<Arc<NotificationService>>,
+    /// Owns the `org.freedesktop.impl.portal.desktop.wayle` connection that the portal
+    /// notification backend is served on; held for the session so the connection (and thus
+    /// the registered interface) stays alive. `None` if the portal backend didn't start.
+    #[allow(dead_code)]
+    pub portal_host: Option<PortalHost>,
     pub power_profiles: DeferredService<PowerProfilesService>,
     pub sysinfo: Arc<SysinfoService>,
     pub systray: Option<Arc<SystemTrayService>>,

--- a/crates/wayle-styling/scss/modules/notification_dropdown/_item.scss
+++ b/crates/wayle-styling/scss/modules/notification_dropdown/_item.scss
@@ -11,7 +11,11 @@
     border-radius: var(--rounding-element);
     background: var(--accent-subtle);
 
-    .critical & {
+    .high & {
+        background: var(--status-warning-subtle);
+    }
+
+    .urgent & {
         background: var(--status-error-subtle);
     }
 
@@ -35,7 +39,11 @@ image.notification-dropdown-item-icon-img {
     color: var(--accent);
     margin: var(--space-sm);
 
-    .critical & {
+    .high & {
+        color: var(--status-warning);
+    }
+
+    .urgent & {
         color: var(--status-error);
     }
 
@@ -68,6 +76,12 @@ image.notification-dropdown-item-icon-img {
     font-size: var(--text-md);
     font-weight: var(--weight-medium);
     color: var(--fg-muted);
+
+    // Match the popup body so `<a href>` links are visually distinct here too, not just
+    // pointer-cursor'd (mirrors notification_popup/_content.scss).
+    link {
+        color: var(--accent);
+    }
 }
 
 button.notification-dropdown-item-dismiss {

--- a/crates/wayle-styling/scss/modules/notification_popup/_content.scss
+++ b/crates/wayle-styling/scss/modules/notification_popup/_content.scss
@@ -7,7 +7,11 @@
     border-radius: var(--rounding-element);
     background: var(--accent-subtle);
 
-    .critical & {
+    .high & {
+        background: var(--status-warning-subtle);
+    }
+
+    .urgent & {
         background: var(--status-error-subtle);
     }
 
@@ -31,7 +35,11 @@ image.notification-popup-icon-img {
     color: var(--accent);
     margin: var(--space-sm);
 
-    .critical & {
+    .high & {
+        color: var(--status-warning);
+    }
+
+    .urgent & {
         color: var(--status-error);
     }
 

--- a/crates/wayle-styling/scss/modules/notification_popup/_index.scss
+++ b/crates/wayle-styling/scss/modules/notification_popup/_index.scss
@@ -26,7 +26,11 @@
         --_urgency-shadow: inset 0 calc(2px * var(--global-scale)) 0 0 var(--accent);
     }
 
-    &.urgency-bar.critical {
+    &.urgency-bar.high {
+        --_urgency-shadow: inset 0 calc(2px * var(--global-scale)) 0 0 var(--status-warning);
+    }
+
+    &.urgency-bar.urgent {
         --_urgency-shadow: inset 0 calc(2px * var(--global-scale)) 0 0 var(--status-error);
     }
 

--- a/resources/wayle.portal
+++ b/resources/wayle.portal
@@ -1,0 +1,3 @@
+[portal]
+DBusName=org.freedesktop.impl.portal.desktop.wayle
+Interfaces=org.freedesktop.impl.portal.Notification;

--- a/wayle/src/cli/notify/commands.rs
+++ b/wayle/src/cli/notify/commands.rs
@@ -10,7 +10,7 @@ pub enum NotifyCommands {
     Dismiss {
         /// Notification ID to dismiss
         #[arg(value_name = "ID")]
-        id: u32,
+        id: i64,
     },
 
     /// Dismiss all notifications

--- a/wayle/src/cli/notify/dismiss.rs
+++ b/wayle/src/cli/notify/dismiss.rs
@@ -5,7 +5,7 @@ use crate::cli::CliAction;
 ///
 /// # Errors
 /// Returns error if D-Bus communication fails.
-pub async fn execute(id: u32) -> CliAction {
+pub async fn execute(id: i64) -> CliAction {
     let (_connection, proxy) = connect().await?;
 
     proxy


### PR DESCRIPTION
Refactor notifications to use the new backend-agnostic API from [wayle-services #36](https://github.com/wayle-rs/wayle-services/pull/36). Also incorporates fixes to several minor UI issues (such as removing stale actions from orphaned freedesktop notifications) and performance improvements for batch dismissal of a large number of notifications.

Requires [wayle-services #36](https://github.com/wayle-rs/wayle-services/pull/36), supersedes #333.