### PR TITLE
chore: update wayle-hyprland to 0.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4712,9 +4712,9 @@ dependencies = [
 
 [[package]]
 name = "wayle-hyprland"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69c465e133c429815ea36019f30a143855c91af6d8778a0ca88b6860c03ce20c"
+checksum = "94211e5d87a633e1d8336a7840d3638f4f823bb903d7a0315841e216a745593d"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -5166,7 +5166,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ wayle-bluetooth = "0.1.2"
 wayle-brightness = "0.1.2"
 wayle-cava = { version = "0.1.2", features = ["vendored"] }
 wayle-core = "0.1.2"
-wayle-hyprland = "0.2.2"
+wayle-hyprland = "0.2.3"
 wayle-mango = "0.1.1"
 wayle-niri = "0.1.0"
 wayle-media = "0.1.2"

--- a/crates/wayle-shell/src/shell/bar/modules/custom/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/custom/helpers.rs
@@ -97,7 +97,7 @@ impl ParsedOutput {
         let mut ctx = self
             .json
             .clone()
-            .and_then(|v| if v.is_object() { Some(v) } else { None })
+            .filter(Value::is_object)
             .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
 
         if let Value::Object(map) = &mut ctx {


### PR DESCRIPTION
## Objective

Update Wayle to use `wayle-hyprland` 0.2.3. This picks up the Hyprland 0.56 compatibility fix from wayle-rs/wayle-services#40

## Solution

Bump the workspace dependency from 0.2.2 to 0.2.3 and update the lockfile

## Test Plan

- `cargo +nightly fmt --all --check`
- `cargo test --workspace --no-fail-fast`
- `cargo clippy --workspace --all-targets -- -D warnings`
