### PR TITLE
fix: set cursor to pointer when hovering workspace buttons

### DIFF
--- a/crates/wayle-idle-inhibit/build.rs
+++ b/crates/wayle-idle-inhibit/build.rs
@@ -1,9 +1,11 @@
 //! Build script for wayle-idle-inhibit.
 //!
-//! this crate intentionally does not force link order for
-//! libwayland-client. Binaries that also use `gtk4-layer-shell` must ensure
-//! `gtk4-layer-shell` is linked before `wayland-client` so its interposition
-//! works. Handle that in the final binary (via its build script).
+//! libwayland-client is linked via `#[link(name = "wayland-client")]` on the
+//! FFI extern block in `src/ffi.rs`, so it is always retained regardless of
+//! linker `--as-needed` ordering, in every binary and test depending on this
+//! crate. This build script therefore forces no link order. Binaries that also
+//! use `gtk4-layer-shell` must still ensure it is linked before wayland-client
+//! for its interposition to work; handle that in the final binary/shell.
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");

--- a/crates/wayle-idle-inhibit/src/ffi.rs
+++ b/crates/wayle-idle-inhibit/src/ffi.rs
@@ -173,6 +173,14 @@ mod sys {
 
     use super::{WlInterface, WlProxy};
 
+    // Declare the library these symbols come from so rustc emits
+    // `-lwayland-client` adjacent to this crate's objects. This keeps it out of
+    // reach of the linker's `--as-needed` pruning (which can otherwise drop a
+    // `-lwayland-client` that appears before the code referencing it, depending
+    // on link ordering) and propagates the link requirement to every binary and
+    // test that depends on this crate. gtk4-layer-shell interposition ordering
+    // is still the final binary's concern (see the shell's build script).
+    #[link(name = "wayland-client")]
     unsafe extern "C" {
         pub fn wl_display_roundtrip(display: *mut super::WlDisplay) -> c_int;
         pub fn wl_proxy_add_listener(

--- a/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/button/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprland_workspaces/button/mod.rs
@@ -118,6 +118,8 @@ impl FactoryComponent for WorkspaceButton {
     view! {
         #[root]
         gtk::Button {
+            set_cursor_from_name: Some("pointer"),
+
             #[watch]
             set_css_classes: &self.current_css_classes(),
 

--- a/crates/wayle-shell/src/shell/bar/modules/mango_workspaces/button/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/mango_workspaces/button/mod.rs
@@ -83,6 +83,8 @@ impl FactoryComponent for MangoTagButton {
     view! {
         #[root]
         gtk::Button {
+            set_cursor_from_name: Some("pointer"),
+
             set_css_classes: &self.classes.iter().map(String::as_str).collect::<Vec<_>>(),
 
             connect_clicked[sender, index = self.index] => move |_| {

--- a/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/button/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/niri_workspaces/button/mod.rs
@@ -87,6 +87,8 @@ impl FactoryComponent for NiriWorkspaceButton {
     view! {
         #[root]
         gtk::Button {
+            set_cursor_from_name: Some("pointer"),
+
             set_css_classes: &self.classes.iter().map(String::as_str).collect::<Vec<_>>(),
 
             connect_clicked[sender, id = self.id] => move |_| {


### PR DESCRIPTION
Every other clickable button in Wayle makes your cursor a pointer on hover; I assume that this was an oversight. Tested with Hyprland but not Niri or Mango, though I am confident it will behave the same since it is a one-line change.