### PR TITLE
feat(hyprsunset): allow using hyprsunset config

### DIFF
--- a/crates/wayle-config/src/schemas/modules/hyprsunset/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/hyprsunset/mod.rs
@@ -29,6 +29,12 @@ pub struct HyprsunsetConfig {
     #[default(String::from("{{ status }}"))]
     pub format: ConfigProperty<String>,
 
+    /// Use hyprsunset's configuration file and time-based profiles instead of
+    /// overriding temperature and gamma.
+    #[serde(rename = "use-hyprsunset-config")]
+    #[default(false)]
+    pub use_hyprsunset_config: ConfigProperty<bool>,
+
     /// Color temperature in Kelvin when filter is enabled. Range: 1000-20000.
     #[serde(rename = "temperature")]
     #[default(5000)]

--- a/crates/wayle-i18n/locales/en-US/config/modules/_hyprsunset.ftl
+++ b/crates/wayle-i18n/locales/en-US/config/modules/_hyprsunset.ftl
@@ -2,6 +2,9 @@
 
 ## Hyprsunset Module Configuration
 
+settings-modules-hyprsunset-use-hyprsunset-config = Use Hyprsunset Configuration
+    .description = Start hyprsunset without temperature or gamma overrides, allowing its configuration file and time-based profiles to apply
+
 settings-modules-hyprsunset-temperature = Temperature
     .description = Color temperature in Kelvin when filter is enabled (1000-20000)
 

--- a/crates/wayle-i18n/locales/fr/config/modules/_hyprsunset.ftl
+++ b/crates/wayle-i18n/locales/fr/config/modules/_hyprsunset.ftl
@@ -2,6 +2,9 @@
 
 ## Configuration du module Hyprsunset
 
+settings-modules-hyprsunset-use-hyprsunset-config = Utiliser la configuration de Hyprsunset
+    .description = Démarrer hyprsunset sans remplacer la température ni le gamma afin d'utiliser son fichier de configuration et ses profils horaires
+
 settings-modules-hyprsunset-temperature = Température
     .description = Température de couleur en Kelvin lorsque le filtre est activé (1000-20000)
 

--- a/crates/wayle-settings/src/pages/modules/hyprsunset.rs
+++ b/crates/wayle-settings/src/pages/modules/hyprsunset.rs
@@ -3,7 +3,7 @@
 use wayle_config::Config;
 
 use crate::{
-    editors::{number::number_u32, text::text},
+    editors::{number::number_u32, text::text, toggle::toggle},
     pages::{
         nav::LeafEntry,
         sections::bar_button::{
@@ -44,6 +44,7 @@ pub(crate) fn entry(config: &Config) -> LeafEntry {
                     title_key: "settings-section-general",
                     items: vec![
                         text(&module.format),
+                        toggle(&module.use_hyprsunset_config),
                         number_u32(&module.temperature),
                         number_u32(&module.gamma),
                         text(&module.icon_off),

--- a/crates/wayle-shell/src/shell/bar/modules/hyprsunset/helpers.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprsunset/helpers.rs
@@ -102,14 +102,23 @@ fn parse_numeric_response(response: &str, command: &str) -> Option<u32> {
     }
 }
 
-pub(super) async fn start(temperature: u32, gamma: u32) -> io::Result<()> {
-    Command::new("hyprsunset")
-        .arg("-t")
-        .arg(temperature.to_string())
-        .arg("-g")
-        .arg(gamma.to_string())
-        .spawn()?;
+pub(super) async fn start(overrides: Option<(u32, u32)>) -> io::Result<()> {
+    start_command(overrides).spawn()?;
     Ok(())
+}
+
+fn start_command(overrides: Option<(u32, u32)>) -> Command {
+    let mut command = Command::new("hyprsunset");
+
+    if let Some((temperature, gamma)) = overrides {
+        command
+            .arg("-t")
+            .arg(temperature.to_string())
+            .arg("-g")
+            .arg(gamma.to_string());
+    }
+
+    command
 }
 
 pub(super) async fn stop() -> io::Result<()> {
@@ -177,6 +186,25 @@ mod tests {
     #[test]
     fn select_icon_disabled() {
         assert_eq!(select_icon(false, "sun", "moon"), "sun");
+    }
+
+    #[test]
+    fn start_command_with_overrides() {
+        let command = start_command(Some((4500, 80)));
+        let args: Vec<String> = command
+            .as_std()
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect();
+
+        assert_eq!(args, ["-t", "4500", "-g", "80"]);
+    }
+
+    #[test]
+    fn start_command_without_overrides() {
+        let command = start_command(None);
+
+        assert!(command.as_std().get_args().next().is_none());
     }
 
     #[test]

--- a/crates/wayle-shell/src/shell/bar/modules/hyprsunset/methods.rs
+++ b/crates/wayle-shell/src/shell/bar/modules/hyprsunset/methods.rs
@@ -14,6 +14,7 @@ impl HyprsunsetModule {
         let enabled = self.enabled;
         let temp = config.temperature.get();
         let gamma = config.gamma.get();
+        let use_hyprsunset_config = config.use_hyprsunset_config.get();
 
         debug!(current_enabled = enabled, "toggle_filter called");
 
@@ -23,8 +24,9 @@ impl HyprsunsetModule {
                 let _ = helpers::stop().await;
                 HyprsunsetCmd::StateChanged(None)
             } else {
-                debug!(temp, gamma, "starting hyprsunset");
-                let _ = helpers::start(temp, gamma).await;
+                debug!(temp, gamma, use_hyprsunset_config, "starting hyprsunset");
+                let overrides = (!use_hyprsunset_config).then_some((temp, gamma));
+                let _ = helpers::start(overrides).await;
                 HyprsunsetCmd::StateChanged(Some(helpers::HyprsunsetState { temp, gamma }))
             }
         });

--- a/docs/config/modules/hyprsunset.md
+++ b/docs/config/modules/hyprsunset.md
@@ -22,6 +22,7 @@ right = ["hyprsunset"]
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `format` | string | `"{{ status }}"` | Format string for the label. |
+| `use-hyprsunset-config` | bool | `false` | Use hyprsunset's configuration file and time-based profiles instead of overriding temperature and gamma. |
 | `temperature` | u32 | `5000` | Color temperature in Kelvin when filter is enabled. Range: 1000-20000. |
 | `gamma` | u32 | `100` | Display gamma percentage when filter is enabled. Range: 0-200. |
 | `icon-off` | string | `"ld-sun-symbolic"` | Icon when filter is disabled (showing normal daylight colors). |
@@ -74,6 +75,7 @@ right = ["hyprsunset"]
 ```toml
 [modules.hyprsunset]
 format = "{{ status }}"
+use-hyprsunset-config = false
 temperature = 5000
 gamma = 100
 icon-off = "ld-sun-symbolic"


### PR DESCRIPTION
<img width="1902" height="2088" alt="image" src="https://github.com/user-attachments/assets/5f824712-267c-4489-a3e2-28e696caf57f" />

`Wayle` ignores `hyprsunset.conf` by passing temperature and gamma explicitly. I added a flag to use conf defaults. 

I didn't write any rust code before. I made the changes by using `Gpt 5.6 Sol`. I validated it works by building `wayle` locally I toggled the flag and validated run parameters of `hyprsunset` successfully.
