### PR TITLE
feat: optional fallback to symbolic desktop icon

### DIFF
--- a/crates/wayle-config/src/schemas/general/mod.rs
+++ b/crates/wayle-config/src/schemas/general/mod.rs
@@ -30,15 +30,16 @@ pub struct GeneralConfig {
     #[default(false)]
     pub tearing_mode: ConfigProperty<bool>,
 
-    /// Fall back to an app's symbolic desktop-entry icon when no icon is mapped.
+    /// Prefer full-colour app icons over symbolic ones for notifications and workspaces.
     ///
-    /// Applies to modules that render per-app icons (notifications, workspaces).
-    /// When enabled and an app matches no hardcoded icon mapping, its desktop
-    /// entry's icon is used if a `-symbolic` variant exists in the icon theme;
-    /// otherwise the module's usual fallback icon is used, as before.
-    #[serde(rename = "symbolic-icon-fallback")]
+    /// When enabled, the notification and workspace modules use an app's colour
+    /// icon when one exists, falling back to a symbolic icon (including the built-in
+    /// symbolic mappings) only when no colour icon is available. When disabled
+    /// (the default), those modules prefer symbolic icons. Either way, modules
+    /// fall back to an app's symbolic desktop-entry icon before the generic icon.
+    #[serde(rename = "prefer-color-icons")]
     #[default(false)]
-    pub symbolic_icon_fallback: ConfigProperty<bool>,
+    pub prefer_color_icons: ConfigProperty<bool>,
 }
 
 impl ModuleInfoProvider for GeneralConfig {

--- a/crates/wayle-config/src/schemas/general/mod.rs
+++ b/crates/wayle-config/src/schemas/general/mod.rs
@@ -29,6 +29,16 @@ pub struct GeneralConfig {
     #[serde(rename = "tearing-mode")]
     #[default(false)]
     pub tearing_mode: ConfigProperty<bool>,
+
+    /// Fall back to an app's symbolic desktop-entry icon when no icon is mapped.
+    ///
+    /// Applies to modules that render per-app icons (notifications, workspaces).
+    /// When enabled and an app matches no hardcoded icon mapping, its desktop
+    /// entry's icon is used if a `-symbolic` variant exists in the icon theme;
+    /// otherwise the module's usual fallback icon is used, as before.
+    #[serde(rename = "symbolic-icon-fallback")]
+    #[default(false)]
+    pub symbolic_icon_fallback: ConfigProperty<bool>,
 }
 
 impl ModuleInfoProvider for GeneralConfig {

--- a/crates/wayle-i18n/locales/en-US/config/_general.ftl
+++ b/crates/wayle-i18n/locales/en-US/config/_general.ftl
@@ -11,8 +11,8 @@ settings-general-font-mono = Monospace Font
 settings-general-tearing-mode = Tearing Mode
     .description = Demote overlay surfaces to allow compositor screen tearing for fullscreen games
 
-settings-general-symbolic-icon-fallback = Symbolic Icon Fallback
-    .description = Use an app's symbolic desktop icon when no icon is mapped, before the generic fallback
+settings-general-prefer-color-icons = Prefer Color Icons
+    .description = Prefer full-colour app icons for notifications and workspaces, falling back to symbolic icons only when no colour icon exists
 
 
 ## Layer enum variants

--- a/crates/wayle-i18n/locales/en-US/config/_general.ftl
+++ b/crates/wayle-i18n/locales/en-US/config/_general.ftl
@@ -11,6 +11,9 @@ settings-general-font-mono = Monospace Font
 settings-general-tearing-mode = Tearing Mode
     .description = Demote overlay surfaces to allow compositor screen tearing for fullscreen games
 
+settings-general-symbolic-icon-fallback = Symbolic Icon Fallback
+    .description = Use an app's symbolic desktop icon when no icon is mapped, before the generic fallback
+
 
 ## Layer enum variants
 enum-layer-background = Background

--- a/crates/wayle-i18n/locales/fr/config/_general.ftl
+++ b/crates/wayle-i18n/locales/fr/config/_general.ftl
@@ -10,3 +10,6 @@ settings-general-font-mono = Police à chasse fixe
 
 settings-general-tearing-mode = Mode de déchirement
     .description = Rétrograder les surfaces de superposition pour permettre le déchirement d'écran du compositeur pour les jeux en plein écran
+
+settings-general-symbolic-icon-fallback = Icône symbolique de repli
+    .description = Utiliser l'icône symbolique du bureau d'une application quand aucune icône n'est associée, avant le repli générique

--- a/crates/wayle-i18n/locales/fr/config/_general.ftl
+++ b/crates/wayle-i18n/locales/fr/config/_general.ftl
@@ -11,5 +11,5 @@ settings-general-font-mono = Police à chasse fixe
 settings-general-tearing-mode = Mode de déchirement
     .description = Rétrograder les surfaces de superposition pour permettre le déchirement d'écran du compositeur pour les jeux en plein écran
 
-settings-general-symbolic-icon-fallback = Icône symbolique de repli
-    .description = Utiliser l'icône symbolique du bureau d'une application quand aucune icône n'est associée, avant le repli générique
+settings-general-prefer-color-icons = Préférer les icônes en couleur
+    .description = Préférer les icônes en couleur des applications pour les notifications et les espaces de travail, en se repliant sur les icônes symboliques uniquement lorsqu'aucune icône en couleur n'existe

--- a/crates/wayle-idle-inhibit/build.rs
+++ b/crates/wayle-idle-inhibit/build.rs
@@ -1,9 +1,11 @@
 //! Build script for wayle-idle-inhibit.
 //!
-//! this crate intentionally does not force link order for
-//! libwayland-client. Binaries that also use `gtk4-layer-shell` must ensure
-//! `gtk4-layer-shell` is linked before `wayland-client` so its interposition
-//! works. Handle that in the final binary (via its build script).
+//! libwayland-client is linked via `#[link(name = "wayland-client")]` on the
+//! FFI extern block in `src/ffi.rs`, so it is always retained regardless of
+//! linker `--as-needed` ordering, in every binary and test depending on this
+//! crate. This build script therefore forces no link order. Binaries that also
+//! use `gtk4-layer-shell` must still ensure it is linked before wayland-client
+//! for its interposition to work; handle that in the final binary/shell.
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");

--- a/crates/wayle-idle-inhibit/src/ffi.rs
+++ b/crates/wayle-idle-inhibit/src/ffi.rs
@@ -173,6 +173,14 @@ mod sys {
 
     use super::{WlInterface, WlProxy};
 
+    // Declare the library these symbols come from so rustc emits
+    // `-lwayland-client` adjacent to this crate's objects. This keeps it out of
+    // reach of the linker's `--as-needed` pruning (which can otherwise drop a
+    // `-lwayland-client` that appears before the code referencing it, depending
+    // on link ordering) and propagates the link requirement to every binary and
+    // test that depends on this crate. gtk4-layer-shell interposition ordering
+    // is still the final binary's concern (see the shell's build script).
+    #[link(name = "wayland-client")]
     unsafe extern "C" {
         pub fn wl_display_roundtrip(display: *mut super::WlDisplay) -> c_int;
         pub fn wl_proxy_add_listener(

--- a/crates/wayle-settings/src/pages/general/mod.rs
+++ b/crates/wayle-settings/src/pages/general/mod.rs
@@ -31,7 +31,10 @@ pub(crate) fn entry(config: &Config) -> LeafEntry {
                 },
                 SectionSpec {
                     title_key: "settings-section-display",
-                    items: vec![toggle(&general.tearing_mode)],
+                    items: vec![
+                        toggle(&general.tearing_mode),
+                        toggle(&general.symbolic_icon_fallback),
+                    ],
                 },
             ],
         ),

--- a/crates/wayle-settings/src/pages/general/mod.rs
+++ b/crates/wayle-settings/src/pages/general/mod.rs
@@ -33,7 +33,7 @@ pub(crate) fn entry(config: &Config) -> LeafEntry {
                     title_key: "settings-section-display",
                     items: vec![
                         toggle(&general.tearing_mode),
-                        toggle(&general.symbolic_icon_fallback),
+                        toggle(&general.prefer_color_icons),
                     ],
                 },
             ],

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/methods.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/methods.rs
@@ -10,6 +10,7 @@ impl NotificationDropdown {
         self.has_notifications = !notifications.is_empty();
 
         let icon_source = self.config.config().modules.notifications.icon_source.get();
+        let symbolic_fallback = self.config.config().general.symbolic_icon_fallback.get();
 
         let new_groups = group_by_app(&notifications);
         let new_keys: Vec<Option<String>> = new_groups
@@ -18,7 +19,7 @@ impl NotificationDropdown {
             .collect();
 
         self.remove_stale_groups(&new_keys);
-        self.update_or_insert_groups(&new_groups, icon_source);
+        self.update_or_insert_groups(&new_groups, icon_source, symbolic_fallback);
         self.reorder_groups(&new_keys);
     }
 
@@ -27,6 +28,7 @@ impl NotificationDropdown {
         self.has_notifications = !notifications.is_empty();
 
         let icon_source = self.config.config().modules.notifications.icon_source.get();
+        let symbolic_fallback = self.config.config().general.symbolic_icon_fallback.get();
 
         let grouped = group_by_app(&notifications);
 
@@ -38,6 +40,7 @@ impl NotificationDropdown {
                 app_name: group_data.app_name,
                 notifications: group_data.notifications,
                 icon_source,
+                symbolic_fallback,
             });
         }
     }
@@ -65,6 +68,7 @@ impl NotificationDropdown {
         &mut self,
         new_groups: &[NotificationGroupData],
         icon_source: wayle_config::schemas::modules::notification::IconSource,
+        symbolic_fallback: bool,
     ) {
         let mut to_add = Vec::new();
 
@@ -81,6 +85,7 @@ impl NotificationDropdown {
                     app_name: group_data.app_name.clone(),
                     notifications: group_data.notifications.clone(),
                     icon_source,
+                    symbolic_fallback,
                 });
             }
         }

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/methods.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/methods.rs
@@ -10,7 +10,7 @@ impl NotificationDropdown {
         self.has_notifications = !notifications.is_empty();
 
         let icon_source = self.config.config().modules.notifications.icon_source.get();
-        let symbolic_fallback = self.config.config().general.symbolic_icon_fallback.get();
+        let prefer_color = self.config.config().general.prefer_color_icons.get();
 
         let new_groups = group_by_app(&notifications);
         let new_keys: Vec<Option<String>> = new_groups
@@ -19,7 +19,7 @@ impl NotificationDropdown {
             .collect();
 
         self.remove_stale_groups(&new_keys);
-        self.update_or_insert_groups(&new_groups, icon_source, symbolic_fallback);
+        self.update_or_insert_groups(&new_groups, icon_source, prefer_color);
         self.reorder_groups(&new_keys);
     }
 
@@ -28,7 +28,7 @@ impl NotificationDropdown {
         self.has_notifications = !notifications.is_empty();
 
         let icon_source = self.config.config().modules.notifications.icon_source.get();
-        let symbolic_fallback = self.config.config().general.symbolic_icon_fallback.get();
+        let prefer_color = self.config.config().general.prefer_color_icons.get();
 
         let grouped = group_by_app(&notifications);
 
@@ -40,7 +40,7 @@ impl NotificationDropdown {
                 app_name: group_data.app_name,
                 notifications: group_data.notifications,
                 icon_source,
-                symbolic_fallback,
+                prefer_color,
             });
         }
     }
@@ -68,7 +68,7 @@ impl NotificationDropdown {
         &mut self,
         new_groups: &[NotificationGroupData],
         icon_source: wayle_config::schemas::modules::notification::IconSource,
-        symbolic_fallback: bool,
+        prefer_color: bool,
     ) {
         let mut to_add = Vec::new();
 
@@ -85,7 +85,7 @@ impl NotificationDropdown {
                     app_name: group_data.app_name.clone(),
                     notifications: group_data.notifications.clone(),
                     icon_source,
-                    symbolic_fallback,
+                    prefer_color,
                 });
             }
         }

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/messages.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/messages.rs
@@ -7,6 +7,7 @@ pub(crate) struct NotificationGroupInit {
     pub app_name: Option<String>,
     pub notifications: Vec<Arc<Notification>>,
     pub icon_source: IconSource,
+    pub symbolic_fallback: bool,
 }
 
 #[derive(Debug)]

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/messages.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/messages.rs
@@ -7,7 +7,7 @@ pub(crate) struct NotificationGroupInit {
     pub app_name: Option<String>,
     pub notifications: Vec<Arc<Notification>>,
     pub icon_source: IconSource,
-    pub symbolic_fallback: bool,
+    pub prefer_color: bool,
 }
 
 #[derive(Debug)]

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/methods.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/methods.rs
@@ -44,7 +44,9 @@ impl NotificationGroup {
 
         let inits: Vec<_> = remaining
             .iter()
-            .map(|notification| build_item_init(self.icon_source, notification))
+            .map(|notification| {
+                build_item_init(self.icon_source, self.symbolic_fallback, notification)
+            })
             .collect();
 
         {
@@ -59,6 +61,7 @@ impl NotificationGroup {
 
     pub(super) fn resolve_group_icon(
         _icon_source: IconSource,
+        symbolic_fallback: bool,
         notifications: &[Arc<Notification>],
     ) -> Option<String> {
         let first = notifications.first()?;
@@ -68,6 +71,7 @@ impl NotificationGroup {
             &first.app_icon.get(),
             &first.image_path.get(),
             &first.desktop_entry.get(),
+            symbolic_fallback,
         );
 
         match resolved {
@@ -108,7 +112,9 @@ impl NotificationGroup {
 
         let inits: Vec<_> = visible
             .iter()
-            .map(|notification| build_item_init(self.icon_source, notification))
+            .map(|notification| {
+                build_item_init(self.icon_source, self.symbolic_fallback, notification)
+            })
             .collect();
 
         {
@@ -124,6 +130,7 @@ impl NotificationGroup {
 
 fn build_item_init(
     icon_source: IconSource,
+    symbolic_fallback: bool,
     notification: &Arc<Notification>,
 ) -> NotificationItemInit {
     let resolved_icon = resolve_icon(
@@ -132,6 +139,7 @@ fn build_item_init(
         &notification.app_icon.get(),
         &notification.image_path.get(),
         &notification.desktop_entry.get(),
+        symbolic_fallback,
     );
 
     NotificationItemInit {

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/methods.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/methods.rs
@@ -45,7 +45,7 @@ impl NotificationGroup {
         let inits: Vec<_> = remaining
             .iter()
             .map(|notification| {
-                build_item_init(self.icon_source, self.symbolic_fallback, notification)
+                build_item_init(self.icon_source, self.prefer_color, notification)
             })
             .collect();
 
@@ -61,7 +61,7 @@ impl NotificationGroup {
 
     pub(super) fn resolve_group_icon(
         _icon_source: IconSource,
-        symbolic_fallback: bool,
+        prefer_color: bool,
         notifications: &[Arc<Notification>],
     ) -> Option<String> {
         let first = notifications.first()?;
@@ -71,7 +71,7 @@ impl NotificationGroup {
             &first.app_icon.get(),
             &first.image_path.get(),
             &first.desktop_entry.get(),
-            symbolic_fallback,
+            prefer_color,
         );
 
         match resolved {
@@ -113,7 +113,7 @@ impl NotificationGroup {
         let inits: Vec<_> = visible
             .iter()
             .map(|notification| {
-                build_item_init(self.icon_source, self.symbolic_fallback, notification)
+                build_item_init(self.icon_source, self.prefer_color, notification)
             })
             .collect();
 
@@ -130,7 +130,7 @@ impl NotificationGroup {
 
 fn build_item_init(
     icon_source: IconSource,
-    symbolic_fallback: bool,
+    prefer_color: bool,
     notification: &Arc<Notification>,
 ) -> NotificationItemInit {
     let resolved_icon = resolve_icon(
@@ -139,7 +139,7 @@ fn build_item_init(
         &notification.app_icon.get(),
         &notification.image_path.get(),
         &notification.desktop_entry.get(),
-        symbolic_fallback,
+        prefer_color,
     );
 
     NotificationItemInit {

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/mod.rs
@@ -25,6 +25,7 @@ pub(crate) struct NotificationGroup {
     total_count: usize,
 
     icon_source: IconSource,
+    symbolic_fallback: bool,
     group_icon: Option<String>,
 
     items: FactoryVecDeque<NotificationItem>,
@@ -170,7 +171,8 @@ impl FactoryComponent for NotificationGroup {
                 NotificationItemOutput::Dismissed(id) => NotificationGroupInput::ItemDismissed(id),
             });
 
-        let group_icon = Self::resolve_group_icon(init.icon_source, &init.notifications);
+        let group_icon =
+            Self::resolve_group_icon(init.icon_source, init.symbolic_fallback, &init.notifications);
 
         let mut model = Self {
             app_name: init.app_name,
@@ -180,6 +182,7 @@ impl FactoryComponent for NotificationGroup {
             overflow_count: 0,
             total_count: 0,
             icon_source: init.icon_source,
+            symbolic_fallback: init.symbolic_fallback,
             group_icon,
             items,
             notifications: Vec::new(),
@@ -242,7 +245,8 @@ impl FactoryComponent for NotificationGroup {
             }
 
             NotificationGroupInput::UpdateNotifications(notifications) => {
-                self.group_icon = Self::resolve_group_icon(self.icon_source, &notifications);
+                self.group_icon =
+                    Self::resolve_group_icon(self.icon_source, self.symbolic_fallback, &notifications);
                 self.reconcile_items(notifications);
             }
 

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/notification_group/mod.rs
@@ -25,7 +25,7 @@ pub(crate) struct NotificationGroup {
     total_count: usize,
 
     icon_source: IconSource,
-    symbolic_fallback: bool,
+    prefer_color: bool,
     group_icon: Option<String>,
 
     items: FactoryVecDeque<NotificationItem>,
@@ -172,7 +172,7 @@ impl FactoryComponent for NotificationGroup {
             });
 
         let group_icon =
-            Self::resolve_group_icon(init.icon_source, init.symbolic_fallback, &init.notifications);
+            Self::resolve_group_icon(init.icon_source, init.prefer_color, &init.notifications);
 
         let mut model = Self {
             app_name: init.app_name,
@@ -182,7 +182,7 @@ impl FactoryComponent for NotificationGroup {
             overflow_count: 0,
             total_count: 0,
             icon_source: init.icon_source,
-            symbolic_fallback: init.symbolic_fallback,
+            prefer_color: init.prefer_color,
             group_icon,
             items,
             notifications: Vec::new(),
@@ -246,7 +246,7 @@ impl FactoryComponent for NotificationGroup {
 
             NotificationGroupInput::UpdateNotifications(notifications) => {
                 self.group_icon =
-                    Self::resolve_group_icon(self.icon_source, self.symbolic_fallback, &notifications);
+                    Self::resolve_group_icon(self.icon_source, self.prefer_color, &notifications);
                 self.reconcile_items(notifications);
             }
 

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/watchers.rs
@@ -64,11 +64,11 @@ fn spawn_icon_source_watcher(
     config: &Arc<ConfigService>,
 ) {
     let icon_source = config.config().modules.notifications.icon_source.clone();
-    let symbolic_fallback = config.config().general.symbolic_icon_fallback.clone();
+    let prefer_color = config.config().general.prefer_color_icons.clone();
 
     watch!(
         sender,
-        [icon_source.watch(), symbolic_fallback.watch()],
+        [icon_source.watch(), prefer_color.watch()],
         |out| {
             let _ = out.send(NotificationDropdownCmd::IconSourceChanged);
         }

--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/watchers.rs
@@ -64,10 +64,15 @@ fn spawn_icon_source_watcher(
     config: &Arc<ConfigService>,
 ) {
     let icon_source = config.config().modules.notifications.icon_source.clone();
+    let symbolic_fallback = config.config().general.symbolic_icon_fallback.clone();
 
-    watch!(sender, [icon_source.watch()], |out| {
-        let _ = out.send(NotificationDropdownCmd::IconSourceChanged);
-    });
+    watch!(
+        sender,
+        [icon_source.watch(), symbolic_fallback.watch()],
+        |out| {
+            let _ = out.send(NotificationDropdownCmd::IconSourceChanged);
+        }
+    );
 }
 
 fn spawn_scale_watcher(

--- a/crates/wayle-shell/src/shell/bar/icons.rs
+++ b/crates/wayle-shell/src/shell/bar/icons.rs
@@ -3,9 +3,11 @@
 //! Patterns use glob syntax and match case-insensitively.
 //! Order matters - first match wins.
 
-use std::sync::OnceLock;
+use std::{cell::RefCell, collections::HashMap, sync::OnceLock};
 
 use glob::Pattern;
+use gtk4::{gdk, gio::prelude::AppInfoExt, glib::prelude::Cast as _, prelude::IconExt};
+use wayle_widgets::icons::icon_exists;
 
 struct CompiledEntry {
     pattern: Pattern,
@@ -273,4 +275,77 @@ pub(crate) fn lookup_app_icon(name: &str) -> Option<&'static str> {
         .iter()
         .find(|entry| entry.pattern.matches(&name_lower))
         .map(|entry| entry.icon)
+}
+
+thread_local! {
+    /// Caches `identifier -> symbolic icon name` resolutions. App→icon mappings
+    /// are stable, so this avoids repeated desktop-database and theme lookups on
+    /// every redraw. `None` (no symbolic variant) is cached too.
+    static SYMBOLIC_DESKTOP_CACHE: RefCell<HashMap<String, Option<String>>> =
+        RefCell::new(HashMap::new());
+}
+
+/// Resolves the `-symbolic` variant of an app's desktop-entry icon.
+///
+/// `identifier` is a desktop-entry id or window class (e.g. `org.gnome.Calendar`
+/// or `firefox`). Returns the symbolic icon name only if such a variant exists
+/// in the current icon theme — never a full-colour icon — so callers fall
+/// through to their own generic fallback otherwise. No-op (returns `None`) when
+/// there is no GDK display, so it is safe to call off-screen (e.g. in tests).
+pub(crate) fn symbolic_desktop_icon(identifier: &str) -> Option<String> {
+    if identifier.is_empty() {
+        return None;
+    }
+
+    SYMBOLIC_DESKTOP_CACHE.with(|cache| {
+        if let Some(cached) = cache.borrow().get(identifier) {
+            return cached.clone();
+        }
+        let resolved = resolve_symbolic_desktop_icon(identifier);
+        cache
+            .borrow_mut()
+            .insert(identifier.to_owned(), resolved.clone());
+        resolved
+    })
+}
+
+fn resolve_symbolic_desktop_icon(identifier: &str) -> Option<String> {
+    // Icon-theme lookups require a GDK display; bail out (rather than panic in
+    // `icon_exists`) when there isn't one.
+    gdk::Display::default()?;
+
+    let icon: String = lookup_desktop_entry(identifier)?.icon()?.to_string()?.into();
+    let base = icon.strip_suffix("-symbolic").unwrap_or(&icon);
+    let symbolic = format!("{base}-symbolic");
+
+    icon_exists(&symbolic).then_some(symbolic)
+}
+
+fn lookup_desktop_entry(identifier: &str) -> Option<gio_unix::DesktopAppInfo> {
+    let candidates = [
+        format!("{identifier}.desktop"),
+        format!("{}.desktop", identifier.to_lowercase()),
+    ];
+    for desktop_id in &candidates {
+        if let Some(app) = gio_unix::DesktopAppInfo::new(desktop_id) {
+            return Some(app);
+        }
+    }
+
+    find_by_startup_wm_class(identifier)
+}
+
+fn find_by_startup_wm_class(wm_class: &str) -> Option<gio_unix::DesktopAppInfo> {
+    let wm_class_lower = wm_class.to_lowercase();
+    for app_info in gtk4::gio::AppInfo::all() {
+        let Ok(desktop_app) = app_info.downcast::<gio_unix::DesktopAppInfo>() else {
+            continue;
+        };
+        if let Some(startup_class) = desktop_app.startup_wm_class()
+            && startup_class.to_lowercase() == wm_class_lower
+        {
+            return Some(desktop_app);
+        }
+    }
+    None
 }

--- a/crates/wayle-shell/src/shell/bar/icons.rs
+++ b/crates/wayle-shell/src/shell/bar/icons.rs
@@ -3,10 +3,15 @@
 //! Patterns use glob syntax and match case-insensitively.
 //! Order matters - first match wins.
 
-use std::{cell::RefCell, collections::HashMap, sync::OnceLock};
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::OnceLock,
+};
 
 use glob::Pattern;
-use gtk4::{gdk, gio::prelude::AppInfoExt, glib::prelude::Cast as _, prelude::IconExt};
+use gtk4::{gdk, glib};
 use wayle_widgets::icons::icon_exists;
 
 struct CompiledEntry {
@@ -279,7 +284,7 @@ pub(crate) fn lookup_app_icon(name: &str) -> Option<&'static str> {
 
 thread_local! {
     /// Caches `identifier -> symbolic icon name` resolutions. App→icon mappings
-    /// are stable, so this avoids repeated desktop-database and theme lookups on
+    /// are stable, so this avoids repeated desktop-file and theme lookups on
     /// every redraw. `None` (no symbolic variant) is cached too.
     static SYMBOLIC_DESKTOP_CACHE: RefCell<HashMap<String, Option<String>>> =
         RefCell::new(HashMap::new());
@@ -314,37 +319,91 @@ fn resolve_symbolic_desktop_icon(identifier: &str) -> Option<String> {
     // `icon_exists`) when there isn't one.
     gdk::Display::default()?;
 
-    let icon: String = lookup_desktop_entry(identifier)?.icon()?.to_string()?.into();
+    let icon = desktop_entry_icon(identifier)?;
     let base = icon.strip_suffix("-symbolic").unwrap_or(&icon);
     let symbolic = format!("{base}-symbolic");
 
     icon_exists(&symbolic).then_some(symbolic)
 }
 
-fn lookup_desktop_entry(identifier: &str) -> Option<gio_unix::DesktopAppInfo> {
-    let candidates = [
+/// Reads the `Icon=` value from an app's desktop entry — by desktop id first,
+/// then by matching `StartupWMClass`.
+///
+/// Reads the `.desktop` files directly (via `glib::KeyFile`) instead of going
+/// through `gio::DesktopAppInfo` / `AppInfo::all()`, which silently drop any app
+/// whose `Exec` program is not found in `$PATH`. That filtering would otherwise
+/// hide an app's icon whenever Wayle runs with a restricted `$PATH` (e.g. as a
+/// systemd user service whose unit sets a minimal `PATH`) even though the icon is
+/// installed — an app's icon does not depend on its binary being runnable.
+fn desktop_entry_icon(identifier: &str) -> Option<String> {
+    let ids = [
         format!("{identifier}.desktop"),
         format!("{}.desktop", identifier.to_lowercase()),
     ];
-    for desktop_id in &candidates {
-        if let Some(app) = gio_unix::DesktopAppInfo::new(desktop_id) {
-            return Some(app);
+    let dirs = application_dirs();
+
+    for id in &ids {
+        for dir in &dirs {
+            if let Some(icon) = read_desktop_icon(&dir.join(id)) {
+                return Some(icon);
+            }
         }
     }
 
-    find_by_startup_wm_class(identifier)
+    icon_by_startup_wm_class(&dirs, identifier)
 }
 
-fn find_by_startup_wm_class(wm_class: &str) -> Option<gio_unix::DesktopAppInfo> {
+/// The `applications` subdirectory of every XDG data directory
+/// (`$XDG_DATA_HOME` then each entry of `$XDG_DATA_DIRS`).
+fn application_dirs() -> Vec<PathBuf> {
+    let mut dirs = vec![glib::user_data_dir()];
+    dirs.extend(glib::system_data_dirs());
+    dirs.into_iter()
+        .map(|dir| dir.join("applications"))
+        .collect()
+}
+
+/// Reads `[Desktop Entry] Icon=` from a `.desktop` file, if present and non-empty.
+fn read_desktop_icon(path: &Path) -> Option<String> {
+    let keyfile = glib::KeyFile::new();
+    keyfile.load_from_file(path, glib::KeyFileFlags::NONE).ok()?;
+    desktop_icon_key(&keyfile)
+}
+
+fn desktop_icon_key(keyfile: &glib::KeyFile) -> Option<String> {
+    keyfile
+        .string("Desktop Entry", "Icon")
+        .ok()
+        .map(|icon| icon.to_string())
+        .filter(|icon| !icon.is_empty())
+}
+
+/// Scans `.desktop` files for one whose `StartupWMClass` matches `wm_class`
+/// (case-insensitively) and returns its `Icon=`.
+fn icon_by_startup_wm_class(dirs: &[PathBuf], wm_class: &str) -> Option<String> {
     let wm_class_lower = wm_class.to_lowercase();
-    for app_info in gtk4::gio::AppInfo::all() {
-        let Ok(desktop_app) = app_info.downcast::<gio_unix::DesktopAppInfo>() else {
+    for dir in dirs {
+        let Ok(entries) = std::fs::read_dir(dir) else {
             continue;
         };
-        if let Some(startup_class) = desktop_app.startup_wm_class()
-            && startup_class.to_lowercase() == wm_class_lower
-        {
-            return Some(desktop_app);
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("desktop") {
+                continue;
+            }
+            let keyfile = glib::KeyFile::new();
+            if keyfile.load_from_file(&path, glib::KeyFileFlags::NONE).is_err() {
+                continue;
+            }
+            let matches = keyfile
+                .string("Desktop Entry", "StartupWMClass")
+                .ok()
+                .is_some_and(|class| class.to_lowercase() == wm_class_lower);
+            if matches
+                && let Some(icon) = desktop_icon_key(&keyfile)
+            {
+                return Some(icon);
+            }
         }
     }
     None

--- a/crates/wayle-shell/src/shell/bar/icons.rs
+++ b/crates/wayle-shell/src/shell/bar/icons.rs
@@ -326,6 +326,43 @@ fn resolve_symbolic_desktop_icon(identifier: &str) -> Option<String> {
     icon_exists(&symbolic).then_some(symbolic)
 }
 
+thread_local! {
+    /// Caches `identifier -> colour icon name` resolutions, mirroring
+    /// [`SYMBOLIC_DESKTOP_CACHE`]. `None` (no colour variant) is cached too.
+    static COLOR_DESKTOP_CACHE: RefCell<HashMap<String, Option<String>>> =
+        RefCell::new(HashMap::new());
+}
+
+/// Resolves the full-colour variant of an app's desktop-entry icon.
+///
+/// The counterpart to [`symbolic_desktop_icon`]: returns the desktop entry's `Icon=`
+/// name only when it is non-symbolic and exists in the current icon theme (never a
+/// `-symbolic` name and never a bare filesystem path), so callers fall through to a
+/// symbolic icon otherwise. No-op (returns `None`) when there is no GDK display.
+pub(crate) fn color_desktop_icon(identifier: &str) -> Option<String> {
+    if identifier.is_empty() {
+        return None;
+    }
+
+    COLOR_DESKTOP_CACHE.with(|cache| {
+        if let Some(cached) = cache.borrow().get(identifier) {
+            return cached.clone();
+        }
+        let resolved = resolve_color_desktop_icon(identifier);
+        cache
+            .borrow_mut()
+            .insert(identifier.to_owned(), resolved.clone());
+        resolved
+    })
+}
+
+fn resolve_color_desktop_icon(identifier: &str) -> Option<String> {
+    gdk::Display::default()?;
+
+    let icon = desktop_entry_icon(identifier)?;
+    (!icon.ends_with("-symbolic") && icon_exists(&icon)).then_some(icon)
+}
+
 /// Reads the `Icon=` value from an app's desktop entry — by desktop id first,
 /// then by matching `StartupWMClass`.
 ///

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/button/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/button/mod.rs
@@ -257,7 +257,7 @@ pub(crate) fn build_button_init(
     config: &HyprlandWorkspacesConfig,
     clients: &[Arc<Client>],
     urgent_addresses: HashSet<Address>,
-    symbolic_fallback: bool,
+    prefer_color: bool,
 ) -> WorkspaceButtonInit {
     let workspace_map = config.workspace_map.get();
     let mapped_style = i32::try_from(ctx.id)
@@ -272,7 +272,7 @@ pub(crate) fn build_button_init(
         let icon_ctx = IconContext {
             user_map: &user_map,
             fallback: &fallback,
-            symbolic_fallback,
+            prefer_color,
         };
         let resolved =
             resolve_workspace_icons(ctx.id, clients, &icon_ctx, config.app_icons_dedupe.get());

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/button/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/button/mod.rs
@@ -257,6 +257,7 @@ pub(crate) fn build_button_init(
     config: &HyprlandWorkspacesConfig,
     clients: &[Arc<Client>],
     urgent_addresses: HashSet<Address>,
+    symbolic_fallback: bool,
 ) -> WorkspaceButtonInit {
     let workspace_map = config.workspace_map.get();
     let mapped_style = i32::try_from(ctx.id)
@@ -271,6 +272,7 @@ pub(crate) fn build_button_init(
         let icon_ctx = IconContext {
             user_map: &user_map,
             fallback: &fallback,
+            symbolic_fallback,
         };
         let resolved =
             resolve_workspace_icons(ctx.id, clients, &icon_ctx, config.app_icons_dedupe.get());

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/helpers.rs
@@ -9,12 +9,14 @@ use wayle_config::schemas::modules::{DisplayMode, Numbering};
 use wayle_hyprland::{Address, Client, WorkspaceId};
 
 use super::filtering::relative_workspace_number;
-use crate::shell::bar::icons::{DEFAULT_APP_ICON_MAP, matches_glob, symbolic_desktop_icon};
+use crate::shell::bar::icons::{
+    DEFAULT_APP_ICON_MAP, color_desktop_icon, matches_glob, symbolic_desktop_icon,
+};
 
 pub(crate) struct IconContext<'a> {
     pub user_map: &'a BTreeMap<String, String>,
     pub fallback: &'a str,
-    pub symbolic_fallback: bool,
+    pub prefer_color: bool,
 }
 
 pub(crate) struct WindowInfo<'a> {
@@ -52,15 +54,21 @@ pub(crate) fn resolve_app_icon(window: &WindowInfo<'_>, ctx: &IconContext<'_>) -
         }
     }
 
+    // Prefer the app's full-colour desktop icon over the built-in symbolic mapping when asked.
+    if ctx.prefer_color
+        && let Some(color) = color_desktop_icon(window.class)
+    {
+        return color;
+    }
+
     for (pattern, icon) in DEFAULT_APP_ICON_MAP {
         if matches_glob(window.class, &pattern.to_lowercase()) {
             return (*icon).to_string();
         }
     }
 
-    if ctx.symbolic_fallback
-        && let Some(symbolic) = symbolic_desktop_icon(window.class)
-    {
+    // Fall back to the app's symbolic desktop icon if one exists (always attempted).
+    if let Some(symbolic) = symbolic_desktop_icon(window.class) {
         return symbolic;
     }
 
@@ -302,7 +310,7 @@ mod tests {
             let ctx = IconContext {
                 user_map: &user_map,
                 fallback: "fallback-icon",
-                symbolic_fallback: false,
+                prefer_color: false,
             };
             let window = WindowInfo {
                 class: "kitty",
@@ -317,7 +325,7 @@ mod tests {
             let ctx = IconContext {
                 user_map: &user_map,
                 fallback: "fallback-icon",
-                symbolic_fallback: false,
+                prefer_color: false,
             };
             let window = WindowInfo {
                 class: "org.mozilla.firefox",
@@ -333,7 +341,7 @@ mod tests {
             let ctx = IconContext {
                 user_map: &user_map,
                 fallback: "fallback-icon",
-                symbolic_fallback: false,
+                prefer_color: false,
             };
             let window = WindowInfo {
                 class: "kitty",
@@ -349,7 +357,7 @@ mod tests {
             let ctx = IconContext {
                 user_map: &user_map,
                 fallback: "fallback-icon",
-                symbolic_fallback: false,
+                prefer_color: false,
             };
             let window = WindowInfo {
                 class: "firefox",
@@ -364,7 +372,7 @@ mod tests {
             let ctx = IconContext {
                 user_map: &user_map,
                 fallback: "fallback-icon",
-                symbolic_fallback: false,
+                prefer_color: false,
             };
             let window = WindowInfo {
                 class: "unknown-app",

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/helpers.rs
@@ -9,11 +9,12 @@ use wayle_config::schemas::modules::{DisplayMode, Numbering};
 use wayle_hyprland::{Address, Client, WorkspaceId};
 
 use super::filtering::relative_workspace_number;
-use crate::shell::bar::icons::{DEFAULT_APP_ICON_MAP, matches_glob};
+use crate::shell::bar::icons::{DEFAULT_APP_ICON_MAP, matches_glob, symbolic_desktop_icon};
 
 pub(crate) struct IconContext<'a> {
     pub user_map: &'a BTreeMap<String, String>,
     pub fallback: &'a str,
+    pub symbolic_fallback: bool,
 }
 
 pub(crate) struct WindowInfo<'a> {
@@ -55,6 +56,12 @@ pub(crate) fn resolve_app_icon(window: &WindowInfo<'_>, ctx: &IconContext<'_>) -
         if matches_glob(window.class, &pattern.to_lowercase()) {
             return (*icon).to_string();
         }
+    }
+
+    if ctx.symbolic_fallback
+        && let Some(symbolic) = symbolic_desktop_icon(window.class)
+    {
+        return symbolic;
     }
 
     ctx.fallback.to_string()
@@ -295,6 +302,7 @@ mod tests {
             let ctx = IconContext {
                 user_map: &user_map,
                 fallback: "fallback-icon",
+                symbolic_fallback: false,
             };
             let window = WindowInfo {
                 class: "kitty",
@@ -309,6 +317,7 @@ mod tests {
             let ctx = IconContext {
                 user_map: &user_map,
                 fallback: "fallback-icon",
+                symbolic_fallback: false,
             };
             let window = WindowInfo {
                 class: "org.mozilla.firefox",
@@ -324,6 +333,7 @@ mod tests {
             let ctx = IconContext {
                 user_map: &user_map,
                 fallback: "fallback-icon",
+                symbolic_fallback: false,
             };
             let window = WindowInfo {
                 class: "kitty",
@@ -339,6 +349,7 @@ mod tests {
             let ctx = IconContext {
                 user_map: &user_map,
                 fallback: "fallback-icon",
+                symbolic_fallback: false,
             };
             let window = WindowInfo {
                 class: "firefox",
@@ -353,6 +364,7 @@ mod tests {
             let ctx = IconContext {
                 user_map: &user_map,
                 fallback: "fallback-icon",
+                symbolic_fallback: false,
             };
             let window = WindowInfo {
                 class: "unknown-app",

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/methods.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/methods.rs
@@ -217,6 +217,7 @@ impl HyprlandWorkspaces {
 
         let config = self.config.config();
         let ws_config = &config.modules.hyprland_workspaces;
+        let symbolic_fallback = config.general.symbolic_icon_fallback.get();
         let is_vertical = self.is_vertical();
 
         self.update_border_classes(ws_config.border_show.get());
@@ -248,7 +249,7 @@ impl HyprlandWorkspaces {
                     is_urgent,
                     is_vertical,
                 };
-                build_button_init(&ctx, ws_config, &clients, urgent_addrs)
+                build_button_init(&ctx, ws_config, &clients, urgent_addrs, symbolic_fallback)
             })
             .collect();
 

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/methods.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/methods.rs
@@ -217,7 +217,7 @@ impl HyprlandWorkspaces {
 
         let config = self.config.config();
         let ws_config = &config.modules.hyprland_workspaces;
-        let symbolic_fallback = config.general.symbolic_icon_fallback.get();
+        let prefer_color = config.general.prefer_color_icons.get();
         let is_vertical = self.is_vertical();
 
         self.update_border_classes(ws_config.border_show.get());
@@ -249,7 +249,7 @@ impl HyprlandWorkspaces {
                     is_urgent,
                     is_vertical,
                 };
-                build_button_init(&ctx, ws_config, &clients, urgent_addrs, symbolic_fallback)
+                build_button_init(&ctx, ws_config, &clients, urgent_addrs, prefer_color)
             })
             .collect();
 

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/mod.rs
@@ -92,7 +92,7 @@ impl Component for HyprlandWorkspaces {
             Self::initial_active_workspace(&init.hyprland, &init.settings, monitor_specific);
         let focused_monitor = Self::initial_focused_monitor(&init.hyprland);
         let bar_scale = config.bar.scale.clone();
-        let symbolic_icon_fallback = config.general.symbolic_icon_fallback.clone();
+        let prefer_color = config.general.prefer_color_icons.clone();
 
         Self::spawn_load_workspace_rules(&sender, &init.hyprland);
 
@@ -102,7 +102,7 @@ impl Component for HyprlandWorkspaces {
             &init.hyprland,
             theme_provider,
             bar_scale,
-            symbolic_icon_fallback,
+            prefer_color,
             &init.settings,
         );
 

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/mod.rs
@@ -92,6 +92,7 @@ impl Component for HyprlandWorkspaces {
             Self::initial_active_workspace(&init.hyprland, &init.settings, monitor_specific);
         let focused_monitor = Self::initial_focused_monitor(&init.hyprland);
         let bar_scale = config.bar.scale.clone();
+        let symbolic_icon_fallback = config.general.symbolic_icon_fallback.clone();
 
         Self::spawn_load_workspace_rules(&sender, &init.hyprland);
 
@@ -101,6 +102,7 @@ impl Component for HyprlandWorkspaces {
             &init.hyprland,
             theme_provider,
             bar_scale,
+            symbolic_icon_fallback,
             &init.settings,
         );
 

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/watchers.rs
@@ -22,7 +22,7 @@ pub(super) fn spawn_watchers(
     hyprland: &Option<Arc<HyprlandService>>,
     theme_provider: ConfigProperty<ThemeProvider>,
     bar_scale: ConfigProperty<ScaleFactor>,
-    symbolic_icon_fallback: ConfigProperty<bool>,
+    prefer_color: ConfigProperty<bool>,
     settings: &BarSettings,
 ) {
     spawn_hyprland_watchers(sender, hyprland);
@@ -31,7 +31,7 @@ pub(super) fn spawn_watchers(
         config,
         theme_provider,
         bar_scale,
-        symbolic_icon_fallback,
+        prefer_color,
         settings,
     );
 }
@@ -152,7 +152,7 @@ fn spawn_config_watchers(
     config: &HyprlandWorkspacesConfig,
     theme_provider: ConfigProperty<ThemeProvider>,
     bar_scale: ConfigProperty<ScaleFactor>,
-    symbolic_icon_fallback: ConfigProperty<bool>,
+    prefer_color: ConfigProperty<bool>,
     settings: &BarSettings,
 ) {
     let min_count = config.min_workspace_count.clone();
@@ -216,7 +216,7 @@ fn spawn_config_watchers(
             app_icon_map.watch(),
             theme_provider.watch(),
             bar_scale.watch(),
-            symbolic_icon_fallback.watch(),
+            prefer_color.watch(),
             border_width.watch(),
             border_location.watch(),
             is_vertical.watch()

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/watchers.rs
@@ -22,10 +22,18 @@ pub(super) fn spawn_watchers(
     hyprland: &Option<Arc<HyprlandService>>,
     theme_provider: ConfigProperty<ThemeProvider>,
     bar_scale: ConfigProperty<ScaleFactor>,
+    symbolic_icon_fallback: ConfigProperty<bool>,
     settings: &BarSettings,
 ) {
     spawn_hyprland_watchers(sender, hyprland);
-    spawn_config_watchers(sender, config, theme_provider, bar_scale, settings);
+    spawn_config_watchers(
+        sender,
+        config,
+        theme_provider,
+        bar_scale,
+        symbolic_icon_fallback,
+        settings,
+    );
 }
 
 fn spawn_hyprland_watchers(
@@ -144,6 +152,7 @@ fn spawn_config_watchers(
     config: &HyprlandWorkspacesConfig,
     theme_provider: ConfigProperty<ThemeProvider>,
     bar_scale: ConfigProperty<ScaleFactor>,
+    symbolic_icon_fallback: ConfigProperty<bool>,
     settings: &BarSettings,
 ) {
     let min_count = config.min_workspace_count.clone();
@@ -207,6 +216,7 @@ fn spawn_config_watchers(
             app_icon_map.watch(),
             theme_provider.watch(),
             bar_scale.watch(),
+            symbolic_icon_fallback.watch(),
             border_width.watch(),
             border_location.watch(),
             is_vertical.watch()

--- a/crates/wayle-shell/src/shell/bar/modules/mango_workspaces/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/mango_workspaces/helpers.rs
@@ -4,7 +4,10 @@ use std::collections::HashMap;
 
 use wayle_config::schemas::modules::WorkspaceStyle;
 
-use crate::{glob, shell::bar::icons::DEFAULT_APP_ICON_MAP};
+use crate::{
+    glob,
+    shell::bar::icons::{DEFAULT_APP_ICON_MAP, symbolic_desktop_icon},
+};
 
 const TITLE_PREFIX: &str = "title:";
 const APP_PREFIX: &str = "app:";
@@ -32,6 +35,7 @@ pub(super) fn resolve_app_icon(
     title: Option<&str>,
     user_map: &HashMap<String, String>,
     fallback: &str,
+    symbolic_fallback: bool,
 ) -> String {
     let (title_entries, app_entries): (Vec<_>, Vec<_>) = user_map
         .iter()
@@ -53,6 +57,12 @@ pub(super) fn resolve_app_icon(
 
     if let Some(icon) = glob::find_match(DEFAULT_APP_ICON_MAP.iter().copied(), app_id) {
         return icon.to_string();
+    }
+
+    if symbolic_fallback
+        && let Some(symbolic) = symbolic_desktop_icon(app_id)
+    {
+        return symbolic;
     }
 
     fallback.to_string()
@@ -112,7 +122,7 @@ mod tests {
         let mut map = HashMap::new();
         map.insert(String::from("*firefox*"), String::from("ld-globe"));
         assert_eq!(
-            resolve_app_icon(Some("org.mozilla.firefox"), None, &map, "fallback"),
+            resolve_app_icon(Some("org.mozilla.firefox"), None, &map, "fallback", false),
             "ld-globe",
         );
     }
@@ -128,6 +138,7 @@ mod tests {
                 Some("YouTube - Firefox"),
                 &map,
                 "fallback",
+                false,
             ),
             "si-youtube",
         );
@@ -137,7 +148,7 @@ mod tests {
     fn resolve_app_icon_falls_back_when_no_match() {
         let map = HashMap::new();
         assert_eq!(
-            resolve_app_icon(Some("unknown.app"), Some("Unknown"), &map, "ld-default"),
+            resolve_app_icon(Some("unknown.app"), Some("Unknown"), &map, "ld-default", false),
             "ld-default",
         );
     }

--- a/crates/wayle-shell/src/shell/bar/modules/mango_workspaces/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/mango_workspaces/helpers.rs
@@ -6,7 +6,7 @@ use wayle_config::schemas::modules::WorkspaceStyle;
 
 use crate::{
     glob,
-    shell::bar::icons::{DEFAULT_APP_ICON_MAP, symbolic_desktop_icon},
+    shell::bar::icons::{DEFAULT_APP_ICON_MAP, color_desktop_icon, symbolic_desktop_icon},
 };
 
 const TITLE_PREFIX: &str = "title:";
@@ -35,7 +35,7 @@ pub(super) fn resolve_app_icon(
     title: Option<&str>,
     user_map: &HashMap<String, String>,
     fallback: &str,
-    symbolic_fallback: bool,
+    prefer_color: bool,
 ) -> String {
     let (title_entries, app_entries): (Vec<_>, Vec<_>) = user_map
         .iter()
@@ -55,13 +55,19 @@ pub(super) fn resolve_app_icon(
         return icon.to_string();
     }
 
+    // Prefer the app's full-colour desktop icon over the built-in symbolic mapping when asked.
+    if prefer_color
+        && let Some(color) = color_desktop_icon(app_id)
+    {
+        return color;
+    }
+
     if let Some(icon) = glob::find_match(DEFAULT_APP_ICON_MAP.iter().copied(), app_id) {
         return icon.to_string();
     }
 
-    if symbolic_fallback
-        && let Some(symbolic) = symbolic_desktop_icon(app_id)
-    {
+    // Fall back to the app's symbolic desktop icon if one exists (always attempted).
+    if let Some(symbolic) = symbolic_desktop_icon(app_id) {
         return symbolic;
     }
 

--- a/crates/wayle-shell/src/shell/bar/modules/mango_workspaces/methods.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/mango_workspaces/methods.rs
@@ -40,7 +40,7 @@ struct TagLayout {
     app_icon_map: HashMap<String, String>,
     tag_map: HashMap<String, WorkspaceStyle>,
     blink_on: bool,
-    symbolic_fallback: bool,
+    prefer_color: bool,
 }
 
 impl MangoWorkspaces {
@@ -68,7 +68,7 @@ impl MangoWorkspaces {
         let min_tag_count = tags_config.min_tag_count.get();
         let urgent_show = tags_config.urgent_show.get();
         let border_show = tags_config.border_show.get();
-        let symbolic_fallback = config.general.symbolic_icon_fallback.get();
+        let prefer_color = config.general.prefer_color_icons.get();
 
         let layout = TagLayout {
             display_mode: tags_config.display_mode.get(),
@@ -85,7 +85,7 @@ impl MangoWorkspaces {
             app_icon_map: tags_config.app_icon_map.get(),
             tag_map: tags_config.tag_map.get(),
             blink_on: self.blink_on,
-            symbolic_fallback,
+            prefer_color,
         };
 
         let monitor = self.chosen_monitor();
@@ -318,7 +318,7 @@ fn collect_app_icons(
     app_icon_map: &HashMap<String, String>,
     fallback: &str,
     dedupe: bool,
-    symbolic_fallback: bool,
+    prefer_color: bool,
 ) -> Vec<AppIconInit> {
     let mut result: Vec<AppIconInit> = Vec::with_capacity(clients.len());
 
@@ -328,7 +328,7 @@ fn collect_app_icons(
             client.title.as_deref(),
             app_icon_map,
             fallback,
-            symbolic_fallback,
+            prefer_color,
         );
 
         if dedupe && let Some(existing) = result.iter_mut().find(|init| init.icon_name == icon_name)
@@ -361,7 +361,7 @@ fn build_button_init(tag: &Tag, clients: &[Client], layout: &TagLayout) -> Mango
             &layout.app_icon_map,
             &layout.app_icons_fallback,
             layout.app_icons_dedupe,
-            layout.symbolic_fallback,
+            layout.prefer_color,
         )
     } else {
         Vec::new()

--- a/crates/wayle-shell/src/shell/bar/modules/mango_workspaces/methods.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/mango_workspaces/methods.rs
@@ -40,6 +40,7 @@ struct TagLayout {
     app_icon_map: HashMap<String, String>,
     tag_map: HashMap<String, WorkspaceStyle>,
     blink_on: bool,
+    symbolic_fallback: bool,
 }
 
 impl MangoWorkspaces {
@@ -67,6 +68,7 @@ impl MangoWorkspaces {
         let min_tag_count = tags_config.min_tag_count.get();
         let urgent_show = tags_config.urgent_show.get();
         let border_show = tags_config.border_show.get();
+        let symbolic_fallback = config.general.symbolic_icon_fallback.get();
 
         let layout = TagLayout {
             display_mode: tags_config.display_mode.get(),
@@ -83,6 +85,7 @@ impl MangoWorkspaces {
             app_icon_map: tags_config.app_icon_map.get(),
             tag_map: tags_config.tag_map.get(),
             blink_on: self.blink_on,
+            symbolic_fallback,
         };
 
         let monitor = self.chosen_monitor();
@@ -315,6 +318,7 @@ fn collect_app_icons(
     app_icon_map: &HashMap<String, String>,
     fallback: &str,
     dedupe: bool,
+    symbolic_fallback: bool,
 ) -> Vec<AppIconInit> {
     let mut result: Vec<AppIconInit> = Vec::with_capacity(clients.len());
 
@@ -324,6 +328,7 @@ fn collect_app_icons(
             client.title.as_deref(),
             app_icon_map,
             fallback,
+            symbolic_fallback,
         );
 
         if dedupe && let Some(existing) = result.iter_mut().find(|init| init.icon_name == icon_name)
@@ -356,6 +361,7 @@ fn build_button_init(tag: &Tag, clients: &[Client], layout: &TagLayout) -> Mango
             &layout.app_icon_map,
             &layout.app_icons_fallback,
             layout.app_icons_dedupe,
+            layout.symbolic_fallback,
         )
     } else {
         Vec::new()

--- a/crates/wayle-shell/src/shell/bar/modules/mango_workspaces/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/mango_workspaces/mod.rs
@@ -67,7 +67,7 @@ impl Component for MangoWorkspaces {
         let tags_config = &config.modules.mango_workspaces;
         let theme_provider = config.styling.theme_provider.clone();
         let bar_scale = config.bar.scale.clone();
-        let symbolic_icon_fallback = config.general.symbolic_icon_fallback.clone();
+        let prefer_color = config.general.prefer_color_icons.clone();
 
         watchers::spawn_watchers(
             &sender,
@@ -75,7 +75,7 @@ impl Component for MangoWorkspaces {
             init.mango.clone(),
             theme_provider,
             bar_scale,
-            symbolic_icon_fallback,
+            prefer_color,
             &init.settings,
         );
 

--- a/crates/wayle-shell/src/shell/bar/modules/mango_workspaces/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/mango_workspaces/mod.rs
@@ -67,6 +67,7 @@ impl Component for MangoWorkspaces {
         let tags_config = &config.modules.mango_workspaces;
         let theme_provider = config.styling.theme_provider.clone();
         let bar_scale = config.bar.scale.clone();
+        let symbolic_icon_fallback = config.general.symbolic_icon_fallback.clone();
 
         watchers::spawn_watchers(
             &sender,
@@ -74,6 +75,7 @@ impl Component for MangoWorkspaces {
             init.mango.clone(),
             theme_provider,
             bar_scale,
+            symbolic_icon_fallback,
             &init.settings,
         );
 

--- a/crates/wayle-shell/src/shell/bar/modules/mango_workspaces/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/mango_workspaces/watchers.rs
@@ -24,10 +24,18 @@ pub(super) fn spawn_watchers(
     mango: Arc<MangoService>,
     theme_provider: ConfigProperty<ThemeProvider>,
     bar_scale: ConfigProperty<ScaleFactor>,
+    symbolic_icon_fallback: ConfigProperty<bool>,
     settings: &BarSettings,
 ) {
     spawn_service_watcher(sender, mango);
-    spawn_config_watcher(sender, config, theme_provider, bar_scale, settings);
+    spawn_config_watcher(
+        sender,
+        config,
+        theme_provider,
+        bar_scale,
+        symbolic_icon_fallback,
+        settings,
+    );
 }
 
 fn spawn_service_watcher(sender: &ComponentSender<MangoWorkspaces>, mango: Arc<MangoService>) {
@@ -68,6 +76,7 @@ fn spawn_config_watcher(
     config: &MangoWorkspacesConfig,
     theme_provider: ConfigProperty<ThemeProvider>,
     bar_scale: ConfigProperty<ScaleFactor>,
+    symbolic_icon_fallback: ConfigProperty<bool>,
     settings: &BarSettings,
 ) {
     let (tx, rx) = mpsc::unbounded_channel();
@@ -75,6 +84,7 @@ fn spawn_config_watcher(
     config.subscribe_changes(tx.clone());
     theme_provider.subscribe_changes(tx.clone());
     bar_scale.subscribe_changes(tx.clone());
+    symbolic_icon_fallback.subscribe_changes(tx.clone());
     settings.border_width.subscribe_changes(tx.clone());
     settings.border_location.subscribe_changes(tx.clone());
     settings.is_vertical.subscribe_changes(tx);

--- a/crates/wayle-shell/src/shell/bar/modules/mango_workspaces/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/mango_workspaces/watchers.rs
@@ -24,7 +24,7 @@ pub(super) fn spawn_watchers(
     mango: Arc<MangoService>,
     theme_provider: ConfigProperty<ThemeProvider>,
     bar_scale: ConfigProperty<ScaleFactor>,
-    symbolic_icon_fallback: ConfigProperty<bool>,
+    prefer_color: ConfigProperty<bool>,
     settings: &BarSettings,
 ) {
     spawn_service_watcher(sender, mango);
@@ -33,7 +33,7 @@ pub(super) fn spawn_watchers(
         config,
         theme_provider,
         bar_scale,
-        symbolic_icon_fallback,
+        prefer_color,
         settings,
     );
 }
@@ -76,7 +76,7 @@ fn spawn_config_watcher(
     config: &MangoWorkspacesConfig,
     theme_provider: ConfigProperty<ThemeProvider>,
     bar_scale: ConfigProperty<ScaleFactor>,
-    symbolic_icon_fallback: ConfigProperty<bool>,
+    prefer_color: ConfigProperty<bool>,
     settings: &BarSettings,
 ) {
     let (tx, rx) = mpsc::unbounded_channel();
@@ -84,7 +84,7 @@ fn spawn_config_watcher(
     config.subscribe_changes(tx.clone());
     theme_provider.subscribe_changes(tx.clone());
     bar_scale.subscribe_changes(tx.clone());
-    symbolic_icon_fallback.subscribe_changes(tx.clone());
+    prefer_color.subscribe_changes(tx.clone());
     settings.border_width.subscribe_changes(tx.clone());
     settings.border_location.subscribe_changes(tx.clone());
     settings.is_vertical.subscribe_changes(tx);

--- a/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/helpers.rs
@@ -7,7 +7,7 @@ use wayle_config::schemas::modules::{LabelStrategy, WorkspaceStyle};
 
 use crate::{
     glob,
-    shell::bar::icons::{DEFAULT_APP_ICON_MAP, symbolic_desktop_icon},
+    shell::bar::icons::{DEFAULT_APP_ICON_MAP, color_desktop_icon, symbolic_desktop_icon},
 };
 
 const TITLE_PREFIX: &str = "title:";
@@ -90,15 +90,16 @@ pub(super) fn is_ignored(name: Option<&str>, idx: u8, id: u64, patterns: &[Strin
 /// Resolves the icon name for a window using the configured icon map.
 ///
 /// Lookup order: title-prefixed patterns against `title`, then app-prefixed
-/// or unprefixed patterns against `app_id`, then the built-in icon map. When
-/// `symbolic_fallback` is enabled and nothing matched, the app's symbolic
-/// desktop icon is tried before falling back to `fallback`.
+/// or unprefixed patterns against `app_id`. When `prefer_color` is set, the app's
+/// full-colour desktop icon is preferred over the built-in symbolic map; otherwise
+/// the built-in map wins. If nothing matched, the app's symbolic desktop icon is
+/// always tried before falling back to `fallback`.
 pub(super) fn resolve_app_icon(
     app_id: Option<&str>,
     title: Option<&str>,
     user_map: &BTreeMap<String, String>,
     fallback: &str,
-    symbolic_fallback: bool,
+    prefer_color: bool,
 ) -> String {
     let (title_entries, app_entries): (Vec<_>, Vec<_>) = user_map
         .iter()
@@ -118,13 +119,19 @@ pub(super) fn resolve_app_icon(
         return icon.to_string();
     }
 
+    // Prefer the app's full-colour desktop icon over the built-in symbolic mapping when asked.
+    if prefer_color
+        && let Some(color) = color_desktop_icon(app_id)
+    {
+        return color;
+    }
+
     if let Some(icon) = glob::find_match(DEFAULT_APP_ICON_MAP.iter().copied(), app_id) {
         return icon.to_string();
     }
 
-    if symbolic_fallback
-        && let Some(symbolic) = symbolic_desktop_icon(app_id)
-    {
+    // Fall back to the app's symbolic desktop icon if one exists (always attempted).
+    if let Some(symbolic) = symbolic_desktop_icon(app_id) {
         return symbolic;
     }
 

--- a/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/helpers.rs
@@ -5,7 +5,10 @@ use std::collections::BTreeMap;
 
 use wayle_config::schemas::modules::{LabelStrategy, WorkspaceStyle};
 
-use crate::{glob, shell::bar::icons::DEFAULT_APP_ICON_MAP};
+use crate::{
+    glob,
+    shell::bar::icons::{DEFAULT_APP_ICON_MAP, symbolic_desktop_icon},
+};
 
 const TITLE_PREFIX: &str = "title:";
 const APP_PREFIX: &str = "app:";
@@ -87,13 +90,15 @@ pub(super) fn is_ignored(name: Option<&str>, idx: u8, id: u64, patterns: &[Strin
 /// Resolves the icon name for a window using the configured icon map.
 ///
 /// Lookup order: title-prefixed patterns against `title`, then app-prefixed
-/// or unprefixed patterns against `app_id`. Falls back to `fallback` when
-/// nothing matches.
+/// or unprefixed patterns against `app_id`, then the built-in icon map. When
+/// `symbolic_fallback` is enabled and nothing matched, the app's symbolic
+/// desktop icon is tried before falling back to `fallback`.
 pub(super) fn resolve_app_icon(
     app_id: Option<&str>,
     title: Option<&str>,
     user_map: &BTreeMap<String, String>,
     fallback: &str,
+    symbolic_fallback: bool,
 ) -> String {
     let (title_entries, app_entries): (Vec<_>, Vec<_>) = user_map
         .iter()
@@ -115,6 +120,12 @@ pub(super) fn resolve_app_icon(
 
     if let Some(icon) = glob::find_match(DEFAULT_APP_ICON_MAP.iter().copied(), app_id) {
         return icon.to_string();
+    }
+
+    if symbolic_fallback
+        && let Some(symbolic) = symbolic_desktop_icon(app_id)
+    {
+        return symbolic;
     }
 
     fallback.to_string()
@@ -299,7 +310,7 @@ mod tests {
         let mut map = BTreeMap::new();
         map.insert(String::from("*firefox*"), String::from("ld-globe"));
         assert_eq!(
-            resolve_app_icon(Some("org.mozilla.firefox"), None, &map, "fallback"),
+            resolve_app_icon(Some("org.mozilla.firefox"), None, &map, "fallback", false),
             "ld-globe",
         );
     }
@@ -309,7 +320,7 @@ mod tests {
         let mut map = BTreeMap::new();
         map.insert(String::from("app:*firefox*"), String::from("ld-globe"));
         assert_eq!(
-            resolve_app_icon(Some("org.mozilla.firefox"), None, &map, "fallback"),
+            resolve_app_icon(Some("org.mozilla.firefox"), None, &map, "fallback", false),
             "ld-globe",
         );
     }
@@ -324,6 +335,7 @@ mod tests {
                 Some("YouTube - Firefox"),
                 &map,
                 "fallback",
+                false,
             ),
             "ld-youtube",
         );
@@ -340,6 +352,7 @@ mod tests {
                 Some("YouTube - Firefox"),
                 &map,
                 "fallback",
+                false,
             ),
             "ld-youtube",
         );
@@ -349,7 +362,13 @@ mod tests {
     fn resolve_app_icon_falls_back_when_no_match() {
         let map = BTreeMap::new();
         assert_eq!(
-            resolve_app_icon(Some("unknown.app"), Some("Unknown"), &map, "ld-default"),
+            resolve_app_icon(
+                Some("unknown.app"),
+                Some("Unknown"),
+                &map,
+                "ld-default",
+                false,
+            ),
             "ld-default",
         );
     }
@@ -357,7 +376,7 @@ mod tests {
     #[test]
     fn resolve_app_icon_uses_builtin_default_when_user_map_misses() {
         let map = BTreeMap::new();
-        let icon = resolve_app_icon(Some("firefox"), None, &map, "ld-default");
+        let icon = resolve_app_icon(Some("firefox"), None, &map, "ld-default", false);
         assert_ne!(
             icon, "ld-default",
             "expected a built-in mapping for firefox"
@@ -369,7 +388,7 @@ mod tests {
         let mut map = BTreeMap::new();
         map.insert(String::from("*firefox*"), String::from("my-override"));
         assert_eq!(
-            resolve_app_icon(Some("firefox"), None, &map, "ld-default"),
+            resolve_app_icon(Some("firefox"), None, &map, "ld-default", false),
             "my-override",
         );
     }
@@ -379,7 +398,7 @@ mod tests {
         let mut map = BTreeMap::new();
         map.insert(String::from("title:*Doc*"), String::from("ld-document"));
         assert_eq!(
-            resolve_app_icon(None, Some("Document Reader"), &map, "fallback"),
+            resolve_app_icon(None, Some("Document Reader"), &map, "fallback", false),
             "ld-document",
         );
     }
@@ -389,7 +408,7 @@ mod tests {
         let mut map = BTreeMap::new();
         map.insert(String::from("*firefox*"), String::from("ld-globe"));
         assert_eq!(
-            resolve_app_icon(Some("org.mozilla.firefox"), None, &map, "fallback"),
+            resolve_app_icon(Some("org.mozilla.firefox"), None, &map, "fallback", false),
             "ld-globe",
         );
     }

--- a/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/methods.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/methods.rs
@@ -54,7 +54,7 @@ impl NiriWorkspaces {
         let config = self.config.config();
         let ws_config = &config.modules.niri_workspaces;
 
-        let symbolic_fallback = config.general.symbolic_icon_fallback.get();
+        let prefer_color = config.general.prefer_color_icons.get();
         let ignore_patterns = ws_config.workspace_ignore.get();
         let ctx = FilterContext {
             monitor_specific: ws_config.monitor_specific.get(),
@@ -97,7 +97,7 @@ impl NiriWorkspaces {
             app_icons_fallback: ws_config.app_icons_fallback.get(),
             app_icon_map: ws_config.app_icon_map.get(),
             workspace_map: ws_config.workspace_map.get(),
-            symbolic_fallback,
+            prefer_color,
             blink_on: self.blink_on,
         };
 
@@ -254,7 +254,7 @@ struct ButtonLayout {
     app_icons_fallback: String,
     app_icon_map: BTreeMap<String, String>,
     workspace_map: NiriWorkspaceMap,
-    symbolic_fallback: bool,
+    prefer_color: bool,
     blink_on: bool,
 }
 
@@ -315,7 +315,7 @@ fn collect_app_icons(
     app_icon_map: &BTreeMap<String, String>,
     fallback: &str,
     dedupe: bool,
-    symbolic_fallback: bool,
+    prefer_color: bool,
 ) -> Vec<AppIconInit> {
     let mut result: Vec<AppIconInit> = Vec::with_capacity(windows.len());
     for window in windows {
@@ -324,7 +324,7 @@ fn collect_app_icons(
             window.title.get().as_deref(),
             app_icon_map,
             fallback,
-            symbolic_fallback,
+            prefer_color,
         );
         let window_id = window.id.get();
         if dedupe && let Some(existing) = result.iter_mut().find(|init| init.icon_name == icon_name)
@@ -357,7 +357,7 @@ fn build_button_init(
             &layout.app_icon_map,
             &layout.app_icons_fallback,
             layout.app_icons_dedupe,
-            layout.symbolic_fallback,
+            layout.prefer_color,
         )
     } else {
         Vec::new()

--- a/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/methods.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/methods.rs
@@ -54,6 +54,7 @@ impl NiriWorkspaces {
         let config = self.config.config();
         let ws_config = &config.modules.niri_workspaces;
 
+        let symbolic_fallback = config.general.symbolic_icon_fallback.get();
         let ignore_patterns = ws_config.workspace_ignore.get();
         let ctx = FilterContext {
             monitor_specific: ws_config.monitor_specific.get(),
@@ -96,6 +97,7 @@ impl NiriWorkspaces {
             app_icons_fallback: ws_config.app_icons_fallback.get(),
             app_icon_map: ws_config.app_icon_map.get(),
             workspace_map: ws_config.workspace_map.get(),
+            symbolic_fallback,
             blink_on: self.blink_on,
         };
 
@@ -252,6 +254,7 @@ struct ButtonLayout {
     app_icons_fallback: String,
     app_icon_map: BTreeMap<String, String>,
     workspace_map: NiriWorkspaceMap,
+    symbolic_fallback: bool,
     blink_on: bool,
 }
 
@@ -312,6 +315,7 @@ fn collect_app_icons(
     app_icon_map: &BTreeMap<String, String>,
     fallback: &str,
     dedupe: bool,
+    symbolic_fallback: bool,
 ) -> Vec<AppIconInit> {
     let mut result: Vec<AppIconInit> = Vec::with_capacity(windows.len());
     for window in windows {
@@ -320,6 +324,7 @@ fn collect_app_icons(
             window.title.get().as_deref(),
             app_icon_map,
             fallback,
+            symbolic_fallback,
         );
         let window_id = window.id.get();
         if dedupe && let Some(existing) = result.iter_mut().find(|init| init.icon_name == icon_name)
@@ -352,6 +357,7 @@ fn build_button_init(
             &layout.app_icon_map,
             &layout.app_icons_fallback,
             layout.app_icons_dedupe,
+            layout.symbolic_fallback,
         )
     } else {
         Vec::new()

--- a/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/mod.rs
@@ -68,7 +68,7 @@ impl Component for NiriWorkspaces {
         let workspaces_config = &config.modules.niri_workspaces;
         let theme_provider = config.styling.theme_provider.clone();
         let bar_scale = config.bar.scale.clone();
-        let symbolic_icon_fallback = config.general.symbolic_icon_fallback.clone();
+        let prefer_color = config.general.prefer_color_icons.clone();
 
         watchers::spawn_watchers(
             &sender,
@@ -76,7 +76,7 @@ impl Component for NiriWorkspaces {
             init.niri.clone(),
             theme_provider,
             bar_scale,
-            symbolic_icon_fallback,
+            prefer_color,
             &init.settings,
         );
 

--- a/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/mod.rs
@@ -68,6 +68,7 @@ impl Component for NiriWorkspaces {
         let workspaces_config = &config.modules.niri_workspaces;
         let theme_provider = config.styling.theme_provider.clone();
         let bar_scale = config.bar.scale.clone();
+        let symbolic_icon_fallback = config.general.symbolic_icon_fallback.clone();
 
         watchers::spawn_watchers(
             &sender,
@@ -75,6 +76,7 @@ impl Component for NiriWorkspaces {
             init.niri.clone(),
             theme_provider,
             bar_scale,
+            symbolic_icon_fallback,
             &init.settings,
         );
 

--- a/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/watchers.rs
@@ -23,7 +23,7 @@ pub(super) fn spawn_watchers(
     niri: Arc<NiriService>,
     theme_provider: ConfigProperty<ThemeProvider>,
     bar_scale: ConfigProperty<ScaleFactor>,
-    symbolic_icon_fallback: ConfigProperty<bool>,
+    prefer_color: ConfigProperty<bool>,
     settings: &BarSettings,
 ) {
     spawn_niri_events(sender, niri);
@@ -32,7 +32,7 @@ pub(super) fn spawn_watchers(
         config,
         theme_provider,
         bar_scale,
-        symbolic_icon_fallback,
+        prefer_color,
         settings,
     );
 }
@@ -83,7 +83,7 @@ fn spawn_config_watcher(
     config: &NiriWorkspacesConfig,
     theme_provider: ConfigProperty<ThemeProvider>,
     bar_scale: ConfigProperty<ScaleFactor>,
-    symbolic_icon_fallback: ConfigProperty<bool>,
+    prefer_color: ConfigProperty<bool>,
     settings: &BarSettings,
 ) {
     let (tx, rx) = mpsc::unbounded_channel();
@@ -91,7 +91,7 @@ fn spawn_config_watcher(
     config.subscribe_changes(tx.clone());
     theme_provider.subscribe_changes(tx.clone());
     bar_scale.subscribe_changes(tx.clone());
-    symbolic_icon_fallback.subscribe_changes(tx.clone());
+    prefer_color.subscribe_changes(tx.clone());
     settings.border_width.subscribe_changes(tx.clone());
     settings.border_location.subscribe_changes(tx.clone());
     settings.is_vertical.subscribe_changes(tx);

--- a/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/watchers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/watchers.rs
@@ -23,10 +23,18 @@ pub(super) fn spawn_watchers(
     niri: Arc<NiriService>,
     theme_provider: ConfigProperty<ThemeProvider>,
     bar_scale: ConfigProperty<ScaleFactor>,
+    symbolic_icon_fallback: ConfigProperty<bool>,
     settings: &BarSettings,
 ) {
     spawn_niri_events(sender, niri);
-    spawn_config_watcher(sender, config, theme_provider, bar_scale, settings);
+    spawn_config_watcher(
+        sender,
+        config,
+        theme_provider,
+        bar_scale,
+        symbolic_icon_fallback,
+        settings,
+    );
 }
 
 fn spawn_niri_events(sender: &ComponentSender<NiriWorkspaces>, niri: Arc<NiriService>) {
@@ -75,6 +83,7 @@ fn spawn_config_watcher(
     config: &NiriWorkspacesConfig,
     theme_provider: ConfigProperty<ThemeProvider>,
     bar_scale: ConfigProperty<ScaleFactor>,
+    symbolic_icon_fallback: ConfigProperty<bool>,
     settings: &BarSettings,
 ) {
     let (tx, rx) = mpsc::unbounded_channel();
@@ -82,6 +91,7 @@ fn spawn_config_watcher(
     config.subscribe_changes(tx.clone());
     theme_provider.subscribe_changes(tx.clone());
     bar_scale.subscribe_changes(tx.clone());
+    symbolic_icon_fallback.subscribe_changes(tx.clone());
     settings.border_width.subscribe_changes(tx.clone());
     settings.border_location.subscribe_changes(tx.clone());
     settings.is_vertical.subscribe_changes(tx);

--- a/crates/wayle-shell/src/shell/notification_popup/card/mod.rs
+++ b/crates/wayle-shell/src/shell/notification_popup/card/mod.rs
@@ -144,14 +144,14 @@ impl Component for NotificationPopupCard {
     ) -> ComponentParts<Self> {
         let notif = &init.notification;
 
-        let symbolic_fallback = init.config.config().general.symbolic_icon_fallback.get();
+        let prefer_color = init.config.config().general.prefer_color_icons.get();
         let resolved_icon = resolve_icon(
             init.icon_source,
             &notif.app_name.get(),
             &notif.app_icon.get(),
             &notif.image_path.get(),
             &notif.desktop_entry.get(),
-            symbolic_fallback,
+            prefer_color,
         );
 
         let app_label = notif

--- a/crates/wayle-shell/src/shell/notification_popup/card/mod.rs
+++ b/crates/wayle-shell/src/shell/notification_popup/card/mod.rs
@@ -144,12 +144,14 @@ impl Component for NotificationPopupCard {
     ) -> ComponentParts<Self> {
         let notif = &init.notification;
 
+        let symbolic_fallback = init.config.config().general.symbolic_icon_fallback.get();
         let resolved_icon = resolve_icon(
             init.icon_source,
             &notif.app_name.get(),
             &notif.app_icon.get(),
             &notif.image_path.get(),
             &notif.desktop_entry.get(),
+            symbolic_fallback,
         );
 
         let app_label = notif

--- a/crates/wayle-shell/src/shell/notification_popup/helpers.rs
+++ b/crates/wayle-shell/src/shell/notification_popup/helpers.rs
@@ -3,7 +3,7 @@ use relm4::gtk::{glib, pango};
 use wayle_config::schemas::modules::notification::{IconSource, UrgencyBarThreshold};
 use wayle_notification::types::Urgency;
 
-use crate::shell::bar::icons::lookup_app_icon;
+use crate::shell::bar::icons::{lookup_app_icon, symbolic_desktop_icon};
 
 const FALLBACK_ICON: &str = "ld-bell-symbolic";
 const MINUTES_PER_HOUR: i64 = 60;
@@ -77,16 +77,17 @@ pub(crate) fn resolve_icon(
     app_icon: &Option<String>,
     image_path: &Option<String>,
     desktop_entry: &Option<String>,
+    symbolic_fallback: bool,
 ) -> ResolvedIcon {
     match icon_source {
-        IconSource::Mapped => mapped_icon(app_name),
+        IconSource::Mapped => mapped_icon(app_name, desktop_entry, symbolic_fallback),
 
         IconSource::Automatic => {
             if let Some(resolved) = try_icon_string(image_path) {
                 return resolved;
             }
 
-            mapped_icon(app_name)
+            mapped_icon(app_name, desktop_entry, symbolic_fallback)
         }
 
         IconSource::Application => {
@@ -104,7 +105,7 @@ pub(crate) fn resolve_icon(
                 return ResolvedIcon::Named(entry.clone());
             }
 
-            mapped_icon(app_name)
+            mapped_icon(app_name, desktop_entry, symbolic_fallback)
         }
     }
 }
@@ -122,13 +123,26 @@ fn try_icon_string(value: &Option<String>) -> Option<ResolvedIcon> {
     }
 }
 
-fn mapped_icon(app_name: &Option<String>) -> ResolvedIcon {
-    let name = app_name
-        .as_deref()
-        .and_then(lookup_app_icon)
-        .unwrap_or(FALLBACK_ICON);
+fn mapped_icon(
+    app_name: &Option<String>,
+    desktop_entry: &Option<String>,
+    symbolic_fallback: bool,
+) -> ResolvedIcon {
+    if let Some(name) = app_name.as_deref().and_then(lookup_app_icon) {
+        return ResolvedIcon::Named(String::from(name));
+    }
 
-    ResolvedIcon::Named(String::from(name))
+    if symbolic_fallback
+        && let Some(id) = desktop_entry
+            .as_deref()
+            .filter(|entry| !entry.is_empty())
+            .or(app_name.as_deref())
+        && let Some(symbolic) = symbolic_desktop_icon(id)
+    {
+        return ResolvedIcon::Named(symbolic);
+    }
+
+    ResolvedIcon::Named(String::from(FALLBACK_ICON))
 }
 
 #[cfg(test)]

--- a/crates/wayle-shell/src/shell/notification_popup/helpers.rs
+++ b/crates/wayle-shell/src/shell/notification_popup/helpers.rs
@@ -3,7 +3,7 @@ use relm4::gtk::{glib, pango};
 use wayle_config::schemas::modules::notification::{IconSource, UrgencyBarThreshold};
 use wayle_notification::types::Urgency;
 
-use crate::shell::bar::icons::{lookup_app_icon, symbolic_desktop_icon};
+use crate::shell::bar::icons::{color_desktop_icon, lookup_app_icon, symbolic_desktop_icon};
 
 const FALLBACK_ICON: &str = "ld-bell-symbolic";
 const MINUTES_PER_HOUR: i64 = 60;
@@ -77,17 +77,17 @@ pub(crate) fn resolve_icon(
     app_icon: &Option<String>,
     image_path: &Option<String>,
     desktop_entry: &Option<String>,
-    symbolic_fallback: bool,
+    prefer_color: bool,
 ) -> ResolvedIcon {
     match icon_source {
-        IconSource::Mapped => mapped_icon(app_name, desktop_entry, symbolic_fallback),
+        IconSource::Mapped => mapped_icon(app_name, desktop_entry, prefer_color),
 
         IconSource::Automatic => {
             if let Some(resolved) = try_icon_string(image_path) {
                 return resolved;
             }
 
-            mapped_icon(app_name, desktop_entry, symbolic_fallback)
+            mapped_icon(app_name, desktop_entry, prefer_color)
         }
 
         IconSource::Application => {
@@ -105,7 +105,7 @@ pub(crate) fn resolve_icon(
                 return ResolvedIcon::Named(entry.clone());
             }
 
-            mapped_icon(app_name, desktop_entry, symbolic_fallback)
+            mapped_icon(app_name, desktop_entry, prefer_color)
         }
     }
 }
@@ -126,17 +126,29 @@ fn try_icon_string(value: &Option<String>) -> Option<ResolvedIcon> {
 fn mapped_icon(
     app_name: &Option<String>,
     desktop_entry: &Option<String>,
-    symbolic_fallback: bool,
+    prefer_color: bool,
 ) -> ResolvedIcon {
+    let identifier = desktop_entry
+        .as_deref()
+        .filter(|entry| !entry.is_empty())
+        .or(app_name.as_deref());
+
+    // When colour icons are preferred, an app's full-colour desktop icon wins over the
+    // built-in symbolic mapping; only if there is none do we fall through to symbolic.
+    if prefer_color
+        && let Some(id) = identifier
+        && let Some(color) = color_desktop_icon(id)
+    {
+        return ResolvedIcon::Named(color);
+    }
+
     if let Some(name) = app_name.as_deref().and_then(lookup_app_icon) {
         return ResolvedIcon::Named(String::from(name));
     }
 
-    if symbolic_fallback
-        && let Some(id) = desktop_entry
-            .as_deref()
-            .filter(|entry| !entry.is_empty())
-            .or(app_name.as_deref())
+    // Fall back to the app's symbolic desktop icon if one exists (previously gated behind
+    // the removed `symbolic-icon-fallback` option — now always attempted).
+    if let Some(id) = identifier
         && let Some(symbolic) = symbolic_desktop_icon(id)
     {
         return ResolvedIcon::Named(symbolic);


### PR DESCRIPTION
Adds a `general.symbolic-icon-fallback` setting. When enabled, the workspaces (hyprland, niri, Mango) and notifications modules will fall back to using the symbolic variant of an application's desktop file icon when there is no `mapped_icon`. A good test case is GNOME Clock (test notifications by setting a timer and closing it from the foreground).

Tested for Hyprland workspaces and Notifications; needs testing for Niri and Mango.

Note: this has nontrivial merge conflicts with another of my outstanding PRs (#321); see [this merge commit](https://github.com/waltmck/wayle/commit/160a9c7c0085ebc5cf51661507180e73e44dea2e).