### PR TITLE
fix: use `#link[]` in wayle-idle-inhibit extern block to resolve link ordering fragility

### DIFF
--- a/crates/wayle-idle-inhibit/build.rs
+++ b/crates/wayle-idle-inhibit/build.rs
@@ -1,9 +1,11 @@
 //! Build script for wayle-idle-inhibit.
 //!
-//! this crate intentionally does not force link order for
-//! libwayland-client. Binaries that also use `gtk4-layer-shell` must ensure
-//! `gtk4-layer-shell` is linked before `wayland-client` so its interposition
-//! works. Handle that in the final binary (via its build script).
+//! libwayland-client is linked via `#[link(name = "wayland-client")]` on the
+//! FFI extern block in `src/ffi.rs`, so it is always retained regardless of
+//! linker `--as-needed` ordering, in every binary and test depending on this
+//! crate. This build script therefore forces no link order. Binaries that also
+//! use `gtk4-layer-shell` must still ensure it is linked before wayland-client
+//! for its interposition to work; handle that in the final binary/shell.
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");

--- a/crates/wayle-idle-inhibit/src/ffi.rs
+++ b/crates/wayle-idle-inhibit/src/ffi.rs
@@ -173,6 +173,14 @@ mod sys {
 
     use super::{WlInterface, WlProxy};
 
+    // Declare the library these symbols come from so rustc emits
+    // `-lwayland-client` adjacent to this crate's objects. This keeps it out of
+    // reach of the linker's `--as-needed` pruning (which can otherwise drop a
+    // `-lwayland-client` that appears before the code referencing it, depending
+    // on link ordering) and propagates the link requirement to every binary and
+    // test that depends on this crate. gtk4-layer-shell interposition ordering
+    // is still the final binary's concern (see the shell's build script).
+    #[link(name = "wayland-client")]
     unsafe extern "C" {
         pub fn wl_display_roundtrip(display: *mut super::WlDisplay) -> c_int;
         pub fn wl_proxy_add_listener(


### PR DESCRIPTION
This is a dependency of a few of my other PRs, but I will also submit it separately (and cherrypick this commit in my other branches) to make merge conflicts easier to manage.