### PR TITLE
feat: reduce jitter from bar resize with non-monospace fonts

### DIFF
--- a/crates/wayle-config/src/schemas/bar/mod.rs
+++ b/crates/wayle-config/src/schemas/bar/mod.rs
@@ -247,9 +247,10 @@ pub struct BarConfig {
     /// Freeze the bar button label while its dropdown is open.
     ///
     /// Prevents the button from resizing mid-interaction, which keeps the
-    /// dropdown anchored in place.
+    /// dropdown anchored in place. Off by default: labels reserve width for the
+    /// widest digit, so their width no longer jitters as values change.
     #[serde(rename = "dropdown-freeze-label")]
-    #[default(true)]
+    #[default(false)]
     pub dropdown_freeze_label: ConfigProperty<bool>,
 }
 

--- a/crates/wayle-config/src/schemas/modules/clock/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/clock/mod.rs
@@ -16,6 +16,7 @@ pub struct ClockConfig {
     ///
     /// - `%H` - Hour (00-23)
     /// - `%I` - Hour (01-12)
+    /// - `%-H` / `%-I` - Hour without a leading zero (9, not 09)
     /// - `%M` - Minute (00-59)
     /// - `%S` - Second (00-59)
     /// - `%p` - AM/PM
@@ -24,14 +25,15 @@ pub struct ClockConfig {
     /// - `%b` - Abbreviated month (Jan, Feb)
     /// - `%B` - Full month (January)
     /// - `%d` - Day of month (01-31)
+    /// - `%-d` - Day of month without a leading zero (5, not 05)
     /// - `%Y` - Year (2024)
     ///
     /// ## Examples
     ///
     /// - `"%H:%M"` - "14:30"
     /// - `"%I:%M %p"` - "02:30 PM"
-    /// - `"%a %b %d %I:%M %p"` - "Mon Jan 15 02:30 PM"
-    #[default(String::from("%a %b %d %I:%M %p"))]
+    /// - `"%a %b %-d %-I:%M %p"` - "Mon Jan 5 2:30 PM"
+    #[default(String::from("%a %b %-d %-I:%M %p"))]
     pub format: ConfigProperty<String>,
 
     /// Symbolic icon name.

--- a/crates/wayle-config/src/schemas/modules/world_clock/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/world_clock/mod.rs
@@ -22,7 +22,7 @@ pub struct WorldClockConfig {
     /// | `"{{ tz('UTC', '%H:%M %Z') }}"` | `14:30 UTC` |
     /// | `"NYC {{ tz('America/New_York', '%H:%M') }}  TYO {{ tz('Asia/Tokyo', '%H:%M') }}"` | `NYC 09:30  TYO 23:30` |
     /// | `"{{ tz('America/New_York', '%H:%M %Z') }} \| {{ tz('Europe/London', '%H:%M %Z') }}"` | `09:30 EST \| 14:30 GMT` |
-    #[default(String::from("{{ tz('UTC', '%H:%M %Z') }}"))]
+    #[default(String::from("{{ tz('UTC', '%-H:%M %Z') }}"))]
     pub format: ConfigProperty<String>,
 
     /// Symbolic icon name.

--- a/crates/wayle-idle-inhibit/build.rs
+++ b/crates/wayle-idle-inhibit/build.rs
@@ -1,9 +1,11 @@
 //! Build script for wayle-idle-inhibit.
 //!
-//! this crate intentionally does not force link order for
-//! libwayland-client. Binaries that also use `gtk4-layer-shell` must ensure
-//! `gtk4-layer-shell` is linked before `wayland-client` so its interposition
-//! works. Handle that in the final binary (via its build script).
+//! libwayland-client is linked via `#[link(name = "wayland-client")]` on the
+//! FFI extern block in `src/ffi.rs`, so it is always retained regardless of
+//! linker `--as-needed` ordering, in every binary and test depending on this
+//! crate. This build script therefore forces no link order. Binaries that also
+//! use `gtk4-layer-shell` must still ensure it is linked before wayland-client
+//! for its interposition to work; handle that in the final binary/shell.
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");

--- a/crates/wayle-idle-inhibit/src/ffi.rs
+++ b/crates/wayle-idle-inhibit/src/ffi.rs
@@ -173,6 +173,14 @@ mod sys {
 
     use super::{WlInterface, WlProxy};
 
+    // Declare the library these symbols come from so rustc emits
+    // `-lwayland-client` adjacent to this crate's objects. This keeps it out of
+    // reach of the linker's `--as-needed` pruning (which can otherwise drop a
+    // `-lwayland-client` that appears before the code referencing it, depending
+    // on link ordering) and propagates the link requirement to every binary and
+    // test that depends on this crate. gtk4-layer-shell interposition ordering
+    // is still the final binary's concern (see the shell's build script).
+    #[link(name = "wayland-client")]
     unsafe extern "C" {
         pub fn wl_display_roundtrip(display: *mut super::WlDisplay) -> c_int;
         pub fn wl_proxy_add_listener(

--- a/crates/wayle-shell/src/shell/bar/modules/clock/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/clock/helpers.rs
@@ -8,3 +8,16 @@ pub(super) fn format_time(format: &str) -> String {
         .inspect_err(|e| error!(error = %e, "cannot format time"))
         .unwrap_or_else(|_| String::from("--"))
 }
+
+#[cfg(test)]
+mod tests {
+    use gtk4::glib::DateTime;
+
+    #[test]
+    fn unpadded_hour_drops_leading_zero() {
+        // GLib's `%-` modifier suppresses zero-padding; minutes stay padded.
+        let dt = DateTime::from_local(2024, 1, 15, 9, 5, 0.0).expect("valid datetime");
+        assert_eq!(dt.format("%-I:%M").expect("format").to_string(), "9:05");
+        assert_eq!(dt.format("%-H:%M").expect("format").to_string(), "9:05");
+    }
+}

--- a/crates/wayle-shell/src/shell/bar/modules/clock/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/clock/mod.rs
@@ -84,6 +84,10 @@ impl Component for ClockModule {
                 BarButtonOutput::ScrollDown => ClockMsg::ScrollDown,
             });
 
+        // Only the time (HH:MM) is reserved. The date changes at most once a day, so
+        // it gets no reserved space and simply renders at its natural width.
+        bar_button.emit(BarButtonInput::SetLabelReserveTimeOnly(true));
+
         watchers::spawn_watchers(&sender, clock);
 
         let model = Self {

--- a/crates/wayle-shell/src/shell/bar/modules/cpu/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/cpu/helpers.rs
@@ -5,12 +5,12 @@ use wayle_sysinfo::types::CpuData;
 ///
 /// ## Variables
 ///
-/// - `{{ percent }}` - CPU usage (00-100, zero-padded)
+/// - `{{ percent }}` - CPU usage (0-100)
 /// - `{{ freq_ghz }}` - Frequency of the busiest core (highest usage)
 /// - `{{ avg_freq_ghz }}` - Average frequency across cores
 /// - `{{ max_freq_ghz }}` - Maximum frequency among cores
-/// - `{{ temp_c }}` - Temperature in Celsius (zero-padded)
-/// - `{{ temp_f }}` - Temperature in Fahrenheit (zero-padded)
+/// - `{{ temp_c }}` - Temperature in Celsius
+/// - `{{ temp_f }}` - Temperature in Fahrenheit
 pub(super) fn format_label(format: &str, cpu: &CpuData) -> String {
     let busiest_ghz = cpu.busiest_core_freq_mhz as f64 / 1000.0;
     let avg_ghz = cpu.avg_frequency_mhz as f64 / 1000.0;
@@ -19,12 +19,12 @@ pub(super) fn format_label(format: &str, cpu: &CpuData) -> String {
     let temp_f = temp_c * 9.0 / 5.0 + 32.0;
 
     let ctx = json!({
-        "percent": format!("{:02.0}", cpu.usage_percent),
+        "percent": format!("{:.0}", cpu.usage_percent),
         "freq_ghz": format!("{busiest_ghz:.1}"),
         "avg_freq_ghz": format!("{avg_ghz:.1}"),
         "max_freq_ghz": format!("{max_ghz:.1}"),
-        "temp_c": format!("{temp_c:02.0}"),
-        "temp_f": format!("{temp_f:02.0}"),
+        "temp_c": format!("{temp_c:.0}"),
+        "temp_f": format!("{temp_f:.0}"),
     });
     crate::template::render(format, ctx).unwrap_or_default()
 }
@@ -58,10 +58,10 @@ mod tests {
     }
 
     #[test]
-    fn format_label_percent_pads_single_digits() {
+    fn format_label_percent_minimal_digits() {
         let cpu = cpu_data(5.2, 3500, 4500, 4200, Some(55.0));
         let result = format_label("{{ percent }}", &cpu);
-        assert_eq!(result, "05");
+        assert_eq!(result, "5");
     }
 
     #[test]
@@ -107,10 +107,10 @@ mod tests {
     }
 
     #[test]
-    fn format_label_temp_c_pads_single_digits() {
+    fn format_label_temp_c_minimal_digits() {
         let cpu = cpu_data(50.0, 3500, 4500, 4200, Some(8.0));
         let result = format_label("{{ temp_c }}", &cpu);
-        assert_eq!(result, "08");
+        assert_eq!(result, "8");
     }
 
     #[test]
@@ -131,7 +131,7 @@ mod tests {
     fn format_label_with_no_temperature_uses_zero() {
         let cpu = cpu_data(50.0, 3500, 4500, 4200, None);
         let result = format_label("{{ temp_c }}°C / {{ temp_f }}°F", &cpu);
-        assert_eq!(result, "00°C / 32°F");
+        assert_eq!(result, "0°C / 32°F");
     }
 
     #[test]

--- a/crates/wayle-shell/src/shell/bar/modules/netstat/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/netstat/helpers.rs
@@ -29,8 +29,16 @@ fn gib(bytes: u64) -> String {
     format!("{:.2}", ByteSize::b(bytes).as_gib())
 }
 
+/// Auto-scaled rate with a stable shape: always one decimal place and a 3-char
+/// unit (KiB/MiB/GiB/TiB). Flooring at KiB avoids the sub-KiB "B" tier, which
+/// would otherwise vary the decimal structure and unit length as traffic idles.
 fn auto(bytes: u64) -> String {
-    ByteSize::b(bytes).to_string()
+    const KIB: u64 = 1024;
+    if bytes < KIB {
+        format!("{:.1} KiB", bytes as f64 / KIB as f64)
+    } else {
+        ByteSize::b(bytes).to_string()
+    }
 }
 
 pub(super) fn select_interface<'a>(
@@ -119,6 +127,14 @@ mod tests {
         let net = net_data("eth0", 100 * KIB, 2 * MIB);
         let result = format_label("{{ up_auto }}", &net);
         assert_eq!(result, "2.0 MiB");
+    }
+
+    #[test]
+    fn format_label_auto_floors_sub_kib_at_kib() {
+        // Idle / sub-KiB traffic keeps the 1-decimal + KiB shape instead of "0 B".
+        let net = net_data("eth0", 0, 512);
+        assert_eq!(format_label("{{ down_auto }}", &net), "0.0 KiB");
+        assert_eq!(format_label("{{ up_auto }}", &net), "0.5 KiB");
     }
 
     #[test]

--- a/crates/wayle-shell/src/shell/bar/modules/netstat/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/netstat/mod.rs
@@ -84,6 +84,11 @@ impl Component for NetstatModule {
                 BarButtonOutput::ScrollDown => NetstatMsg::ScrollDown,
             });
 
+        // Rates swing across orders of magnitude every second. Reserve the integer
+        // part to 3 digits so idle<->active swings up to 999 don't shove neighbors;
+        // only rare 4-integer-digit values (1000+, just before the unit switch) grow.
+        bar_button.emit(BarButtonInput::SetLabelMinDigits(3));
+
         watchers::spawn_watchers(&sender, netstat_config, &init.sysinfo);
 
         let model = Self {

--- a/crates/wayle-shell/src/shell/bar/modules/notification/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/notification/helpers.rs
@@ -19,7 +19,7 @@ pub(crate) fn select_icon(ctx: &IconContext<'_>) -> String {
 }
 
 pub(crate) fn format_label(count: usize) -> String {
-    format!("{count:02}")
+    format!("{count}")
 }
 
 #[cfg(test)]
@@ -61,9 +61,9 @@ mod tests {
     }
 
     #[test]
-    fn label_shows_count_zero_padded() {
-        assert_eq!(format_label(5), "05");
-        assert_eq!(format_label(0), "00");
+    fn label_shows_count_minimal_digits() {
+        assert_eq!(format_label(5), "5");
+        assert_eq!(format_label(0), "0");
         assert_eq!(format_label(12), "12");
         assert_eq!(format_label(99), "99");
         assert_eq!(format_label(100), "100");

--- a/crates/wayle-shell/src/shell/bar/modules/ram/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/ram/helpers.rs
@@ -4,11 +4,11 @@ use wayle_sysinfo::types::MemoryData;
 
 pub(super) fn format_label(format: &str, mem: &MemoryData) -> String {
     let ctx = json!({
-        "percent": format!("{:02.0}", mem.usage_percent),
+        "percent": format!("{:.0}", mem.usage_percent),
         "used_gib": gib(mem.used_bytes),
         "total_gib": gib(mem.total_bytes),
         "available_gib": gib(mem.available_bytes),
-        "swap_percent": format!("{:02.0}", mem.swap_percent),
+        "swap_percent": format!("{:.0}", mem.swap_percent),
         "swap_used_gib": gib(mem.swap_used_bytes),
         "swap_total_gib": gib(mem.swap_total_bytes),
     });
@@ -53,10 +53,10 @@ mod tests {
     }
 
     #[test]
-    fn format_label_percent_pads_single_digits() {
+    fn format_label_percent_minimal_digits() {
         let mem = mem_data(GIB, 16 * GIB, 15 * GIB, 6.25, 0, 4 * GIB, 0.0);
         let result = format_label("{{ percent }}", &mem);
-        assert_eq!(result, "06");
+        assert_eq!(result, "6");
     }
 
     #[test]

--- a/crates/wayle-shell/src/shell/bar/modules/storage/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/storage/helpers.rs
@@ -58,7 +58,7 @@ pub(super) fn aggregate_storage(
 
 pub(super) fn format_label(format: &str, snapshot: &StorageSnapshot) -> String {
     let ctx = json!({
-        "percent": format!("{:02.0}", snapshot.usage_percent),
+        "percent": format!("{:.0}", snapshot.usage_percent),
         "used_tib": tib(snapshot.used_bytes),
         "used_gib": gib(snapshot.used_bytes),
         "used_mib": mib(snapshot.used_bytes),
@@ -88,8 +88,16 @@ fn mib(bytes: u64) -> String {
     format!("{:.0}", ByteSize::b(bytes).as_mib())
 }
 
+/// Auto-scaled size with a stable shape: always one decimal place and a 3-char
+/// unit (KiB/MiB/GiB/TiB). Flooring at KiB avoids the sub-KiB "B" tier, which
+/// would otherwise vary the decimal structure and unit length.
 fn auto(bytes: u64) -> String {
-    ByteSize::b(bytes).to_string()
+    const KIB: u64 = 1024;
+    if bytes < KIB {
+        format!("{:.1} KiB", bytes as f64 / KIB as f64)
+    } else {
+        ByteSize::b(bytes).to_string()
+    }
 }
 
 #[cfg(test)]
@@ -213,10 +221,10 @@ mod tests {
     }
 
     #[test]
-    fn format_label_percent_pads_single_digits() {
+    fn format_label_percent_minimal_digits() {
         let snapshot = storage_snapshot(50 * GIB, 1000 * GIB, 950 * GIB, 5.0, "ext4");
         let result = format_label("{{ percent }}", &snapshot);
-        assert_eq!(result, "05");
+        assert_eq!(result, "5");
     }
 
     #[test]
@@ -245,6 +253,12 @@ mod tests {
         let snapshot = storage_snapshot(512 * MIB, 2 * GIB, GIB + 512 * MIB, 25.0, "ext4");
         let result = format_label("{{ used_auto }}", &snapshot);
         assert_eq!(result, "512.0 MiB");
+    }
+
+    #[test]
+    fn format_label_auto_floors_sub_kib_at_kib() {
+        let snapshot = storage_snapshot(512, 2 * GIB, 2 * GIB - 512, 0.0, "ext4");
+        assert_eq!(format_label("{{ used_auto }}", &snapshot), "0.5 KiB");
     }
 
     #[test]

--- a/crates/wayle-shell/src/shell/bar/modules/world_clock/mod.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/world_clock/mod.rs
@@ -85,6 +85,9 @@ impl Component for WorldClockModule {
                 BarButtonOutput::ScrollDown => WorldClockMsg::ScrollDown,
             });
 
+        // Reserve only the time components; any date part shows its natural width.
+        bar_button.emit(BarButtonInput::SetLabelReserveTimeOnly(true));
+
         watchers::spawn_watchers(&sender, world_clock);
 
         let model = Self {

--- a/crates/wayle-widgets/src/components/bar_buttons/component.rs
+++ b/crates/wayle-widgets/src/components/bar_buttons/component.rs
@@ -20,7 +20,9 @@ use super::{
     },
     watchers::{spawn_icon_position_watcher, spawn_variant_watcher},
 };
-use crate::{styling::InlineStyling, utils::force_window_resize};
+use crate::{
+    primitives::stable_label::StableLabel, styling::InlineStyling, utils::force_window_resize,
+};
 
 /// Initialization data for BarButton.
 #[derive(Debug, Clone)]
@@ -56,6 +58,11 @@ pub enum BarButtonInput {
     ConfigChanged,
     /// Apply threshold-based color overrides.
     SetThresholdColors(ThresholdColors),
+    /// Reserve label width for at least this many digit slots, so volatile
+    /// numeric fields don't jitter across their common value range.
+    SetLabelMinDigits(u32),
+    /// Reserve width only for colon-separated time components (used by clocks).
+    SetLabelReserveTimeOnly(bool),
 }
 
 /// Command outputs from async watchers.
@@ -74,6 +81,13 @@ pub struct BarButton {
     tooltip: Option<String>,
     size_frozen: bool,
     pending_label: Option<String>,
+    /// Digits each number's integer part reserves width for. Defaults to 2 so a
+    /// numeric label shows the natural value (e.g. `5%`) yet holds the width of a
+    /// 2-digit value; applied per number, so multi-field formats stay stable too.
+    label_min_digits: u32,
+    /// When true, reserve width only for colon-separated time components (clocks),
+    /// so date parts that change at most daily get no reserved space.
+    label_reserve_time_only: bool,
     pub(super) variant: BarButtonVariant,
     pub(super) colors: BarButtonColors,
     pub(super) behavior: BarButtonBehavior,
@@ -149,22 +163,30 @@ impl Component for BarButton {
                     #[watch]
                     set_hexpand: model.settings.is_vertical.get(),
 
-                    gtk::Label {
+                    StableLabel {
                         add_css_class: "bar-button-label",
                         set_align: gtk::Align::Center,
-                        set_justify: gtk::Justification::Center,
 
                         #[watch]
                         set_hexpand: model.settings.is_vertical.get(),
 
                         #[watch]
-                        set_label: &model.label,
+                        set_text: &model.label,
 
                         #[watch]
                         set_ellipsize: model.ellipsize(),
 
                         #[watch]
                         set_max_width_chars: model.max_width_chars(),
+
+                        #[watch]
+                        set_stabilize: model.stabilize_enabled(),
+
+                        #[watch]
+                        set_min_digits: model.label_min_digits,
+
+                        #[watch]
+                        set_time_only: model.label_reserve_time_only,
                     },
                 },
             },
@@ -185,6 +207,8 @@ impl Component for BarButton {
             tooltip: init.tooltip,
             size_frozen: false,
             pending_label: None,
+            label_min_digits: 2,
+            label_reserve_time_only: false,
             variant: init.settings.variant.get(),
             colors: init.colors,
             behavior: init.behavior,
@@ -239,6 +263,12 @@ impl Component for BarButton {
             BarButtonInput::SetThresholdColors(colors) => {
                 self.threshold_overrides = colors;
                 self.reload_css();
+            }
+            BarButtonInput::SetLabelMinDigits(min_digits) => {
+                self.label_min_digits = min_digits;
+            }
+            BarButtonInput::SetLabelReserveTimeOnly(time_only) => {
+                self.label_reserve_time_only = time_only;
             }
         }
     }
@@ -320,6 +350,13 @@ impl BarButton {
     fn max_width_chars(&self) -> i32 {
         let max = self.behavior.label_max_chars.get();
         if max > 0 { max as i32 } else { -1 }
+    }
+
+    /// Stabilize label width only for non-truncating horizontal labels. Truncating
+    /// (ellipsized) labels must stay free to shrink; vertical bars size their labels
+    /// to the bar width, so a horizontal-width floor is unwanted there.
+    fn stabilize_enabled(&self) -> bool {
+        self.behavior.label_max_chars.get() == 0 && !self.settings.is_vertical.get()
     }
 
     fn is_icon_only(&self) -> bool {

--- a/crates/wayle-widgets/src/lib.rs
+++ b/crates/wayle-widgets/src/lib.rs
@@ -33,8 +33,8 @@ pub mod prelude {
         primitives::{
             alert::*, badge::*, buttons::*, card::*, checkbox::*, confirm_modal::*, dropdown::*,
             empty_state::*, password_input::*, popover::*, progress_bar::*, progress_ring::*,
-            radio_group::*, separator::*, slider::*, spinner::*, status_dot::*, switch::*,
-            text_input::*,
+            radio_group::*, separator::*, slider::*, spinner::*, stable_label::*, status_dot::*,
+            switch::*, text_input::*,
         },
         styling::{InlineStyling, resolve_color},
         utils::force_window_resize,

--- a/crates/wayle-widgets/src/primitives/mod.rs
+++ b/crates/wayle-widgets/src/primitives/mod.rs
@@ -16,6 +16,7 @@ pub mod radio_group;
 pub mod separator;
 pub mod slider;
 pub mod spinner;
+pub mod stable_label;
 pub mod status_dot;
 pub mod switch;
 pub mod text_input;

--- a/crates/wayle-widgets/src/primitives/stable_label/imp.rs
+++ b/crates/wayle-widgets/src/primitives/stable_label/imp.rs
@@ -1,0 +1,274 @@
+use std::cell::{Cell, OnceCell};
+
+use gtk4::{glib, pango, prelude::*, subclass::prelude::*};
+
+#[derive(Default)]
+pub struct StableLabelImp {
+    label: OnceCell<gtk4::Label>,
+    /// When false, behaves like a plain centered label.
+    stabilize: Cell<bool>,
+    /// Minimum digits to reserve for each number's integer part, regardless of
+    /// the value shown. `0` disables the reservation.
+    min_digits: Cell<u32>,
+    /// When true, only reserve/normalize digit groups that are part of a
+    /// colon-separated time (e.g. the hour and minute in `9:30`); standalone
+    /// numbers such as a date stay at their natural width. Used by the clocks so
+    /// date parts (which change at most once a day) get no reserved space.
+    time_only: Cell<bool>,
+}
+
+#[glib::object_subclass]
+impl ObjectSubclass for StableLabelImp {
+    const NAME: &'static str = "WayleStableLabel";
+    type Type = super::StableLabel;
+    type ParentType = gtk4::Widget;
+    // NOTE: deliberately no layout manager. `gtk_widget_measure()` delegates
+    // straight to a layout manager when one is set and never calls our `measure`
+    // vfunc, so a manager here would silently disable stabilization. We size the
+    // single child by hand instead.
+}
+
+impl ObjectImpl for StableLabelImp {
+    fn constructed(&self) {
+        self.parent_constructed();
+        self.stabilize.set(true);
+
+        // Fill the (possibly widened) allocation; text position is controlled by
+        // xalign/yalign so it centers by default and right-anchors when reserving.
+        let label = gtk4::Label::builder()
+            .halign(gtk4::Align::Fill)
+            .valign(gtk4::Align::Fill)
+            .justify(gtk4::Justification::Center)
+            .xalign(0.5)
+            .build();
+        label.set_parent(&*self.obj());
+        let _ = self.label.set(label);
+    }
+
+    fn dispose(&self) {
+        if let Some(label) = self.label.get() {
+            label.unparent();
+        }
+    }
+}
+
+impl WidgetImpl for StableLabelImp {
+    fn request_mode(&self) -> gtk4::SizeRequestMode {
+        self.label
+            .get()
+            .map_or(gtk4::SizeRequestMode::ConstantSize, |l| l.request_mode())
+    }
+
+    fn measure(&self, orientation: gtk4::Orientation, for_size: i32) -> (i32, i32, i32, i32) {
+        let Some(label) = self.label.get() else {
+            return (0, 0, -1, -1);
+        };
+
+        let (mut min, mut nat, min_baseline, nat_baseline) = label.measure(orientation, for_size);
+
+        // Recomputed on every measure so it stays correct across runtime
+        // font/theme/scale changes (those queue a resize, re-invoking measure()).
+        if orientation == gtk4::Orientation::Horizontal && self.stabilize.get() {
+            let extra = stabilized_extra_px(label, self.min_digits.get(), self.time_only.get());
+            min += extra;
+            nat += extra;
+        }
+
+        (min, nat, min_baseline, nat_baseline)
+    }
+
+    fn size_allocate(&self, width: i32, height: i32, baseline: i32) {
+        if let Some(label) = self.label.get() {
+            label.allocate(width, height, baseline, None);
+        }
+    }
+}
+
+impl StableLabelImp {
+    pub(super) fn set_text(&self, text: &str) {
+        if let Some(label) = self.label.get()
+            && label.text() != text
+        {
+            // set_label already queues a resize; measure() recomputes the width.
+            label.set_label(text);
+        }
+    }
+
+    pub(super) fn set_stabilize(&self, on: bool) {
+        if self.stabilize.get() != on {
+            self.stabilize.set(on);
+            self.obj().queue_resize();
+        }
+    }
+
+    pub(super) fn set_min_digits(&self, n: u32) {
+        if self.min_digits.get() != n {
+            self.min_digits.set(n);
+            self.obj().queue_resize();
+        }
+    }
+
+    pub(super) fn set_time_only(&self, on: bool) {
+        if self.time_only.get() != on {
+            self.time_only.set(on);
+            self.obj().queue_resize();
+        }
+    }
+
+    pub(super) fn set_ellipsize(&self, mode: pango::EllipsizeMode) {
+        if let Some(label) = self.label.get() {
+            label.set_ellipsize(mode);
+        }
+    }
+
+    pub(super) fn set_max_width_chars(&self, n: i32) {
+        if let Some(label) = self.label.get() {
+            label.set_max_width_chars(n);
+        }
+    }
+
+    pub(super) fn add_css_class(&self, class: &str) {
+        if let Some(label) = self.label.get() {
+            label.add_css_class(class);
+        }
+    }
+}
+
+/// Extra horizontal pixels to add so every ASCII-digit slot occupies the width of
+/// the widest digit in the resolved font, plus per-number reservation so each
+/// integer part holds at least `min_digits` digits. Returned as a *delta* from the
+/// current text so it's independent of the label's margins/padding and GtkLabel's
+/// own width rounding. `0` when there is nothing to stabilize.
+fn stabilized_extra_px(label: &gtk4::Label, min_digits: u32, time_only: bool) -> i32 {
+    let text = label.text();
+    let text = text.as_str();
+
+    // Only stabilize labels that actually contain a digit; a digit-free label
+    // (icon text, "--", a keyboard layout) should never reserve digit slots.
+    if text.is_empty() || !text.bytes().any(|b| b.is_ascii_digit()) {
+        return 0;
+    }
+
+    // Copy the label's own render layout so measurements use the exact
+    // CSS-resolved font/attributes it draws with.
+    let layout = label.layout().copy();
+
+    let mut widest = b'0';
+    let mut widest_w = 0;
+    for d in b'0'..=b'9' {
+        layout.set_text(&(d as char).to_string());
+        let w = layout.pixel_size().0;
+        if w > widest_w {
+            widest_w = w;
+            widest = d;
+        }
+    }
+
+    layout.set_text(text);
+    let actual_w = layout.pixel_size().0;
+
+    // Measure the whole "worst case" rendering in one pass: every digit widened
+    // and each integer part padded to `min_digits`. Taking the delta from a single
+    // in-context measurement avoids mixing isolated glyph advances with in-context
+    // ones (which made a padded 1-digit value render slightly *wider* than 2 digits).
+    let padded = padded_canonical(text, widest as char, min_digits, time_only);
+    layout.set_text(&padded);
+    let padded_w = layout.pixel_size().0;
+
+    (padded_w - actual_w).max(0)
+}
+
+/// Builds the widest same-shape rendering of `text`: every ASCII digit replaced by
+/// `widest`, and **each number's integer part** padded with `widest` up to
+/// `min_digits` digits. Digits after a decimal point are widened but not padded
+/// (those fields render at a fixed precision), and each number is padded
+/// independently, so multi-field labels like `"{{ percent }}% {{ temp }}C"` stay
+/// stable field-by-field rather than only in aggregate.
+///
+/// When `time_only` is set, only digit groups directly adjacent to a `:` (a clock's
+/// hour/minute/second) are widened and padded; every other number keeps its exact
+/// characters, so date parts get no reserved space.
+fn padded_canonical(text: &str, widest: char, min_digits: u32, time_only: bool) -> String {
+    let chars: Vec<char> = text.chars().collect();
+    let mut out = String::with_capacity(chars.len() + 4);
+    let mut i = 0;
+    while i < chars.len() {
+        if !chars[i].is_ascii_digit() {
+            out.push(chars[i]);
+            i += 1;
+            continue;
+        }
+        let start = i;
+        while i < chars.len() && chars[i].is_ascii_digit() {
+            i += 1;
+        }
+
+        // A digit group is a clock time component if it directly touches a ':'.
+        let is_time =
+            (start > 0 && chars[start - 1] == ':') || (i < chars.len() && chars[i] == ':');
+        if time_only && !is_time {
+            for &c in &chars[start..i] {
+                out.push(c);
+            }
+            continue;
+        }
+
+        let run_len = (i - start) as u32;
+        // A digit run immediately after "<digit>." is a fractional part; don't pad it.
+        let is_fractional =
+            start >= 2 && chars[start - 1] == '.' && chars[start - 2].is_ascii_digit();
+        if !is_fractional {
+            for _ in 0..min_digits.saturating_sub(run_len) {
+                out.push(widest);
+            }
+        }
+        for _ in 0..run_len {
+            out.push(widest);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::padded_canonical;
+
+    #[test]
+    fn single_integer_pads_to_min() {
+        assert_eq!(padded_canonical("5", '8', 2, false), "88");
+        assert_eq!(padded_canonical("50", '8', 2, false), "88");
+        assert_eq!(padded_canonical("100", '8', 2, false), "888");
+    }
+
+    #[test]
+    fn fractional_part_is_widened_but_not_padded() {
+        assert_eq!(padded_canonical("3.2", '8', 2, false), "88.8");
+        assert_eq!(padded_canonical("512.0", '8', 3, false), "888.8");
+        assert_eq!(padded_canonical("0.0", '8', 3, false), "888.8");
+    }
+
+    #[test]
+    fn each_number_padded_independently() {
+        assert_eq!(padded_canonical("5% 8C", '8', 2, false), "88% 88C");
+        assert_eq!(padded_canonical("45% 55C", '8', 2, false), "88% 88C");
+        assert_eq!(padded_canonical("5% 08C", '8', 2, false), "88% 88C");
+    }
+
+    #[test]
+    fn non_digits_are_preserved() {
+        assert_eq!(padded_canonical("", '8', 2, false), "");
+        assert_eq!(padded_canonical("--", '8', 2, false), "--");
+        assert_eq!(padded_canonical("KiB/s", '8', 2, false), "KiB/s");
+        assert_eq!(padded_canonical("55°C", '8', 2, false), "88°C");
+    }
+
+    #[test]
+    fn time_only_reserves_time_but_not_date() {
+        // Hour padded to 2 digits and the time widened; the day stays natural.
+        assert_eq!(padded_canonical("Jan 5 9:30 PM", '8', 2, true), "Jan 5 88:88 PM");
+        assert_eq!(padded_canonical("Jan 15 12:30 PM", '8', 2, true), "Jan 15 88:88 PM");
+        assert_eq!(padded_canonical("9:30 UTC", '8', 2, true), "88:88 UTC");
+        // A year is not colon-adjacent, so it is left at its natural width.
+        assert_eq!(padded_canonical("2024 9:05", '8', 2, true), "2024 88:88");
+    }
+}

--- a/crates/wayle-widgets/src/primitives/stable_label/mod.rs
+++ b/crates/wayle-widgets/src/primitives/stable_label/mod.rs
@@ -1,0 +1,68 @@
+//! A label that reserves width for the widest digit in each digit slot, so
+//! non-monospace fonts don't shift neighboring bar items as digits change.
+//!
+//! Digit *width* jitter (same digit count, e.g. `1` vs `8`) is eliminated by
+//! measuring the text with every digit replaced by the widest digit. Digit
+//! *count* jitter can additionally be reduced via [`StableLabel::set_min_digits`],
+//! which reserves width for a minimum number of digit slots.
+#![allow(missing_docs)]
+
+mod imp;
+
+use gtk4::{glib, pango, subclass::prelude::*};
+
+glib::wrapper! {
+    pub struct StableLabel(ObjectSubclass<imp::StableLabelImp>)
+        @extends gtk4::Widget,
+        @implements gtk4::Accessible, gtk4::Buildable, gtk4::ConstraintTarget;
+}
+
+impl Default for StableLabel {
+    fn default() -> Self {
+        glib::Object::builder().build()
+    }
+}
+
+impl StableLabel {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the displayed text and re-measures the reserved width.
+    pub fn set_text(&self, text: &str) {
+        self.imp().set_text(text);
+    }
+
+    /// Enables or disables width stabilization. When disabled the widget behaves
+    /// like a plain centered label.
+    pub fn set_stabilize(&self, on: bool) {
+        self.imp().set_stabilize(on);
+    }
+
+    /// Reserves width so each number's integer part holds at least `n` digits,
+    /// regardless of the value shown. `0` disables the reservation.
+    pub fn set_min_digits(&self, n: u32) {
+        self.imp().set_min_digits(n);
+    }
+
+    /// When enabled, only stabilizes digit groups that are part of a colon-separated
+    /// time (a clock's hour/minute/second); standalone numbers such as a date keep
+    /// their natural width and get no reserved space.
+    pub fn set_time_only(&self, on: bool) {
+        self.imp().set_time_only(on);
+    }
+
+    /// Forwards to the inner label so `.bar-button-label` styling attaches to the
+    /// node that is actually rendered and measured.
+    pub fn add_css_class(&self, class: &str) {
+        self.imp().add_css_class(class);
+    }
+
+    pub fn set_ellipsize(&self, mode: pango::EllipsizeMode) {
+        self.imp().set_ellipsize(mode);
+    }
+
+    pub fn set_max_width_chars(&self, n: i32) {
+        self.imp().set_max_width_chars(n);
+    }
+}

--- a/docs/config/bar.md
+++ b/docs/config/bar.md
@@ -118,7 +118,7 @@ When disabled, windows may overlap the bar and the bar draws over them.
 | `dropdown-shadow` | bool | `true` | Enable dropdown panel shadow. |
 | `dropdown-opacity` | [`Percentage`](/config/types#percentage) | `100` | Dropdown panel opacity (0-100). |
 | `dropdown-autohide` | bool | `true` | Close dropdown when clicking outside it. |
-| `dropdown-freeze-label` | bool | `true` | Freeze the bar button label while its dropdown is open. |
+| `dropdown-freeze-label` | bool | `false` | Freeze the bar button label while its dropdown is open. |
 
 ::: details More about `dropdown-freeze-label`
 
@@ -171,7 +171,7 @@ button-group-rounding = "sm"
 dropdown-shadow = true
 dropdown-opacity = 100
 dropdown-autohide = true
-dropdown-freeze-label = true
+dropdown-freeze-label = false
 ```
 
 

--- a/docs/config/modules/clock.md
+++ b/docs/config/modules/clock.md
@@ -21,7 +21,7 @@ right = ["clock"]
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `format` | string | `"%a %b %d %I:%M %p"` | Format string using strftime syntax. |
+| `format` | string | `"%a %b %-d %-I:%M %p"` | Format string using strftime syntax. |
 | `icon-name` | string | `"tb-calendar-time-symbolic"` | Symbolic icon name. |
 | `border-show` | bool | `false` | Display border around button. |
 | `icon-show` | bool | `true` | Display module icon. |
@@ -34,6 +34,7 @@ right = ["clock"]
 
 - `%H` - Hour (00-23)
 - `%I` - Hour (01-12)
+- `%-H` / `%-I` - Hour without a leading zero (9, not 09)
 - `%M` - Minute (00-59)
 - `%S` - Second (00-59)
 - `%p` - AM/PM
@@ -42,13 +43,14 @@ right = ["clock"]
 - `%b` - Abbreviated month (Jan, Feb)
 - `%B` - Full month (January)
 - `%d` - Day of month (01-31)
+- `%-d` - Day of month without a leading zero (5, not 05)
 - `%Y` - Year (2024)
 
 #### Examples
 
 - `"%H:%M"` - "14:30"
 - `"%I:%M %p"` - "02:30 PM"
-- `"%a %b %d %I:%M %p"` - "Mon Jan 15 02:30 PM"
+- `"%a %b %-d %-I:%M %p"` - "Mon Jan 5 2:30 PM"
 
 :::
 
@@ -82,7 +84,7 @@ right = ["clock"]
 
 ```toml
 [modules.clock]
-format = "%a %b %d %I:%M %p"
+format = "%a %b %-d %-I:%M %p"
 icon-name = "tb-calendar-time-symbolic"
 border-show = false
 border-color = "border-accent"

--- a/docs/config/modules/world-clock.md
+++ b/docs/config/modules/world-clock.md
@@ -21,7 +21,7 @@ right = ["world-clock"]
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `format` | string | `"{{ tz('UTC', '%H:%M %Z') }}"` | Format string with embedded timezone blocks. |
+| `format` | string | `"{{ tz('UTC', '%-H:%M %Z') }}"` | Format string with embedded timezone blocks. |
 | `icon-name` | string | `"ld-globe-symbolic"` | Symbolic icon name. |
 | `border-show` | bool | `false` | Display border around button. |
 | `icon-show` | bool | `true` | Display module icon. |
@@ -37,7 +37,7 @@ Anything outside a placeholder stays as literal text.
 
 | Format string | Renders as |
 |---|---|
-| `"{{ tz('UTC', '%H:%M %Z') }}"` | `14:30 UTC` |
+| `"{{ tz('UTC', '%-H:%M %Z') }}"` | `14:30 UTC` |
 | `"NYC {{ tz('America/New_York', '%H:%M') }}  TYO {{ tz('Asia/Tokyo', '%H:%M') }}"` | `NYC 09:30  TYO 23:30` |
 | `"{{ tz('America/New_York', '%H:%M %Z') }} \| {{ tz('Europe/London', '%H:%M %Z') }}"` | `09:30 EST \| 14:30 GMT` |
 
@@ -67,7 +67,7 @@ Anything outside a placeholder stays as literal text.
 
 ```toml
 [modules.world-clock]
-format = "{{ tz('UTC', '%H:%M %Z') }}"
+format = "{{ tz('UTC', '%-H:%M %Z') }}"
 icon-name = "ld-globe-symbolic"
 border-show = false
 border-color = "yellow"


### PR DESCRIPTION
Previously, bar buttons would often move around from left to right as displayed numbers changed. This caused other buttons and even open dropdowns to move around as well.

This PR mitigates that with a few layout heuristics:
- Always reserve enough space as if every digit in your labels were the digit of maximum width, so the button width only changes if the number of digits changes
  - The only exception is date labels that change at most once per day (day, month, year, etc.) for which no extra space is reserved
- For notifications and percentages, get rid of the leading zeroes and instead reserve the amount of space needed for 2 digits (things will still resize when you go to 3+ digits, but this is rare enough that it isn't as big a deal).

I also added non-zero-padded hours and days `%-d` and `%-H` and made these the new defaults, and disabled `dropdown-freeze-label` by default since it is no longer as big a problem.