### PR TITLE
fix(notifications): resolve app label from desktop-entry when app_nae is missing

### DIFF
--- a/crates/wayle-shell/src/shell/bar/dropdowns/notification/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/dropdowns/notification/helpers.rs
@@ -2,6 +2,8 @@ use std::{cmp::Reverse, collections::HashMap, sync::Arc};
 
 use wayle_notification::core::notification::Notification;
 
+use crate::shell::notification_popup::helpers::desktop_entry_app_label;
+
 pub(super) struct NotificationGroupData {
     pub app_name: Option<String>,
     pub notifications: Vec<Arc<Notification>>,
@@ -15,7 +17,10 @@ pub(super) fn group_by_app(notifications: &[Arc<Notification>]) -> Vec<Notificat
     let mut groups: HashMap<Option<String>, Vec<Arc<Notification>>> = HashMap::new();
 
     for notification in notifications {
-        let key = notification.app_name.get();
+        let key = notification
+            .app_name
+            .get()
+            .or_else(|| desktop_entry_app_label(notification.desktop_entry.get()));
         groups.entry(key).or_default().push(notification.clone());
     }
 

--- a/crates/wayle-shell/src/shell/notification_popup/card/mod.rs
+++ b/crates/wayle-shell/src/shell/notification_popup/card/mod.rs
@@ -13,8 +13,8 @@ use wayle_notification::{NotificationService, core::notification::Notification};
 
 use super::{
     helpers::{
-        ResolvedIcon, relative_time, resolve_icon, sanitize_markup, urgency_bar_visible,
-        urgency_css_class,
+        ResolvedIcon, desktop_entry_app_label, relative_time, resolve_icon, sanitize_markup,
+        urgency_bar_visible, urgency_css_class,
     },
     templates::NotificationContentTemplate,
 };
@@ -155,6 +155,7 @@ impl Component for NotificationPopupCard {
         let app_label = notif
             .app_name
             .get()
+            .or_else(|| desktop_entry_app_label(notif.desktop_entry.get()))
             .unwrap_or_else(|| t!("notification-popup-unknown-app"));
 
         let time_label = Self::format_time_label(relative_time(&notif.timestamp.get()));

--- a/crates/wayle-shell/src/shell/notification_popup/helpers.rs
+++ b/crates/wayle-shell/src/shell/notification_popup/helpers.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use relm4::gtk::{glib, pango};
+use relm4::gtk::{gio::prelude::AppInfoExt, glib, pango};
 use wayle_config::schemas::modules::notification::{IconSource, UrgencyBarThreshold};
 use wayle_notification::types::Urgency;
 
@@ -27,6 +27,25 @@ pub(crate) enum ResolvedIcon {
     Named(String),
     /// Filesystem path to an image file.
     File(String),
+}
+
+/// Human-readable app label for a notification without an `app_name`.
+///
+/// Portal-routed notifications (e.g. from flatpak apps) arrive with an empty
+/// app name and a `desktop-entry` hint instead; resolve the entry's display
+/// name, falling back to the raw entry id when no desktop file is found.
+pub(crate) fn desktop_entry_app_label(desktop_entry: Option<String>) -> Option<String> {
+    let entry = desktop_entry?;
+    let desktop_id = if entry.ends_with(".desktop") {
+        entry.clone()
+    } else {
+        format!("{entry}.desktop")
+    };
+
+    Some(
+        gio_unix::DesktopAppInfo::new(&desktop_id)
+            .map_or(entry, |info| info.display_name().to_string()),
+    )
 }
 
 /// Returns the CSS class name for a notification's urgency level.
@@ -230,6 +249,17 @@ mod tests {
             panic!("expected Hours, got {result:?}");
         };
         assert_eq!(hours, 2);
+    }
+
+    #[test]
+    fn desktop_entry_app_label_none_returns_none() {
+        assert!(desktop_entry_app_label(None).is_none());
+    }
+
+    #[test]
+    fn desktop_entry_app_label_unknown_entry_falls_back_to_raw_id() {
+        let result = desktop_entry_app_label(Some("com.wayle.does-not-exist".into()));
+        assert_eq!(result.as_deref(), Some("com.wayle.does-not-exist"));
     }
 
     #[test]


### PR DESCRIPTION
## Objective

Portal-routed notifications (all flatpak apps: libnotify >= 0.8 silently switches to org.freedesktop.portal.Notification inside a sandbox, and the portal backend forwards to the daemon with an EMPTY app_name and only a desktop-entry hint). Wayle groups and labels purely by app_name, so every flatpak app's notifications pile into a single "unknown app" group, even though the desktop-entry hint is already parsed and used for the group icon.

Fall back to the desktop-entry's display name (resolved via gio, like the media module's desktop_entry_icon) for both the dropdown grouping key and the popup card app label, using the raw entry id when no desktop file is found. Notifications with neither field keep the "unknown app" label.
