### PR TITLE
feat(battery): support profile-based charge limit UI messages

### DIFF
--- a/crates/wayle-shell/locales/en-US/dropdowns/_battery.ftl
+++ b/crates/wayle-shell/locales/en-US/dropdowns/_battery.ftl
@@ -27,6 +27,8 @@ dropdown-battery-charge-limit = Charge Limit
 dropdown-battery-limit-to = Limit to { $threshold }%
 dropdown-battery-resumes-at = Resumes charging at { $threshold }%
 dropdown-battery-charge-limit-not-supported = Charge limit not supported on this device
+dropdown-battery-charge-limit-optimized = Optimized Battery Health
+dropdown-battery-charge-limit-optimized-subtitle = Prolongs lifespan by limiting full charges
 
 ## Power Profile
 dropdown-battery-power-profile = Power Profile

--- a/crates/wayle-shell/locales/fr/dropdowns/_battery.ftl
+++ b/crates/wayle-shell/locales/fr/dropdowns/_battery.ftl
@@ -27,6 +27,8 @@ dropdown-battery-charge-limit = Limite de charge
 dropdown-battery-limit-to = Limiter à { $threshold } %
 dropdown-battery-resumes-at = Reprend la charge à { $threshold } %
 dropdown-battery-charge-limit-not-supported = Limite de charge non prise en charge sur cet appareil
+dropdown-battery-charge-limit-optimized = Santé de batterie optimisée
+dropdown-battery-charge-limit-optimized-subtitle = Prolonge la durée de vie en limitant les charges complètes
 
 ## Profil d'alimentation
 dropdown-battery-power-profile = Profil d'alimentation

--- a/crates/wayle-shell/src/shell/bar/dropdowns/battery/battery_section/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/battery/battery_section/mod.rs
@@ -244,20 +244,28 @@ impl Component for BatterySection {
                                 add_css_class: "charge-limit-title",
                                 set_halign: gtk::Align::Start,
                                 #[watch]
-                                set_label: &t!(
-                                    "dropdown-battery-limit-to",
-                                    threshold = model.charge_end_threshold.to_string()
-                                ),
+                                set_label: &if model.charge_end_threshold == 0 {
+                                    t!("dropdown-battery-charge-limit-optimized")
+                                } else {
+                                    t!(
+                                        "dropdown-battery-limit-to",
+                                        threshold = model.charge_end_threshold.to_string()
+                                    )
+                                },
                             },
 
                             gtk::Label {
                                 add_css_class: "charge-limit-subtitle",
                                 set_halign: gtk::Align::Start,
                                 #[watch]
-                                set_label: &t!(
-                                    "dropdown-battery-resumes-at",
-                                    threshold = model.resume_threshold().to_string()
-                                ),
+                                set_label: &if model.charge_end_threshold == 0 {
+                                    t!("dropdown-battery-charge-limit-optimized-subtitle")
+                                } else {
+                                    t!(
+                                        "dropdown-battery-resumes-at",
+                                        threshold = model.resume_threshold().to_string()
+                                    )
+                                },
                             },
                         },
 


### PR DESCRIPTION


## Objective
The battery dropdown currently assumes charge limits are strictly percentage-based numeric thresholds. However, certain laptops (like Lenovo IdeaPads and other brands) use sysfs profile-based charge limits (e.g., `Long_Life` vs `Standard`), which UPower abstracts. When these profile-based limits are active, the backend returns a threshold of `0`, causing the UI to confusingly display "Limit to 0%".

- Fixes #296

**Backend Context:** This PR depends on [wayle-services#38](https://github.com/wayle-rs/wayle-services/pull/38), which implements the fallback mechanism to detect and handle profile-based limits.

## Solution
Updated `BatterySection` to handle `0` percentage limits as profile-based optimized limits rather than literal zero percent:

- Added localization keys for English and French: `dropdown-battery-charge-limit-optimized` and `dropdown-battery-charge-limit-optimized-subtitle`
- Updated `wayle-shell/src/shell/bar/dropdowns/battery/battery_section/mod.rs` to detect when `model.charge_end_threshold == 0`
- Displays "Optimized Battery Health" with subtitle "Prolongs lifespan by limiting full charges" instead of "Limit to 0%"
- Numeric percentage limits (e.g., `80`) continue to display normally

## Test Plan
- Tested locally on a Lenovo laptop using `charge_types` (profile-based limits)
- Verified UI displays the new localized strings when charge threshold is `0`
- Verified traditional numeric percentage limits still display correctly