### PR TITLE
feat: suport systemd type=Notify ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3205,6 +3205,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sd-notify"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e4ef7359e694bfaf1dd27a30f9d760b54c00dfae9f19bd0c05a39bc9128fe76"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4948,6 +4957,7 @@ dependencies = [
  "notify",
  "relm4",
  "rust-embed",
+ "sd-notify",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ reqwest = { version = "0.13", default-features = false, features = [
 rusqlite = { version = "0.38.0", features = ["bundled"] }
 rust-embed = "8"
 schemars = { version = "1.0.4", features = ["derive"] }
+sd-notify = "0.5"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { version = "1.0.145", features = ["preserve_order"] }
 serde_json_path = "0.7"

--- a/crates/wayle-idle-inhibit/build.rs
+++ b/crates/wayle-idle-inhibit/build.rs
@@ -1,9 +1,11 @@
 //! Build script for wayle-idle-inhibit.
 //!
-//! this crate intentionally does not force link order for
-//! libwayland-client. Binaries that also use `gtk4-layer-shell` must ensure
-//! `gtk4-layer-shell` is linked before `wayland-client` so its interposition
-//! works. Handle that in the final binary (via its build script).
+//! libwayland-client is linked via `#[link(name = "wayland-client")]` on the
+//! FFI extern block in `src/ffi.rs`, so it is always retained regardless of
+//! linker `--as-needed` ordering, in every binary and test depending on this
+//! crate. This build script therefore forces no link order. Binaries that also
+//! use `gtk4-layer-shell` must still ensure it is linked before wayland-client
+//! for its interposition to work; handle that in the final binary/shell.
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");

--- a/crates/wayle-idle-inhibit/src/ffi.rs
+++ b/crates/wayle-idle-inhibit/src/ffi.rs
@@ -173,6 +173,14 @@ mod sys {
 
     use super::{WlInterface, WlProxy};
 
+    // Declare the library these symbols come from so rustc emits
+    // `-lwayland-client` adjacent to this crate's objects. This keeps it out of
+    // reach of the linker's `--as-needed` pruning (which can otherwise drop a
+    // `-lwayland-client` that appears before the code referencing it, depending
+    // on link ordering) and propagates the link requirement to every binary and
+    // test that depends on this crate. gtk4-layer-shell interposition ordering
+    // is still the final binary's concern (see the shell's build script).
+    #[link(name = "wayland-client")]
     unsafe extern "C" {
         pub fn wl_display_roundtrip(display: *mut super::WlDisplay) -> c_int;
         pub fn wl_proxy_add_listener(

--- a/crates/wayle-shell/Cargo.toml
+++ b/crates/wayle-shell/Cargo.toml
@@ -24,6 +24,7 @@ rust-embed.workspace = true
 indicatif.workspace = true
 notify.workspace = true
 relm4.workspace = true
+sd-notify.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/wayle-shell/src/lib.rs
+++ b/crates/wayle-shell/src/lib.rs
@@ -13,6 +13,7 @@ mod process;
 mod services;
 mod shell;
 mod startup;
+mod systemd;
 mod template;
 mod tracing_init;
 mod wallpaper_map;

--- a/crates/wayle-shell/src/shell/mod.rs
+++ b/crates/wayle-shell/src/shell/mod.rs
@@ -114,6 +114,11 @@ impl Component for Shell {
         };
         let widgets = view_output!();
 
+        // Bootstrap-level readiness barrier: every shell module has now been
+        // constructed, so report `READY=1` to the service manager exactly
+        // once. No-op unless launched as a `Type=notify` systemd unit.
+        crate::systemd::notify_ready();
+
         ComponentParts { model, widgets }
     }
 

--- a/crates/wayle-shell/src/systemd.rs
+++ b/crates/wayle-shell/src/systemd.rs
@@ -1,0 +1,42 @@
+//! systemd service-manager readiness notification.
+//!
+//! When Wayle is run as a `Type=notify` systemd unit (see
+//! `resources/wayle.service`), the service manager keeps
+//! `graphical-session.target` — and anything ordered `After=` it, such as
+//! `xdg-desktop-autostart.target` — waiting until Wayle reports that it has
+//! finished starting up. This lets autostarted apps reliably find Wayle's
+//! notification buses already owned instead of racing them (a GApplication
+//! picks its `GNotification` backend once, on first send, and caches it for
+//! life).
+//!
+//! Readiness is a *bootstrap-level* concern, not a per-module one: it is
+//! reported exactly once, after the last shell module's constructor has
+//! returned (the end of [`Shell::init`](crate::shell)). The contract for
+//! modules is therefore that their constructors block until they have
+//! finished setting up.
+//!
+//! This is a no-op unless launched by a notify-enabled systemd unit:
+//! [`sd_notify::notify`] returns `Ok(())` and does nothing when
+//! `$NOTIFY_SOCKET` is unset, so it is safe under compositor autostart
+//! (Hyprland `exec-once`, `dex`, …) and when run straight from a shell.
+
+use sd_notify::NotifyState;
+use tracing::{debug, warn};
+
+/// Reports startup completion to the service manager (`READY=1`).
+///
+/// Call exactly once, after every shell module has been constructed. No-ops
+/// when `$NOTIFY_SOCKET` is unset — i.e. whenever Wayle was not launched by a
+/// `Type=notify` systemd unit.
+pub(crate) fn notify_ready() {
+    // `sd_notify::notify` leaves `$NOTIFY_SOCKET` set (it does not mutate the
+    // environment, which would be unsound here — the shell is already
+    // multithreaded). That is harmless: the unit uses `NotifyAccess=main`, so
+    // the service manager ignores any notifications from child processes.
+    match sd_notify::notify(&[NotifyState::Ready]) {
+        Ok(()) => {
+            debug!("reported startup readiness (no-op unless run as a Type=notify systemd unit)");
+        }
+        Err(err) => warn!(error = %err, "failed to notify service manager of readiness"),
+    }
+}

--- a/resources/wayle.service
+++ b/resources/wayle.service
@@ -2,10 +2,15 @@
 Description=Wayle Desktop Shell
 PartOf=graphical-session.target
 After=graphical-session.target
+# Ordering only: hold autostart apps and tray clients until the shell is ready.
+Before=xdg-desktop-autostart.target tray.target
 StartLimitIntervalSec=30
 StartLimitBurst=5
 
 [Service]
+# READY=1 is sent once all modules have started; NotifyAccess=main ignores child processes.
+Type=notify
+NotifyAccess=main
 ExecStart=/usr/bin/wayle shell
 Restart=on-failure
 RestartSec=3

--- a/wayle/src/cli/panel/start.rs
+++ b/wayle/src/cli/panel/start.rs
@@ -29,8 +29,12 @@ pub async fn execute() -> CliAction {
     let current_exe =
         env::current_exe().map_err(|err| format!("Failed to resolve executable: {err}"))?;
 
+    // Strip `$NOTIFY_SOCKET` from the detached child: systemd readiness is
+    // reported only by a directly-launched `wayle shell`, never by a shell
+    // spawned via `wayle panel start` (whose parent has already exited).
     Command::new(current_exe)
         .arg("shell")
+        .env_remove("NOTIFY_SOCKET")
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())


### PR DESCRIPTION
Makes Wayle signal `NOTIFY_SOCKET` after all service constructors finish. In particular, this (combined with tweaking the `.service` file to use `Type=notify` and enforce ordering) prevents `xdg-autostart`-ed apps from starting too soon and trying to send a notification before Wayle finishes setting up its notification service. Previously, this race could lead to two undesirable outcomes
- Missed notifications
- (with [wayle-services #36](https://github.com/wayle-rs/wayle-services/pull/36)) A GApplication incorrectly falling back to `org.freedesktop.Notifications` even when `org.gtk.Notifications` is available

sd_notify signaling only happens when Wayle is run with `wayle shell`, not with `wayle panel start` (this is to prevent unexpected behavior on misconfigured setups that use `exec-start=wayle panel shell` or similar in a compositor service with `Type=notify` but without `NotifyAccess=main`; in this case, Wayle might incorrectly signal readiness for the compositor service it runs in rather than for itself).

Added a new dependency `sd-notify`, and also needed to fix(?) a build script bug that led to fragile link ordering guarantees.