### PR TITLE
feat: open OSD from CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4772,6 +4772,7 @@ dependencies = [
 name = "wayle-ipc"
 version = "0.7.0"
 dependencies = [
+ "serde",
  "zbus",
 ]
 

--- a/crates/wayle-config/src/schemas/osd/mod.rs
+++ b/crates/wayle-config/src/schemas/osd/mod.rs
@@ -6,16 +6,48 @@ use wayle_derive::wayle_config;
 
 use crate::{
     ConfigProperty,
-    docs::{ConfigGroup, GroupDefaults, ModuleInfo, ModuleInfoProvider},
+    docs::{ConfigGroup, ModuleInfo, ModuleInfoProvider},
     schemas::{general::Layer, styling::Spacing},
 };
 
 /// On-screen display overlay for transient events like volume and brightness.
+///
+/// The `auto-*` keys control whether a change *opens* the overlay. An overlay
+/// that is already open always tracks its device's value, and that tracking
+/// never restarts the dismiss timer — though a change that also re-triggers
+/// the automatic display does.
 #[wayle_config(i18n_prefix = "settings-osd")]
 pub struct OsdConfig {
     /// Show OSD overlays for volume, brightness, and keyboard toggles.
     #[default(true)]
     pub enabled: ConfigProperty<bool>,
+
+    /// Show the speaker OSD automatically when output volume or mute changes.
+    ///
+    /// Turn off to only show it on demand via `wayle osd speaker`.
+    #[serde(rename = "auto-speaker")]
+    #[default(true)]
+    pub auto_speaker: ConfigProperty<bool>,
+
+    /// Show the microphone OSD automatically when input volume or mute changes.
+    ///
+    /// Turn off to only show it on demand via `wayle osd mic`.
+    #[serde(rename = "auto-microphone")]
+    #[default(true)]
+    pub auto_microphone: ConfigProperty<bool>,
+
+    /// Show the brightness OSD automatically when display brightness changes.
+    ///
+    /// Turn off when an external daemon adjusts brightness continuously, so the
+    /// overlay isn't permanently on screen. `wayle osd brightness` still works.
+    #[serde(rename = "auto-brightness")]
+    #[default(true)]
+    pub auto_brightness: ConfigProperty<bool>,
+
+    /// Show the OSD automatically when caps, num, or scroll lock is pressed.
+    #[serde(rename = "auto-toggles")]
+    #[default(true)]
+    pub auto_toggles: ConfigProperty<bool>,
 
     /// Screen anchor position.
     #[default(OsdPosition::default())]
@@ -56,7 +88,10 @@ impl ModuleInfoProvider for OsdConfig {
     }
 
     fn groups() -> Vec<ConfigGroup> {
-        GroupDefaults::standard()
+        vec![
+            ConfigGroup::general(),
+            ConfigGroup::prefix("Automatic display", "auto-"),
+        ]
     }
 }
 

--- a/crates/wayle-i18n/locales/en-US/config/_osd.ftl
+++ b/crates/wayle-i18n/locales/en-US/config/_osd.ftl
@@ -21,6 +21,18 @@ settings-osd-border = Border
 settings-osd-layer = Layer
     .description = Layer-shell layer the OSD is placed on. Tearing mode demotes overlay to top.
 
+settings-osd-auto-speaker = Speaker Changes
+    .description = Show the speaker OSD automatically when output volume or mute changes
+
+settings-osd-auto-microphone = Microphone Changes
+    .description = Show the microphone OSD automatically when input volume or mute changes
+
+settings-osd-auto-brightness = Brightness Changes
+    .description = Show the brightness OSD automatically when display brightness changes. Turn off when another program adjusts brightness continuously.
+
+settings-osd-auto-toggles = Lock Keys
+    .description = Show the OSD automatically when caps, num, or scroll lock is pressed
+
 
 ## OsdPosition variants
 enum-osd-position-top-left = Top Left

--- a/crates/wayle-i18n/locales/fr/config/_osd.ftl
+++ b/crates/wayle-i18n/locales/fr/config/_osd.ftl
@@ -18,6 +18,21 @@ settings-osd-margin = Marge
 settings-osd-border = Bordure
     .description = Dessiner une bordure autour de l'indicateur OSD
 
+settings-osd-layer = Couche
+    .description = Couche layer-shell de l'OSD. Le mode tearing rétrograde overlay vers top.
+
+settings-osd-auto-speaker = Changements de haut-parleur
+    .description = Afficher l'OSD du haut-parleur automatiquement lorsque le volume ou la sourdine de sortie change
+
+settings-osd-auto-microphone = Changements de microphone
+    .description = Afficher l'OSD du microphone automatiquement lorsque le volume ou la sourdine d'entrée change
+
+settings-osd-auto-brightness = Changements de luminosité
+    .description = Afficher l'OSD de luminosité automatiquement lorsque la luminosité de l'écran change. Désactivez si un autre programme ajuste la luminosité en continu.
+
+settings-osd-auto-toggles = Touches de verrouillage
+    .description = Afficher l'OSD automatiquement lors de l'appui sur verr. maj., verr. num. ou arrêt défil.
+
 
 ## Variantes de OsdPosition
 enum-osd-position-top-left = Haut gauche

--- a/crates/wayle-idle-inhibit/build.rs
+++ b/crates/wayle-idle-inhibit/build.rs
@@ -1,9 +1,11 @@
 //! Build script for wayle-idle-inhibit.
 //!
-//! this crate intentionally does not force link order for
-//! libwayland-client. Binaries that also use `gtk4-layer-shell` must ensure
-//! `gtk4-layer-shell` is linked before `wayland-client` so its interposition
-//! works. Handle that in the final binary (via its build script).
+//! libwayland-client is linked via `#[link(name = "wayland-client")]` on the
+//! FFI extern block in `src/ffi.rs`, so it is always retained regardless of
+//! linker `--as-needed` ordering, in every binary and test depending on this
+//! crate. This build script therefore forces no link order. Binaries that also
+//! use `gtk4-layer-shell` must still ensure it is linked before wayland-client
+//! for its interposition to work; handle that in the final binary/shell.
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");

--- a/crates/wayle-idle-inhibit/src/ffi.rs
+++ b/crates/wayle-idle-inhibit/src/ffi.rs
@@ -173,6 +173,14 @@ mod sys {
 
     use super::{WlInterface, WlProxy};
 
+    // Declare the library these symbols come from so rustc emits
+    // `-lwayland-client` adjacent to this crate's objects. This keeps it out of
+    // reach of the linker's `--as-needed` pruning (which can otherwise drop a
+    // `-lwayland-client` that appears before the code referencing it, depending
+    // on link ordering) and propagates the link requirement to every binary and
+    // test that depends on this crate. gtk4-layer-shell interposition ordering
+    // is still the final binary's concern (see the shell's build script).
+    #[link(name = "wayland-client")]
     unsafe extern "C" {
         pub fn wl_display_roundtrip(display: *mut super::WlDisplay) -> c_int;
         pub fn wl_proxy_add_listener(

--- a/crates/wayle-ipc/Cargo.toml
+++ b/crates/wayle-ipc/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 license.workspace = true
 
 [dependencies]
+serde.workspace = true
 zbus.workspace = true
 
 [lints]

--- a/crates/wayle-ipc/src/shell_ipc.rs
+++ b/crates/wayle-ipc/src/shell_ipc.rs
@@ -1,13 +1,31 @@
 //! D-Bus client proxy for shell IPC commands.
 #![allow(missing_docs)]
 
-use zbus::{Result, proxy};
+use serde::{Deserialize, Serialize};
+use zbus::{Result, proxy, zvariant::Type};
 
 /// D-Bus service name for shell IPC.
 pub const SERVICE_NAME: &str = "com.wayle.Shell1";
 
 /// D-Bus object path for shell IPC.
 pub const SERVICE_PATH: &str = "/com/wayle/Shell";
+
+/// A device the OSD show methods can target.
+#[derive(Debug, Clone, Serialize, Deserialize, Type)]
+pub struct OsdDeviceInfo {
+    /// Device class: `speaker`, `microphone` or `brightness`.
+    pub kind: String,
+
+    /// Stable identifier accepted by the show methods: the PulseAudio node
+    /// name for audio, the sysfs directory name for backlights.
+    pub id: String,
+
+    /// Human-readable name, as shown on the overlay.
+    pub label: String,
+
+    /// Whether this is the device used when no device is named.
+    pub is_default: bool,
+}
 
 #[proxy(
     interface = "com.wayle.Shell1",
@@ -21,6 +39,14 @@ pub trait ShellIpc {
     async fn bar_show(&self, monitor: &str) -> Result<()>;
 
     async fn bar_toggle(&self, monitor: &str) -> Result<()>;
+
+    async fn osd_show_speaker(&self, device: &str) -> Result<String>;
+
+    async fn osd_show_microphone(&self, device: &str) -> Result<String>;
+
+    async fn osd_show_brightness(&self, device: &str) -> Result<String>;
+
+    async fn osd_devices(&self) -> Result<Vec<OsdDeviceInfo>>;
 
     #[zbus(property)]
     fn bar_hidden(&self) -> Result<Vec<String>>;

--- a/crates/wayle-settings/src/pages/osd/mod.rs
+++ b/crates/wayle-settings/src/pages/osd/mod.rs
@@ -1,4 +1,4 @@
-//! OSD settings page: display options for on-screen indicators.
+//! OSD settings page: appearance and automatic display of on-screen indicators.
 
 use wayle_config::Config;
 
@@ -24,18 +24,29 @@ pub(crate) fn entry(config: &Config) -> LeafEntry {
         icon: "ld-monitor-symbolic",
         spec: page_spec(
             "settings-page-osd",
-            vec![SectionSpec {
-                title_key: "settings-section-display",
-                items: vec![
-                    toggle(&osd.enabled),
-                    enum_select(&osd.position),
-                    enum_select(&osd.layer),
-                    number_u32(&osd.duration),
-                    text_like(&osd.monitor),
-                    spacing(&osd.margin),
-                    toggle(&osd.border),
-                ],
-            }],
+            vec![
+                SectionSpec {
+                    title_key: "settings-section-display",
+                    items: vec![
+                        toggle(&osd.enabled),
+                        enum_select(&osd.position),
+                        enum_select(&osd.layer),
+                        number_u32(&osd.duration),
+                        text_like(&osd.monitor),
+                        spacing(&osd.margin),
+                        toggle(&osd.border),
+                    ],
+                },
+                SectionSpec {
+                    title_key: "settings-section-behavior",
+                    items: vec![
+                        toggle(&osd.auto_speaker),
+                        toggle(&osd.auto_microphone),
+                        toggle(&osd.auto_brightness),
+                        toggle(&osd.auto_toggles),
+                    ],
+                },
+            ],
         ),
     }
 }

--- a/crates/wayle-shell/src/bootstrap/mod.rs
+++ b/crates/wayle-shell/src/bootstrap/mod.rs
@@ -145,7 +145,13 @@ pub async fn init_services() -> Result<(StartupTimer, ShellServices), Box<dyn Er
     spawn_deferred_bluetooth(bluetooth.clone());
     spawn_deferred_power_profiles(power_profiles.clone());
 
-    let shell_ipc = match ShellIpcService::new().await {
+    let shell_ipc = match ShellIpcService::new(
+        Arc::clone(&config_service),
+        daemons.audio.clone(),
+        core.brightness.clone(),
+    )
+    .await
+    {
         Ok(service) => Arc::new(service),
         Err(err) => {
             warn!(error = %err, "Shell IPC service unavailable");

--- a/crates/wayle-shell/src/services/shell_ipc/dbus.rs
+++ b/crates/wayle-shell/src/services/shell_ipc/dbus.rs
@@ -1,19 +1,32 @@
 //! D-Bus interface adapter for shell IPC.
 
+use std::sync::Arc;
+
+use wayle_audio::AudioService;
+use wayle_brightness::BrightnessService;
+use wayle_config::ConfigService;
+use wayle_ipc::shell_ipc::OsdDeviceInfo;
 use zbus::{fdo, interface};
 
-use super::{bar::BarVisibility, state::ShellIpcState};
+use super::{bar::BarVisibility, osd::OsdControl, state::ShellIpcState};
 
 /// D-Bus daemon that dispatches shell commands to domain handlers.
 pub(crate) struct ShellIpcDaemon {
     bar: BarVisibility,
+    osd: OsdControl,
     state: ShellIpcState,
 }
 
 impl ShellIpcDaemon {
-    pub(crate) fn new(state: ShellIpcState) -> Self {
+    pub(crate) fn new(
+        state: ShellIpcState,
+        config: Arc<ConfigService>,
+        audio: Option<Arc<AudioService>>,
+        brightness: Option<Arc<BrightnessService>>,
+    ) -> Self {
         Self {
             bar: BarVisibility::new(state.clone()),
+            osd: OsdControl::new(state.clone(), config, audio, brightness),
             state,
         }
     }
@@ -34,6 +47,35 @@ impl ShellIpcDaemon {
     /// Toggles bar visibility on a monitor. Empty string toggles all.
     pub async fn bar_toggle(&self, monitor: &str) -> fdo::Result<()> {
         self.bar.toggle(monitor)
+    }
+
+    /// Shows the speaker OSD regardless of whether the volume changed.
+    ///
+    /// Empty device targets the default output. Returns the resolved device
+    /// description.
+    pub async fn osd_show_speaker(&self, device: &str) -> fdo::Result<String> {
+        self.osd.show_speaker(device)
+    }
+
+    /// Shows the microphone OSD regardless of whether the volume changed.
+    ///
+    /// Empty device targets the default input. Returns the resolved device
+    /// description.
+    pub async fn osd_show_microphone(&self, device: &str) -> fdo::Result<String> {
+        self.osd.show_microphone(device)
+    }
+
+    /// Shows the brightness OSD regardless of whether brightness changed.
+    ///
+    /// Empty device targets the primary backlight. Returns the resolved
+    /// device name.
+    pub async fn osd_show_brightness(&self, device: &str) -> fdo::Result<String> {
+        self.osd.show_brightness(device)
+    }
+
+    /// Devices the OSD show methods can target.
+    pub async fn osd_devices(&self) -> Vec<OsdDeviceInfo> {
+        self.osd.devices()
     }
 
     /// Currently hidden monitor connectors.

--- a/crates/wayle-shell/src/services/shell_ipc/mod.rs
+++ b/crates/wayle-shell/src/services/shell_ipc/mod.rs
@@ -1,24 +1,31 @@
 //! Shell IPC service exposing `com.wayle.Shell1` on the session bus.
 //!
-//! Provides bar visibility control (hide/show/toggle per monitor) via
-//! D-Bus methods, and reactive [`ShellIpcState`] that bar components
-//! watch to apply visibility changes.
+//! Provides bar visibility control (hide/show/toggle per monitor) and manual
+//! OSD display via D-Bus methods, plus reactive [`ShellIpcState`] that shell
+//! components watch to apply those commands.
 
 mod bar;
 mod dbus;
 mod error;
+mod osd;
 mod state;
 
+use std::sync::Arc;
+
 pub use error::Error;
-pub use state::ShellIpcState;
+pub use state::{OsdDevice, OsdRequest, ShellIpcState};
 use tracing::info;
+use wayle_audio::AudioService;
+use wayle_brightness::BrightnessService;
+use wayle_config::ConfigService;
 use wayle_ipc::shell_ipc::{SERVICE_NAME, SERVICE_PATH};
 use zbus::Connection;
 
 use self::dbus::ShellIpcDaemon;
 
 /// Registers the `com.wayle.Shell1` D-Bus interface and holds the
-/// [`ShellIpcState`] that bar components watch for visibility changes.
+/// [`ShellIpcState`] that shell components watch for visibility and OSD
+/// commands.
 pub struct ShellIpcService {
     state: ShellIpcState,
     _connection: Connection,
@@ -27,18 +34,26 @@ pub struct ShellIpcService {
 impl ShellIpcService {
     /// Connects to the session bus and registers the `com.wayle.Shell1` interface.
     ///
+    /// The audio and brightness services are used to resolve the device named
+    /// in an OSD request; when either is unavailable the matching OSD commands
+    /// report that instead of failing silently.
+    ///
     /// # Errors
     ///
     /// Returns an error if the session bus is unreachable or the D-Bus name
     /// is already claimed.
-    pub async fn new() -> Result<Self, Error> {
+    pub async fn new(
+        config: Arc<ConfigService>,
+        audio: Option<Arc<AudioService>>,
+        brightness: Option<Arc<BrightnessService>>,
+    ) -> Result<Self, Error> {
         let state = ShellIpcState::new();
 
         let connection = Connection::session()
             .await
             .map_err(|err| Error::Connection(err.to_string()))?;
 
-        let daemon = ShellIpcDaemon::new(state.clone());
+        let daemon = ShellIpcDaemon::new(state.clone(), config, audio, brightness);
 
         connection
             .object_server()
@@ -59,7 +74,7 @@ impl ShellIpcService {
         })
     }
 
-    /// Reactive state that bar components subscribe to for visibility updates.
+    /// Reactive state that shell components subscribe to for IPC commands.
     pub fn state(&self) -> ShellIpcState {
         self.state.clone()
     }

--- a/crates/wayle-shell/src/services/shell_ipc/osd.rs
+++ b/crates/wayle-shell/src/services/shell_ipc/osd.rs
@@ -1,0 +1,464 @@
+//! On-screen display domain logic.
+//!
+//! Resolves the device named on the command line before publishing an
+//! [`OsdRequest`], so a bad name fails the D-Bus call instead of silently
+//! doing nothing, and so [`OsdControl::devices`] can list exactly the
+//! identifiers the show methods accept.
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
+
+use tracing::{debug, instrument};
+use wayle_audio::{
+    AudioService,
+    core::device::{input::InputDevice, output::OutputDevice},
+};
+use wayle_brightness::{BacklightDevice, BrightnessService};
+use wayle_config::ConfigService;
+use wayle_ipc::shell_ipc::OsdDeviceInfo;
+use zbus::fdo;
+
+use super::state::{OsdDevice, OsdRequest, ShellIpcState};
+
+const KIND_SPEAKER: &str = "speaker";
+const KIND_MICROPHONE: &str = "microphone";
+const KIND_BRIGHTNESS: &str = "brightness";
+
+/// One targetable device, flattened for matching and error messages.
+struct Candidate {
+    /// PulseAudio sink or source index. `None` for backlights.
+    index: Option<u32>,
+
+    /// Stable identifier: node name for audio, sysfs name for backlights.
+    id: String,
+
+    /// Human-readable name, as shown on the overlay.
+    label: String,
+}
+
+/// Why a query didn't resolve to exactly one device.
+enum Unresolved {
+    NoMatch,
+    Ambiguous(Vec<String>),
+}
+
+/// OSD display logic. Resolves device queries against the live service state
+/// and publishes [`ShellIpcState::osd_request`].
+pub(crate) struct OsdControl {
+    state: ShellIpcState,
+    config: Arc<ConfigService>,
+    audio: Option<Arc<AudioService>>,
+    brightness: Option<Arc<BrightnessService>>,
+    seq: AtomicU64,
+}
+
+impl OsdControl {
+    pub(crate) fn new(
+        state: ShellIpcState,
+        config: Arc<ConfigService>,
+        audio: Option<Arc<AudioService>>,
+        brightness: Option<Arc<BrightnessService>>,
+    ) -> Self {
+        Self {
+            state,
+            config,
+            audio,
+            brightness,
+            seq: AtomicU64::new(0),
+        }
+    }
+
+    /// Shows the speaker OSD. Empty query targets the default output.
+    #[instrument(skip(self))]
+    pub(crate) fn show_speaker(&self, query: &str) -> fdo::Result<String> {
+        self.ensure_enabled()?;
+
+        let device = self.resolve_output(query)?;
+        let label = device.description.get();
+
+        self.publish(OsdDevice::Speaker(device));
+
+        Ok(label)
+    }
+
+    /// Shows the microphone OSD. Empty query targets the default input.
+    #[instrument(skip(self))]
+    pub(crate) fn show_microphone(&self, query: &str) -> fdo::Result<String> {
+        self.ensure_enabled()?;
+
+        let device = self.resolve_input(query)?;
+        let label = device.description.get();
+
+        self.publish(OsdDevice::Microphone(device));
+
+        Ok(label)
+    }
+
+    /// Shows the brightness OSD. Empty query targets the primary backlight.
+    #[instrument(skip(self))]
+    pub(crate) fn show_brightness(&self, query: &str) -> fdo::Result<String> {
+        self.ensure_enabled()?;
+
+        let device = self.resolve_brightness(query)?;
+        let label = device.name.to_string();
+
+        self.publish(OsdDevice::Brightness(device));
+
+        Ok(label)
+    }
+
+    /// Every device the show methods can target.
+    pub(crate) fn devices(&self) -> Vec<OsdDeviceInfo> {
+        let mut devices = Vec::new();
+
+        if let Some(audio) = &self.audio {
+            let default = audio.default_output.get().map(|device| device.key);
+
+            devices.extend(audio.output_devices.get().iter().map(|device| OsdDeviceInfo {
+                kind: String::from(KIND_SPEAKER),
+                id: device.name.get(),
+                label: device.description.get(),
+                is_default: default == Some(device.key),
+            }));
+
+            let default = audio.default_input.get().map(|device| device.key);
+
+            devices.extend(input_devices(audio).iter().map(|device| OsdDeviceInfo {
+                kind: String::from(KIND_MICROPHONE),
+                id: device.name.get(),
+                label: device.description.get(),
+                is_default: default == Some(device.key),
+            }));
+        }
+
+        if let Some(brightness) = &self.brightness {
+            let primary = brightness.primary.get().map(|device| device.name.clone());
+
+            devices.extend(brightness.devices.get().iter().map(|device| OsdDeviceInfo {
+                kind: String::from(KIND_BRIGHTNESS),
+                id: device.name.to_string(),
+                label: device.name.to_string(),
+                is_default: primary.as_ref() == Some(&device.name),
+            }));
+        }
+
+        devices
+    }
+
+    fn ensure_enabled(&self) -> fdo::Result<()> {
+        if self.config.config().osd.enabled.get() {
+            return Ok(());
+        }
+
+        Err(fdo::Error::Failed(String::from(
+            "OSD is disabled; enable it with `wayle config set osd.enabled true`",
+        )))
+    }
+
+    fn publish(&self, device: OsdDevice) {
+        let seq = self.seq.fetch_add(1, Ordering::Relaxed).saturating_add(1);
+
+        debug!(seq, "publishing OSD request");
+
+        self.state
+            .osd_request
+            .replace(Some(OsdRequest { seq, device }));
+    }
+
+    fn audio(&self) -> fdo::Result<&Arc<AudioService>> {
+        self.audio
+            .as_ref()
+            .ok_or_else(|| fdo::Error::Failed(String::from("audio service unavailable")))
+    }
+
+    fn brightness(&self) -> fdo::Result<&Arc<BrightnessService>> {
+        self.brightness
+            .as_ref()
+            .ok_or_else(|| fdo::Error::Failed(String::from("no backlight devices available")))
+    }
+
+    fn resolve_output(&self, query: &str) -> fdo::Result<Arc<OutputDevice>> {
+        let audio = self.audio()?;
+
+        if query.is_empty() {
+            return audio
+                .default_output
+                .get()
+                .ok_or_else(|| fdo::Error::Failed(String::from("no default output device")));
+        }
+
+        resolve(
+            query,
+            "output device",
+            audio.output_devices.get(),
+            |device| Candidate {
+                index: Some(device.key.index),
+                id: device.name.get(),
+                label: device.description.get(),
+            },
+        )
+    }
+
+    fn resolve_input(&self, query: &str) -> fdo::Result<Arc<InputDevice>> {
+        let audio = self.audio()?;
+
+        if query.is_empty() {
+            return audio
+                .default_input
+                .get()
+                .ok_or_else(|| fdo::Error::Failed(String::from("no default input device")));
+        }
+
+        resolve(query, "input device", input_devices(audio), |device| {
+            Candidate {
+                index: Some(device.key.index),
+                id: device.name.get(),
+                label: device.description.get(),
+            }
+        })
+    }
+
+    fn resolve_brightness(&self, query: &str) -> fdo::Result<Arc<BacklightDevice>> {
+        let brightness = self.brightness()?;
+
+        if query.is_empty() {
+            return brightness
+                .primary
+                .get()
+                .ok_or_else(|| fdo::Error::Failed(String::from("no backlight devices available")));
+        }
+
+        resolve(
+            query,
+            "backlight device",
+            brightness.devices.get(),
+            |device| Candidate {
+                index: None,
+                id: device.name.to_string(),
+                label: device.name.to_string(),
+            },
+        )
+    }
+}
+
+/// Input devices excluding monitor sources, which mirror an output and aren't
+/// meaningful microphone targets.
+fn input_devices(audio: &AudioService) -> Vec<Arc<InputDevice>> {
+    audio
+        .input_devices
+        .get()
+        .into_iter()
+        .filter(|device| !device.is_monitor.get())
+        .collect()
+}
+
+/// Picks the one device in `devices` that `query` names.
+///
+/// `kind` names the device class in error messages; `describe` flattens a
+/// device into the fields the query is matched against.
+fn resolve<T>(
+    query: &str,
+    kind: &str,
+    devices: Vec<T>,
+    describe: impl Fn(&T) -> Candidate,
+) -> fdo::Result<T> {
+    let candidates: Vec<Candidate> = devices.iter().map(describe).collect();
+
+    let position =
+        match_query(query, &candidates).map_err(|reason| error(kind, query, reason, &candidates))?;
+
+    devices
+        .into_iter()
+        .nth(position)
+        .ok_or_else(|| error(kind, query, Unresolved::NoMatch, &candidates))
+}
+
+/// Matches a query against candidates, most specific rule first: PulseAudio
+/// index, exact id, case-insensitive label, then a substring of either.
+///
+/// A numeric query only ever means an index. Letting it fall through to
+/// substring matching would resolve a stale index to whichever unrelated
+/// device happens to have those digits in its node name.
+fn match_query(query: &str, candidates: &[Candidate]) -> Result<usize, Unresolved> {
+    if let Ok(index) = query.parse::<u32>()
+        && candidates.iter().any(|it| it.index.is_some())
+    {
+        return candidates
+            .iter()
+            .position(|it| it.index == Some(index))
+            .ok_or(Unresolved::NoMatch);
+    }
+
+    if let Some(position) = candidates.iter().position(|it| it.id == query) {
+        return Ok(position);
+    }
+
+    let query = query.to_lowercase();
+
+    let exact = positions(candidates, |it| it.label.to_lowercase() == query);
+
+    if !exact.is_empty() {
+        return only(exact, candidates);
+    }
+
+    let substring = positions(candidates, |it| {
+        it.id.to_lowercase().contains(&query) || it.label.to_lowercase().contains(&query)
+    });
+
+    only(substring, candidates)
+}
+
+fn positions(candidates: &[Candidate], matches: impl Fn(&Candidate) -> bool) -> Vec<usize> {
+    candidates
+        .iter()
+        .enumerate()
+        .filter(|(_, candidate)| matches(candidate))
+        .map(|(position, _)| position)
+        .collect()
+}
+
+/// Accepts a match set only when it names one device.
+fn only(matched: Vec<usize>, candidates: &[Candidate]) -> Result<usize, Unresolved> {
+    match matched.as_slice() {
+        [position] => Ok(*position),
+        [] => Err(Unresolved::NoMatch),
+        _ => Err(Unresolved::Ambiguous(
+            matched
+                .iter()
+                .filter_map(|position| candidates.get(*position))
+                .map(label)
+                .collect(),
+        )),
+    }
+}
+
+fn error(kind: &str, query: &str, reason: Unresolved, candidates: &[Candidate]) -> fdo::Error {
+    match reason {
+        Unresolved::Ambiguous(matched) => fdo::Error::Failed(format!(
+            "\"{query}\" matches several devices: {}",
+            matched.join(", ")
+        )),
+
+        Unresolved::NoMatch if candidates.is_empty() => {
+            fdo::Error::Failed(format!("no {kind} available"))
+        }
+
+        Unresolved::NoMatch => fdo::Error::Failed(format!(
+            "no {kind} matching \"{query}\". Available: {}",
+            candidates
+                .iter()
+                .map(label)
+                .collect::<Vec<String>>()
+                .join(", ")
+        )),
+    }
+}
+
+fn label(candidate: &Candidate) -> String {
+    if candidate.id == candidate.label {
+        return candidate.id.clone();
+    }
+
+    format!("{} ({})", candidate.label, candidate.id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn audio(index: u32, id: &str, label: &str) -> Candidate {
+        Candidate {
+            index: Some(index),
+            id: String::from(id),
+            label: String::from(label),
+        }
+    }
+
+    fn backlight(name: &str) -> Candidate {
+        Candidate {
+            index: None,
+            id: String::from(name),
+            label: String::from(name),
+        }
+    }
+
+    fn sinks() -> Vec<Candidate> {
+        vec![
+            audio(0, "alsa_output.pci-0000_00_1f.3.analog-stereo", "Built-in Audio"),
+            audio(55, "bluez_output.AC_12_2F_5D_00_01.1", "WH-1000XM4"),
+        ]
+    }
+
+    #[test]
+    fn numeric_query_matches_index() {
+        assert!(matches!(match_query("55", &sinks()), Ok(1)));
+    }
+
+    #[test]
+    fn numeric_query_never_falls_through_to_substring() {
+        // "3" appears in `pci-0000_00_1f.3`; a stale index must not silently
+        // resolve to whichever device happens to have those digits.
+        assert!(matches!(
+            match_query("3", &sinks()),
+            Err(Unresolved::NoMatch)
+        ));
+    }
+
+    #[test]
+    fn numeric_query_matches_by_name_when_no_device_has_an_index() {
+        let backlights = vec![backlight("amdgpu_bl1"), backlight("acpi_video0")];
+
+        assert!(matches!(match_query("1", &backlights), Ok(0)));
+    }
+
+    #[test]
+    fn exact_id_wins_over_substring() {
+        let candidates = vec![
+            audio(0, "usb", "First"),
+            audio(1, "usb-extended", "Second"),
+        ];
+
+        assert!(matches!(match_query("usb", &candidates), Ok(0)));
+    }
+
+    #[test]
+    fn label_match_ignores_case() {
+        assert!(matches!(match_query("wh-1000xm4", &sinks()), Ok(1)));
+    }
+
+    #[test]
+    fn duplicate_labels_are_ambiguous() {
+        let candidates = vec![
+            audio(0, "alsa_output.usb-first", "USB Audio"),
+            audio(1, "alsa_output.usb-second", "USB Audio"),
+        ];
+
+        assert!(matches!(
+            match_query("usb audio", &candidates),
+            Err(Unresolved::Ambiguous(_))
+        ));
+    }
+
+    #[test]
+    fn unique_substring_resolves() {
+        assert!(matches!(match_query("xm4", &sinks()), Ok(1)));
+    }
+
+    #[test]
+    fn shared_substring_is_ambiguous() {
+        assert!(matches!(
+            match_query("output", &sinks()),
+            Err(Unresolved::Ambiguous(_))
+        ));
+    }
+
+    #[test]
+    fn unknown_query_does_not_match() {
+        assert!(matches!(
+            match_query("nonexistent", &sinks()),
+            Err(Unresolved::NoMatch)
+        ));
+    }
+}

--- a/crates/wayle-shell/src/services/shell_ipc/state.rs
+++ b/crates/wayle-shell/src/services/shell_ipc/state.rs
@@ -1,7 +1,9 @@
 //! Reactive state for shell IPC.
 
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::Arc};
 
+use wayle_audio::core::device::{input::InputDevice, output::OutputDevice};
+use wayle_brightness::BacklightDevice;
 use wayle_core::Property;
 
 /// Shared reactive state exposed to shell components via `ShellIpcService`.
@@ -15,6 +17,38 @@ pub struct ShellIpcState {
     /// All active monitor connectors. Updated by the shell when bars are
     /// created or destroyed.
     pub connectors: Property<Vec<String>>,
+
+    /// Most recent CLI request to display an OSD, or `None` before the first
+    /// request. Written with [`Property::replace`] so repeat requests for an
+    /// unchanged device still notify.
+    pub osd_request: Property<Option<OsdRequest>>,
+}
+
+/// A CLI request to display an OSD for an already-resolved device.
+#[derive(Debug, Clone)]
+pub struct OsdRequest {
+    /// Monotonic counter, starting at 1.
+    ///
+    /// [`Property::watch`] replays the current value to every new subscriber,
+    /// so consumers track the sequence they have seen and ignore anything at
+    /// or below it.
+    pub seq: u64,
+
+    /// Device to display.
+    pub device: OsdDevice,
+}
+
+/// A device the OSD can report on.
+#[derive(Debug, Clone, PartialEq)]
+pub enum OsdDevice {
+    /// Output device volume and mute state.
+    Speaker(Arc<OutputDevice>),
+
+    /// Input device volume and mute state.
+    Microphone(Arc<InputDevice>),
+
+    /// Backlight device brightness.
+    Brightness(Arc<BacklightDevice>),
 }
 
 impl ShellIpcState {
@@ -22,6 +56,7 @@ impl ShellIpcState {
         Self {
             hidden_bars: Property::new(HashSet::new()),
             connectors: Property::new(Vec::new()),
+            osd_request: Property::new(None),
         }
     }
 }

--- a/crates/wayle-shell/src/shell/mod.rs
+++ b/crates/wayle-shell/src/shell/mod.rs
@@ -103,7 +103,7 @@ impl Component for Shell {
                 .detach()
         });
 
-        let osd = create_osd(&init.services);
+        let osd = create_osd(&init.services, 0);
 
         let model = Shell {
             css_provider,
@@ -179,7 +179,10 @@ impl Shell {
 
     fn toggle_osd(&mut self, enabled: bool) {
         if enabled && self._osd.is_none() {
-            self._osd = create_osd(&self.services);
+            let ipc = self.services.shell_ipc.state();
+            let seen_seq = ipc.osd_request.get().map_or(0, |request| request.seq);
+
+            self._osd = create_osd(&self.services, seen_seq);
             debug!("OSD enabled");
         } else if !enabled && let Some(controller) = self._osd.take() {
             controller.widget().destroy();
@@ -188,7 +191,13 @@ impl Shell {
     }
 }
 
-fn create_osd(services: &ShellServices) -> Option<Controller<Osd>> {
+/// Builds the OSD component, ignoring IPC requests at or below `seen_seq`.
+///
+/// Startup passes 0, so a request that landed while the shell was still coming
+/// up still renders. Recreating after an `osd.enabled` toggle passes the
+/// pending sequence, so the request `Property::watch()` replays to the new
+/// subscriber is dropped instead of resurfacing.
+fn create_osd(services: &ShellServices, seen_seq: u64) -> Option<Controller<Osd>> {
     let osd_enabled = services.config.config().osd.enabled.get();
 
     if !osd_enabled {
@@ -201,6 +210,8 @@ fn create_osd(services: &ShellServices) -> Option<Controller<Osd>> {
                 config: services.config.clone(),
                 audio: services.audio.clone(),
                 brightness: services.brightness.clone(),
+                shell_ipc: services.shell_ipc.state(),
+                seen_seq,
             })
             .detach(),
     )

--- a/crates/wayle-shell/src/shell/osd/messages.rs
+++ b/crates/wayle-shell/src/shell/osd/messages.rs
@@ -7,10 +7,18 @@ use wayle_audio::{
 use wayle_brightness::{BacklightDevice, BrightnessService};
 use wayle_config::ConfigService;
 
+use crate::services::shell_ipc::{OsdRequest, ShellIpcState};
+
 pub(crate) struct OsdInit {
     pub(crate) config: Arc<ConfigService>,
     pub(crate) audio: Option<Arc<AudioService>>,
     pub(crate) brightness: Option<Arc<BrightnessService>>,
+    pub(crate) shell_ipc: ShellIpcState,
+
+    /// Requests at or below this sequence are ignored. Non-zero only when the
+    /// component is being recreated, to skip the request `Property::watch()`
+    /// replays to every new subscriber.
+    pub(crate) seen_seq: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -41,6 +49,8 @@ pub(crate) enum OsdCmd {
     BrightnessDeviceChanged(Option<Arc<BacklightDevice>>),
     BrightnessChanged,
     ToggleChanged(ToggleEvent),
+    ShowRequested(Option<OsdRequest>),
+    DisplayedValueChanged,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/wayle-shell/src/shell/osd/methods.rs
+++ b/crates/wayle-shell/src/shell/osd/methods.rs
@@ -13,6 +13,7 @@ use super::{
 };
 use crate::{
     i18n::t,
+    services::shell_ipc::{OsdDevice, OsdRequest},
     shell::helpers::layer_shell::{
         apply_layer as apply_window_layer, apply_monitor_by_connector, apply_primary_monitor,
         reset_anchors,
@@ -20,16 +21,17 @@ use crate::{
 };
 
 impl Osd {
-    pub(super) fn show_event(
+    /// Shows an event and restarts the dismiss timer.
+    ///
+    /// `displayed` is the device the reading came from, `None` for keyboard
+    /// toggles. It is watched until the overlay is dismissed.
+    fn present(
         &mut self,
         event: OsdEvent,
+        displayed: Option<OsdDevice>,
         sender: &ComponentSender<Self>,
         root: &gtk::Window,
     ) {
-        if !self.ready {
-            return;
-        }
-
         self.current_event = Some(event);
         self.dismiss_id = self.dismiss_id.wrapping_add(1);
 
@@ -37,6 +39,60 @@ impl Osd {
 
         let duration = self.config.config().osd.duration.get();
         Self::schedule_dismiss(sender, duration, self.dismiss_id);
+
+        self.watch_displayed(displayed, sender);
+    }
+
+    /// [`Self::present`] for change-driven events, held back until the
+    /// startup replay has passed.
+    pub(super) fn show_event(
+        &mut self,
+        event: OsdEvent,
+        displayed: Option<OsdDevice>,
+        sender: &ComponentSender<Self>,
+        root: &gtk::Window,
+    ) {
+        if !self.ready {
+            return;
+        }
+
+        self.present(event, displayed, sender, root);
+    }
+
+    /// Re-points the live watcher, skipping the re-arm when the device is
+    /// unchanged so a rapid stream of changes doesn't churn watcher tasks.
+    fn watch_displayed(
+        &mut self,
+        displayed: Option<OsdDevice>,
+        sender: &ComponentSender<Self>,
+    ) {
+        if self.displayed == displayed {
+            return;
+        }
+
+        let token = self.displayed_watcher.reset();
+        self.displayed = displayed;
+
+        if let Some(device) = &self.displayed {
+            watchers::spawn_displayed_watcher(sender, device, token);
+        }
+    }
+
+    /// Stops tracking on dismiss, so nothing recomputes an overlay nobody can
+    /// see.
+    pub(super) fn clear_displayed(&mut self) {
+        self.displayed_watcher.reset();
+        self.displayed = None;
+    }
+
+    /// Refreshes the reading without touching the dismiss timer, so a stream
+    /// of changes can't hold the overlay open indefinitely.
+    pub(super) fn handle_displayed_value_changed(&mut self) {
+        let Some(displayed) = &self.displayed else {
+            return;
+        };
+
+        self.current_event = Some(displayed_event(displayed));
     }
 
     pub(super) fn handle_device_changed(
@@ -64,11 +120,7 @@ impl Osd {
             return;
         };
 
-        let percentage = device.volume.get().average_percentage();
-        let muted = device.muted.get();
-        let rounded = percentage.round() as u32;
-
-        let snapshot = (rounded, muted);
+        let (event, snapshot) = output_event(&device);
 
         if self.last_volume == Some(snapshot) {
             return;
@@ -76,17 +128,11 @@ impl Osd {
 
         self.last_volume = Some(snapshot);
 
-        let description = device.description.get();
-        let icon = volume_icon(percentage, muted);
+        if !self.config.config().osd.auto_speaker.get() {
+            return;
+        }
 
-        let event = OsdEvent::Slider {
-            label: description,
-            icon: icon.to_string(),
-            percentage,
-            muted,
-        };
-
-        self.show_event(event, sender, root);
+        self.show_event(event, Some(OsdDevice::Speaker(device)), sender, root);
     }
 
     pub(super) fn handle_brightness_device_changed(
@@ -114,23 +160,19 @@ impl Osd {
             return;
         };
 
-        let percentage = device.percentage().value();
-        let rounded = percentage.round() as u32;
+        let (event, snapshot) = brightness_event(&device);
 
-        if self.last_brightness == Some(rounded) {
+        if self.last_brightness == Some(snapshot) {
             return;
         }
 
-        self.last_brightness = Some(rounded);
+        self.last_brightness = Some(snapshot);
 
-        let event = OsdEvent::Slider {
-            label: device.name.to_string(),
-            icon: BRIGHTNESS_ICON.to_string(),
-            percentage,
-            muted: false,
-        };
+        if !self.config.config().osd.auto_brightness.get() {
+            return;
+        }
 
-        self.show_event(event, sender, root);
+        self.show_event(event, Some(OsdDevice::Brightness(device)), sender, root);
     }
 
     pub(super) fn handle_input_device_changed(
@@ -158,11 +200,7 @@ impl Osd {
             return;
         };
 
-        let percentage = device.volume.get().average_percentage();
-        let muted = device.muted.get();
-        let rounded = percentage.round() as u32;
-
-        let snapshot = (rounded, muted);
+        let (event, snapshot) = input_event(&device);
 
         if self.last_input_volume == Some(snapshot) {
             return;
@@ -170,22 +208,11 @@ impl Osd {
 
         self.last_input_volume = Some(snapshot);
 
-        let description = device.description.get();
+        if !self.config.config().osd.auto_microphone.get() {
+            return;
+        }
 
-        let icon = if muted {
-            "ld-mic-off-symbolic"
-        } else {
-            "ld-mic-symbolic"
-        };
-
-        let event = OsdEvent::Slider {
-            label: description,
-            icon: icon.to_string(),
-            percentage,
-            muted,
-        };
-
-        self.show_event(event, sender, root);
+        self.show_event(event, Some(OsdDevice::Microphone(device)), sender, root);
     }
 
     pub(super) fn handle_toggle_changed(
@@ -194,6 +221,10 @@ impl Osd {
         sender: &ComponentSender<Self>,
         root: &gtk::Window,
     ) {
+        if !self.config.config().osd.auto_toggles.get() {
+            return;
+        }
+
         let (label, icon) = match toggle.key {
             messages::ToggleKey::CapsLock => (t!("osd-caps-lock"), "ld-a-large-small-symbolic"),
             messages::ToggleKey::NumLock => (t!("osd-num-lock"), "ld-hash-symbolic"),
@@ -206,7 +237,32 @@ impl Osd {
             active: toggle.active,
         };
 
-        self.show_event(event, sender, root);
+        self.show_event(event, None, sender, root);
+    }
+
+    /// Shows the device an IPC client asked for, whatever its value.
+    ///
+    /// The `last_*` snapshots are left alone: they track the *default* device,
+    /// and a request may name any device.
+    pub(super) fn handle_show_requested(
+        &mut self,
+        request: Option<OsdRequest>,
+        sender: &ComponentSender<Self>,
+        root: &gtk::Window,
+    ) {
+        let Some(OsdRequest { seq, device }) = request else {
+            return;
+        };
+
+        if seq <= self.seen_seq {
+            return;
+        }
+
+        self.seen_seq = seq;
+
+        let event = displayed_event(&device);
+
+        self.present(event, Some(device), sender, root);
     }
 
     pub(super) fn apply_position(&self, root: &gtk::Window) {
@@ -293,6 +349,68 @@ impl Osd {
             OsdCmd::Dismiss(dismiss_id)
         });
     }
+}
+
+/// Reads a device's current values into a renderable event.
+fn displayed_event(device: &OsdDevice) -> OsdEvent {
+    match device {
+        OsdDevice::Speaker(device) => output_event(device).0,
+        OsdDevice::Microphone(device) => input_event(device).0,
+        OsdDevice::Brightness(device) => brightness_event(device).0,
+    }
+}
+
+/// Builds the speaker OSD payload and the snapshot used to detect a change.
+///
+/// The snapshot is the rounded percentage, not the raw float, so per-channel
+/// jitter below a whole percent doesn't count as a change.
+fn output_event(device: &OutputDevice) -> (OsdEvent, (u32, bool)) {
+    let percentage = device.volume.get().average_percentage();
+    let muted = device.muted.get();
+
+    let event = OsdEvent::Slider {
+        label: device.description.get(),
+        icon: volume_icon(percentage, muted).to_string(),
+        percentage,
+        muted,
+    };
+
+    (event, (percentage.round() as u32, muted))
+}
+
+/// Builds the microphone OSD payload and its change-detection snapshot.
+fn input_event(device: &InputDevice) -> (OsdEvent, (u32, bool)) {
+    let percentage = device.volume.get().average_percentage();
+    let muted = device.muted.get();
+
+    let icon = if muted {
+        "ld-mic-off-symbolic"
+    } else {
+        "ld-mic-symbolic"
+    };
+
+    let event = OsdEvent::Slider {
+        label: device.description.get(),
+        icon: icon.to_string(),
+        percentage,
+        muted,
+    };
+
+    (event, (percentage.round() as u32, muted))
+}
+
+/// Builds the brightness OSD payload and its change-detection snapshot.
+fn brightness_event(device: &BacklightDevice) -> (OsdEvent, u32) {
+    let percentage = device.percentage().value();
+
+    let event = OsdEvent::Slider {
+        label: device.name.to_string(),
+        icon: BRIGHTNESS_ICON.to_string(),
+        percentage,
+        muted: false,
+    };
+
+    (event, percentage.round() as u32)
 }
 
 pub(super) fn osd_classes(model: &Osd) -> Vec<&'static str> {

--- a/crates/wayle-shell/src/shell/osd/mod.rs
+++ b/crates/wayle-shell/src/shell/osd/mod.rs
@@ -22,6 +22,7 @@ use self::{
         is_toggle, osd_classes,
     },
 };
+use crate::services::shell_ipc::OsdDevice;
 
 const BRIGHTNESS_ICON: &str = "ld-sun-symbolic";
 
@@ -35,10 +36,17 @@ pub(crate) struct Osd {
     input_device_watcher: WatcherToken,
     brightness_watcher: WatcherToken,
 
+    /// Device the visible overlay is reporting on, watched while it stays up.
+    displayed: Option<OsdDevice>,
+    displayed_watcher: WatcherToken,
+
     current_event: Option<OsdEvent>,
     last_volume: Option<(u32, bool)>,
     last_input_volume: Option<(u32, bool)>,
     last_brightness: Option<u32>,
+
+    /// Highest IPC request sequence already handled.
+    seen_seq: u64,
 }
 
 #[allow(clippy::needless_borrow)]
@@ -160,10 +168,13 @@ impl Component for Osd {
             device_watcher: WatcherToken::new(),
             input_device_watcher: WatcherToken::new(),
             brightness_watcher: WatcherToken::new(),
+            displayed: None,
+            displayed_watcher: WatcherToken::new(),
             current_event: None,
             last_volume: None,
             last_input_volume: None,
             last_brightness: None,
+            seen_seq: init.seen_seq,
         };
 
         model.apply_position(&root);
@@ -176,7 +187,13 @@ impl Component for Osd {
 
         let widgets = view_output!();
 
-        watchers::spawn(&sender, &init.config, &init.audio, &init.brightness);
+        watchers::spawn(
+            &sender,
+            &init.config,
+            &init.audio,
+            &init.brightness,
+            &init.shell_ipc,
+        );
 
         ComponentParts { model, widgets }
     }
@@ -190,6 +207,7 @@ impl Component for Osd {
             OsdCmd::Dismiss(dismiss_id) => {
                 if dismiss_id == self.dismiss_id {
                     root.set_visible(false);
+                    self.clear_displayed();
                     debug!("OSD dismissed");
                 }
             }
@@ -225,6 +243,14 @@ impl Component for Osd {
 
             OsdCmd::ToggleChanged(toggle) => {
                 self.handle_toggle_changed(toggle, &sender, root);
+            }
+
+            OsdCmd::ShowRequested(request) => {
+                self.handle_show_requested(request, &sender, root);
+            }
+
+            OsdCmd::DisplayedValueChanged => {
+                self.handle_displayed_value_changed();
             }
         }
     }

--- a/crates/wayle-shell/src/shell/osd/watchers.rs
+++ b/crates/wayle-shell/src/shell/osd/watchers.rs
@@ -6,9 +6,11 @@ use tokio_util::sync::CancellationToken;
 use wayle_audio::{
     AudioService,
     core::device::{input::InputDevice, output::OutputDevice},
+    volume::types::Volume,
 };
 use wayle_brightness::{BacklightDevice, BrightnessService};
 use wayle_config::ConfigService;
+use wayle_core::Property;
 use wayle_widgets::{watch, watch_cancellable, watch_cancellable_throttled};
 
 use super::{
@@ -16,6 +18,7 @@ use super::{
     messages::{OsdCmd, ToggleEvent},
     toggles,
 };
+use crate::services::shell_ipc::{OsdDevice, ShellIpcState};
 
 const VOLUME_THROTTLE: Duration = Duration::from_millis(30);
 
@@ -24,6 +27,7 @@ pub(super) fn spawn(
     config: &Arc<ConfigService>,
     audio: &Option<Arc<AudioService>>,
     brightness: &Option<Arc<BrightnessService>>,
+    ipc: &ShellIpcState,
 ) {
     spawn_config_watcher(sender, config);
 
@@ -36,6 +40,17 @@ pub(super) fn spawn(
     }
 
     spawn_toggle_watchers(sender);
+    spawn_ipc_watcher(sender, ipc);
+}
+
+/// Watches for CLI-initiated show requests. The component drops replays by
+/// sequence, so this forwards every emission.
+fn spawn_ipc_watcher(sender: &ComponentSender<Osd>, ipc: &ShellIpcState) {
+    let osd_request = ipc.osd_request.clone();
+
+    watch!(sender, [osd_request.watch()], |out| {
+        let _ = out.send(OsdCmd::ShowRequested(osd_request.get()));
+    });
 }
 
 fn spawn_config_watcher(sender: &ComponentSender<Osd>, config: &Arc<ConfigService>) {
@@ -182,4 +197,53 @@ pub(super) fn spawn_brightness_watcher(
     watch_cancellable!(sender, token, [brightness.watch()], |out| {
         let _ = out.send(OsdCmd::BrightnessChanged);
     });
+}
+
+/// Watches the device currently on screen so its reading stays live.
+///
+/// The watchers above follow the *default* device to decide when to open the
+/// OSD; this one follows whatever is displayed, including a device named on
+/// the command line, and only refreshes the content.
+pub(super) fn spawn_displayed_watcher(
+    sender: &ComponentSender<Osd>,
+    device: &OsdDevice,
+    token: CancellationToken,
+) {
+    match device {
+        OsdDevice::Speaker(device) => {
+            spawn_volume_refresh(sender, &device.volume, &device.muted, token);
+        }
+
+        OsdDevice::Microphone(device) => {
+            spawn_volume_refresh(sender, &device.volume, &device.muted, token);
+        }
+
+        OsdDevice::Brightness(device) => {
+            let brightness = device.brightness.clone();
+
+            watch_cancellable!(sender, token, [brightness.watch()], |out| {
+                let _ = out.send(OsdCmd::DisplayedValueChanged);
+            });
+        }
+    }
+}
+
+fn spawn_volume_refresh(
+    sender: &ComponentSender<Osd>,
+    volume: &Property<Volume>,
+    muted: &Property<bool>,
+    token: CancellationToken,
+) {
+    let volume = volume.clone();
+    let muted = muted.clone();
+
+    watch_cancellable_throttled!(
+        sender,
+        token,
+        VOLUME_THROTTLE,
+        [volume.watch(), muted.watch()],
+        |out| {
+            let _ = out.send(OsdCmd::DisplayedValueChanged);
+        }
+    );
 }

--- a/docs/config/osd.md
+++ b/docs/config/osd.md
@@ -9,6 +9,11 @@ outline: [2, 3]
 
 On-screen display overlay for transient events like volume and brightness.
 
+The `auto-*` keys control whether a change *opens* the overlay. An overlay
+that is already open always tracks its device's value, and that tracking
+never restarts the dismiss timer — though a change that also re-triggers
+the automatic display does.
+
 ## General
 
 | Field | Type | Default | Description |
@@ -28,11 +33,43 @@ to allow fullscreen tearing.
 
 :::
 
+## Automatic display
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `auto-speaker` | bool | `true` | Show the speaker OSD automatically when output volume or mute changes. |
+| `auto-microphone` | bool | `true` | Show the microphone OSD automatically when input volume or mute changes. |
+| `auto-brightness` | bool | `true` | Show the brightness OSD automatically when display brightness changes. |
+| `auto-toggles` | bool | `true` | Show the OSD automatically when caps, num, or scroll lock is pressed. |
+
+::: details More about `auto-speaker`
+
+Turn off to only show it on demand via `wayle osd speaker`.
+
+:::
+
+::: details More about `auto-microphone`
+
+Turn off to only show it on demand via `wayle osd mic`.
+
+:::
+
+::: details More about `auto-brightness`
+
+Turn off when an external daemon adjusts brightness continuously, so the
+overlay isn't permanently on screen. `wayle osd brightness` still works.
+
+:::
+
 ## Default configuration
 
 ```toml
 [osd]
 enabled = true
+auto-speaker = true
+auto-microphone = true
+auto-brightness = true
+auto-toggles = true
 position = "bottom"
 duration = 2500
 monitor = "primary"

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -26,6 +26,28 @@ wayle media play-pause
 wayle idle toggle
 ```
 
+Show an OSD on demand, even when the value hasn't changed — useful on a
+keybind. Run `wayle osd devices` to see which device names are accepted:
+
+```sh
+wayle osd speaker
+wayle osd mic
+wayle osd brightness intel_backlight
+```
+
+Pair these with the `osd.auto-*` settings to stop an OSD appearing on every
+change. For example, when another program adjusts the backlight continuously:
+
+```sh
+wayle config set osd.auto-brightness false
+```
+
+The `auto-*` settings only control whether a change *opens* the overlay. While
+it is open it keeps tracking the device's value, so an OSD you brought up by
+hand still shows live readings, and that tracking never restarts the dismiss
+timer. With the matching `auto-*` key left on, though, a change to the default
+device also re-triggers the automatic display, which does restart it.
+
 Shell completions for bash, fish, and zsh:
 
 ```sh

--- a/wayle/src/cli/app.rs
+++ b/wayle/src/cli/app.rs
@@ -9,7 +9,7 @@ use clap_complete::Shell;
 use crate::cli::{
     audio::commands::AudioCommands, config::commands::ConfigCommands,
     icons::commands::IconsCommands, idle::commands::IdleCommands, media::commands::MediaCommands,
-    notify::commands::NotifyCommands, panel::commands::PanelCommands,
+    notify::commands::NotifyCommands, osd::commands::OsdCommands, panel::commands::PanelCommands,
     power::commands::PowerCommands, systray::commands::SystrayCommands,
     wallpaper::commands::WallpaperCommands,
 };
@@ -67,6 +67,12 @@ pub enum Commands {
         /// Notification subcommand to execute.
         #[command(subcommand)]
         command: NotifyCommands,
+    },
+    /// On-screen display commands
+    Osd {
+        /// OSD subcommand to execute.
+        #[command(subcommand)]
+        command: OsdCommands,
     },
     /// Panel management commands
     Panel {

--- a/wayle/src/cli/dbus.rs
+++ b/wayle/src/cli/dbus.rs
@@ -3,9 +3,6 @@
 use wayle_ipc::shell_ipc::ShellIpcProxy;
 use zbus::{Connection, Error as ZbusError, fdo::Error as FdoError};
 
-/// Label used when reporting `com.wayle.Shell1` failures.
-const SHELL_SERVICE_NAME: &str = "Shell";
-
 /// Establishes a D-Bus session connection.
 ///
 /// # Errors
@@ -16,13 +13,10 @@ pub async fn session() -> Result<Connection, String> {
         .map_err(|e| format!("Failed to connect to D-Bus session bus: {e}"))
 }
 
-/// Creates a proxy for the shell's `com.wayle.Shell1` interface.
-///
-/// The connection is returned alongside the proxy because dropping it would
-/// invalidate the proxy.
+/// Creates a `ShellIpcProxy` (`com.wayle.Shell1`) for shell commands.
 ///
 /// # Errors
-/// Returns error if D-Bus connection or proxy creation fails.
+/// Returns error if the D-Bus connection or proxy creation fails.
 pub async fn shell_ipc_proxy() -> Result<(Connection, ShellIpcProxy<'static>), String> {
     let connection = session().await?;
 
@@ -33,9 +27,9 @@ pub async fn shell_ipc_proxy() -> Result<(Connection, ShellIpcProxy<'static>), S
     Ok((connection, proxy))
 }
 
-/// Formats a shell IPC D-Bus error for CLI output.
-pub fn format_shell_error(operation: &str, error: ZbusError) -> String {
-    format_error(SHELL_SERVICE_NAME, operation, error)
+/// Formats a shell IPC (`com.wayle.Shell1`) D-Bus error for CLI output.
+pub fn format_ipc_error(operation: &str, error: ZbusError) -> String {
+    format_error("Shell", operation, error)
 }
 
 /// Formats D-Bus errors into user-friendly messages.

--- a/wayle/src/cli/dbus.rs
+++ b/wayle/src/cli/dbus.rs
@@ -1,6 +1,10 @@
 //! Shared D-Bus utilities for CLI commands.
 
+use wayle_ipc::shell_ipc::ShellIpcProxy;
 use zbus::{Connection, Error as ZbusError, fdo::Error as FdoError};
+
+/// Label used when reporting `com.wayle.Shell1` failures.
+const SHELL_SERVICE_NAME: &str = "Shell";
 
 /// Establishes a D-Bus session connection.
 ///
@@ -10,6 +14,28 @@ pub async fn session() -> Result<Connection, String> {
     Connection::session()
         .await
         .map_err(|e| format!("Failed to connect to D-Bus session bus: {e}"))
+}
+
+/// Creates a proxy for the shell's `com.wayle.Shell1` interface.
+///
+/// The connection is returned alongside the proxy because dropping it would
+/// invalidate the proxy.
+///
+/// # Errors
+/// Returns error if D-Bus connection or proxy creation fails.
+pub async fn shell_ipc_proxy() -> Result<(Connection, ShellIpcProxy<'static>), String> {
+    let connection = session().await?;
+
+    let proxy = ShellIpcProxy::new(&connection)
+        .await
+        .map_err(|err| format!("cannot create shell IPC proxy: {err}"))?;
+
+    Ok((connection, proxy))
+}
+
+/// Formats a shell IPC D-Bus error for CLI output.
+pub fn format_shell_error(operation: &str, error: ZbusError) -> String {
+    format_error(SHELL_SERVICE_NAME, operation, error)
 }
 
 /// Formats D-Bus errors into user-friendly messages.

--- a/wayle/src/cli/mod.rs
+++ b/wayle/src/cli/mod.rs
@@ -13,6 +13,8 @@ pub mod idle;
 pub mod media;
 /// Notification control commands
 pub mod notify;
+/// On-screen display commands
+pub mod osd;
 /// Panel management commands
 pub mod panel;
 /// Power profile commands

--- a/wayle/src/cli/osd/commands.rs
+++ b/wayle/src/cli/osd/commands.rs
@@ -1,0 +1,65 @@
+use clap::Subcommand;
+
+use crate::styled_header;
+
+/// On-screen display subcommands.
+#[derive(Subcommand, Debug)]
+#[command(after_long_help = OSD_EXAMPLES)]
+pub enum OsdCommands {
+    /// Show the speaker OSD
+    #[command(after_long_help = DEVICE_MATCHING)]
+    Speaker {
+        /// Output device (omit for the default sink)
+        #[arg(value_name = "DEVICE")]
+        device: Option<String>,
+    },
+
+    /// Show the microphone OSD
+    #[command(after_long_help = DEVICE_MATCHING)]
+    Mic {
+        /// Input device (omit for the default source)
+        #[arg(value_name = "DEVICE")]
+        device: Option<String>,
+    },
+
+    /// Show the display brightness OSD
+    #[command(after_long_help = DEVICE_MATCHING)]
+    Brightness {
+        /// Backlight device (omit for the primary backlight)
+        #[arg(value_name = "DEVICE")]
+        device: Option<String>,
+    },
+
+    /// List devices the show commands can target
+    Devices,
+}
+
+const OSD_EXAMPLES: &str = concat!(
+    styled_header!("Examples:"),
+    "
+  wayle osd speaker                 Show the default sink's volume
+  wayle osd mic                     Show the default source's volume
+  wayle osd brightness              Show the primary backlight
+  wayle osd devices                 List targetable devices
+
+The OSD appears even when the value has not changed, so these pair well with
+keybinds. To stop an OSD appearing on every change, turn off its automatic
+trigger:
+
+  wayle config set osd.auto-brightness false"
+);
+
+const DEVICE_MATCHING: &str = concat!(
+    styled_header!("Device matching:"),
+    "
+Rules are tried in order: PulseAudio index (audio only, from `pactl list short
+sinks`), exact node name, exact description, then a substring of either that
+matches one device. A device name that is only digits is always read as an
+index, never as a substring.
+
+Run `wayle osd devices` for the node names and descriptions.
+
+  wayle osd speaker \"HDMI Audio\"
+  wayle osd speaker alsa_output.pci-0000_00_1f.3.analog-stereo
+  wayle osd speaker 3"
+);

--- a/wayle/src/cli/osd/devices.rs
+++ b/wayle/src/cli/osd/devices.rs
@@ -1,0 +1,55 @@
+//! Lists the devices `wayle osd` can target.
+
+use wayle_ipc::shell_ipc::OsdDeviceInfo;
+
+use super::proxy::{connect, format_error};
+use crate::cli::CliAction;
+
+/// Device kinds in display order, paired with their section heading.
+const SECTIONS: [(&str, &str); 3] = [
+    ("speaker", "Speakers"),
+    ("microphone", "Microphones"),
+    ("brightness", "Displays"),
+];
+
+/// Prints every targetable device grouped by kind, marking defaults with `*`.
+///
+/// # Errors
+/// Returns error if D-Bus communication fails.
+pub async fn execute() -> CliAction {
+    let (_connection, proxy) = connect().await?;
+
+    let devices = proxy
+        .osd_devices()
+        .await
+        .map_err(|err| format_error("list OSD devices", err))?;
+
+    if devices.is_empty() {
+        println!("No OSD devices found");
+        return Ok(());
+    }
+
+    for (kind, heading) in SECTIONS {
+        let matching: Vec<&OsdDeviceInfo> =
+            devices.iter().filter(|device| device.kind == kind).collect();
+
+        if matching.is_empty() {
+            continue;
+        }
+
+        println!("{heading}:");
+
+        for device in matching {
+            let marker = if device.is_default { "*" } else { " " };
+            let label = &device.label;
+
+            if device.id == device.label {
+                println!("  {marker} {label}");
+            } else {
+                println!("  {marker} {label} [{}]", device.id);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/wayle/src/cli/osd/mod.rs
+++ b/wayle/src/cli/osd/mod.rs
@@ -1,0 +1,22 @@
+/// OSD command definitions.
+pub mod commands;
+mod devices;
+mod proxy;
+mod show;
+
+use commands::OsdCommands;
+
+use super::CliAction;
+
+/// Executes on-screen display commands.
+///
+/// # Errors
+/// Returns error if the command execution fails.
+pub async fn execute(command: OsdCommands) -> CliAction {
+    match command {
+        OsdCommands::Speaker { device } => show::speaker(device.as_deref()).await,
+        OsdCommands::Mic { device } => show::microphone(device.as_deref()).await,
+        OsdCommands::Brightness { device } => show::brightness(device.as_deref()).await,
+        OsdCommands::Devices => devices::execute().await,
+    }
+}

--- a/wayle/src/cli/osd/proxy.rs
+++ b/wayle/src/cli/osd/proxy.rs
@@ -1,0 +1,19 @@
+//! D-Bus proxy utilities for OSD commands.
+
+use wayle_ipc::shell_ipc::ShellIpcProxy;
+use zbus::{Connection, Error as ZbusError};
+
+use crate::cli::dbus;
+
+/// Creates a ShellIpcProxy for OSD commands.
+///
+/// # Errors
+/// Returns error if D-Bus connection or proxy creation fails.
+pub async fn connect() -> Result<(Connection, ShellIpcProxy<'static>), String> {
+    dbus::shell_ipc_proxy().await
+}
+
+/// Transforms zbus errors into user-friendly messages.
+pub fn format_error(operation: &str, error: ZbusError) -> String {
+    dbus::format_shell_error(operation, error)
+}

--- a/wayle/src/cli/osd/proxy.rs
+++ b/wayle/src/cli/osd/proxy.rs
@@ -15,5 +15,5 @@ pub async fn connect() -> Result<(Connection, ShellIpcProxy<'static>), String> {
 
 /// Transforms zbus errors into user-friendly messages.
 pub fn format_error(operation: &str, error: ZbusError) -> String {
-    dbus::format_shell_error(operation, error)
+    dbus::format_ipc_error(operation, error)
 }

--- a/wayle/src/cli/osd/show.rs
+++ b/wayle/src/cli/osd/show.rs
@@ -1,0 +1,59 @@
+//! Manual OSD display commands.
+//!
+//! The three targets differ only in which proxy method they call, so they
+//! share one round-trip helper. An empty device string means "the default
+//! device", matching the convention `bar_hide` already uses for monitors.
+
+use super::proxy::{connect, format_error};
+use crate::cli::CliAction;
+
+/// Shows the speaker OSD for `device`, or the default sink when `None`.
+///
+/// # Errors
+/// Returns error if D-Bus communication fails or the device is unknown.
+pub async fn speaker(device: Option<&str>) -> CliAction {
+    let (_connection, proxy) = connect().await?;
+
+    let label = proxy
+        .osd_show_speaker(device.unwrap_or_default())
+        .await
+        .map_err(|err| format_error("show speaker OSD", err))?;
+
+    println!("Speaker OSD: {label}");
+
+    Ok(())
+}
+
+/// Shows the microphone OSD for `device`, or the default source when `None`.
+///
+/// # Errors
+/// Returns error if D-Bus communication fails or the device is unknown.
+pub async fn microphone(device: Option<&str>) -> CliAction {
+    let (_connection, proxy) = connect().await?;
+
+    let label = proxy
+        .osd_show_microphone(device.unwrap_or_default())
+        .await
+        .map_err(|err| format_error("show microphone OSD", err))?;
+
+    println!("Microphone OSD: {label}");
+
+    Ok(())
+}
+
+/// Shows the brightness OSD for `device`, or the primary backlight when `None`.
+///
+/// # Errors
+/// Returns error if D-Bus communication fails or the device is unknown.
+pub async fn brightness(device: Option<&str>) -> CliAction {
+    let (_connection, proxy) = connect().await?;
+
+    let label = proxy
+        .osd_show_brightness(device.unwrap_or_default())
+        .await
+        .map_err(|err| format_error("show brightness OSD", err))?;
+
+    println!("Brightness OSD: {label}");
+
+    Ok(())
+}

--- a/wayle/src/cli/panel/hide.rs
+++ b/wayle/src/cli/panel/hide.rs
@@ -1,5 +1,7 @@
-use super::proxy::{format_ipc_error, shell_ipc_proxy};
-use crate::cli::CliAction;
+use crate::cli::{
+    CliAction,
+    dbus::{format_ipc_error, shell_ipc_proxy},
+};
 
 pub async fn execute(monitor: Option<String>) -> CliAction {
     let (_connection, proxy) = shell_ipc_proxy().await?;

--- a/wayle/src/cli/panel/proxy.rs
+++ b/wayle/src/cli/panel/proxy.rs
@@ -3,13 +3,8 @@
 use std::time::Duration;
 
 use futures::StreamExt;
-use wayle_ipc::{
-    shell::{APP_ID, GtkActionsProxy},
-    shell_ipc::ShellIpcProxy,
-};
-use zbus::{Connection, Error as ZbusError, fdo::DBusProxy};
-
-use crate::cli::dbus;
+use wayle_ipc::shell::{APP_ID, GtkActionsProxy};
+use zbus::{Connection, fdo::DBusProxy};
 
 const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
@@ -88,18 +83,4 @@ pub async fn wait_for_shutdown(connection: &Connection) -> Result<(), String> {
     tokio::time::timeout(SHUTDOWN_TIMEOUT, wait_for_release)
         .await
         .map_err(|_| "Timeout waiting for panel to stop".to_string())?
-}
-
-/// Creates a ShellIpcProxy for shell commands.
-///
-/// # Errors
-///
-/// Returns error if D-Bus connection or proxy creation fails.
-pub async fn shell_ipc_proxy() -> Result<(Connection, ShellIpcProxy<'static>), String> {
-    dbus::shell_ipc_proxy().await
-}
-
-/// Formats a shell IPC D-Bus error for CLI output.
-pub fn format_ipc_error(operation: &str, error: ZbusError) -> String {
-    dbus::format_shell_error(operation, error)
 }

--- a/wayle/src/cli/panel/proxy.rs
+++ b/wayle/src/cli/panel/proxy.rs
@@ -96,16 +96,10 @@ pub async fn wait_for_shutdown(connection: &Connection) -> Result<(), String> {
 ///
 /// Returns error if D-Bus connection or proxy creation fails.
 pub async fn shell_ipc_proxy() -> Result<(Connection, ShellIpcProxy<'static>), String> {
-    let connection = connect().await?;
-
-    let proxy = ShellIpcProxy::new(&connection)
-        .await
-        .map_err(|err| format!("cannot create shell IPC proxy: {err}"))?;
-
-    Ok((connection, proxy))
+    dbus::shell_ipc_proxy().await
 }
 
 /// Formats a shell IPC D-Bus error for CLI output.
 pub fn format_ipc_error(operation: &str, error: ZbusError) -> String {
-    dbus::format_error("Shell", operation, error)
+    dbus::format_shell_error(operation, error)
 }

--- a/wayle/src/cli/panel/show.rs
+++ b/wayle/src/cli/panel/show.rs
@@ -1,5 +1,7 @@
-use super::proxy::{format_ipc_error, shell_ipc_proxy};
-use crate::cli::CliAction;
+use crate::cli::{
+    CliAction,
+    dbus::{format_ipc_error, shell_ipc_proxy},
+};
 
 pub async fn execute(monitor: Option<String>) -> CliAction {
     let (_connection, proxy) = shell_ipc_proxy().await?;

--- a/wayle/src/cli/panel/toggle.rs
+++ b/wayle/src/cli/panel/toggle.rs
@@ -1,5 +1,7 @@
-use super::proxy::{format_ipc_error, shell_ipc_proxy};
-use crate::cli::CliAction;
+use crate::cli::{
+    CliAction,
+    dbus::{format_ipc_error, shell_ipc_proxy},
+};
 
 pub async fn execute(monitor: Option<String>) -> CliAction {
     let (_connection, proxy) = shell_ipc_proxy().await?;

--- a/wayle/src/main.rs
+++ b/wayle/src/main.rs
@@ -45,6 +45,7 @@ fn main() {
             Commands::Icons { command } => cli::icons::execute(command).await,
             Commands::Media { command } => cli::media::execute(command).await,
             Commands::Notify { command } => cli::notify::execute(command).await,
+            Commands::Osd { command } => cli::osd::execute(command).await,
             Commands::Panel { command } => cli::panel::execute(command).await,
             Commands::Power { command } => cli::power::execute(command).await,
             Commands::Systray { command } => cli::systray::execute(command).await,


### PR DESCRIPTION
Implements `wayle osd` commands to manually open OSDs. Also added settings to disable auto OSD open on change (motivation was to make it possible to avoid wluma opening the brightness OSD constantly, and make the brightness keys call `brightnessctl` and then `wayle osd brightness`).