### PR TITLE
fix(cli): resolve bundled icons at runtime so `icons setup` works in release builds

### DIFF
--- a/wayle/src/cli/icons/setup.rs
+++ b/wayle/src/cli/icons/setup.rs
@@ -1,28 +1,59 @@
-use std::{fs, path::Path};
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
 
 use wayle_icons::IconRegistry;
 
 use crate::cli::CliAction;
 
-const RESOURCES_DIR: &str = concat!(
+/// Bundled icons in a source checkout, for development builds. Compile-time
+/// only: in a release binary this resolves to the build machine's checkout.
+const DEV_RESOURCES_DIR: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/../resources/icons/hicolor/scalable/actions"
 );
+
+/// Bundled icons relative to the executable or a system data directory.
+const ICONS_SUBPATH: &str = "icons/hicolor/scalable/actions";
+
+/// Candidate locations for the bundled icons, in lookup order: next to the
+/// executable (extracted release archive), system data directories (distro
+/// packages), then the source checkout (development builds).
+fn resource_candidates() -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Some(exe_dir) = env::current_exe()
+        .ok()
+        .and_then(|exe| exe.parent().map(Path::to_path_buf))
+    {
+        candidates.push(exe_dir.join(ICONS_SUBPATH));
+    }
+
+    candidates.push(PathBuf::from("/usr/share/wayle").join(ICONS_SUBPATH));
+    candidates.push(PathBuf::from("/usr/local/share/wayle").join(ICONS_SUBPATH));
+    candidates.push(PathBuf::from(DEV_RESOURCES_DIR));
+
+    candidates
+}
 
 /// Installs bundled icons from the resources directory.
 ///
 /// # Errors
 ///
-/// Returns error if source directory doesn't exist or copy fails.
+/// Returns error if no bundled icons are found or copy fails.
 pub fn execute() -> CliAction {
-    let source_dir = Path::new(RESOURCES_DIR);
-
-    if !source_dir.exists() {
+    let candidates = resource_candidates();
+    let Some(source_dir) = candidates.iter().find(|path| path.exists()) else {
         return Err(format!(
-            "Resources directory not found: {}",
-            source_dir.display()
+            "Bundled icons not found. Searched:\n{}",
+            candidates
+                .iter()
+                .map(|path| format!("  {}", path.display()))
+                .collect::<Vec<_>>()
+                .join("\n")
         ));
-    }
+    };
 
     let registry = IconRegistry::new().map_err(|err| err.to_string())?;
     let dest_dir = registry.icons_dir();


### PR DESCRIPTION
## Problem

`wayle icons setup` is broken in every packaged build. It locates the bundled icons with a **compile-time** path (`env!("CARGO_MANIFEST_DIR")/../resources/...`), which in CI-built release binaries bakes in the runner's workspace:

```
$ wayle icons setup
Error: Resources directory not found: /__w/wayle/wayle/wayle/../resources/icons/hicolor/scalable/actions
```

This fails even though the release archive ships the icons right next to the binary, and it means packaged installs (release tarball, AUR `wayle-bin`) have no way to install or refresh the bundled set.

The practical fallout is worse than a failed command: users who set up icons under an older version and then upgraded across the grappa **v1 → v2** icon format change are left with stale stroke-based v1 SVGs on disk, which a v2-era shell renders as filled-in silhouettes (bluetooth rune with its counters filled, night-light reduced to a dot) — with no supported way to fix it.

## Fix

Resolve the resources directory at **runtime**, first existing candidate wins:

1. `<exe_dir>/icons/hicolor/scalable/actions` — extracted release-archive layout
2. `/usr/share/wayle/…` and `/usr/local/share/wayle/…` — distro packages that install the shipped `icons/` directory
3. the `CARGO_MANIFEST_DIR` path — development builds (`cargo run` from a checkout), unchanged behavior

On no match, the error now lists every searched location instead of one baked-in path.

## Testing

- `cargo check` / `cargo clippy -p wayle` clean, `cargo fmt` applied
- From a source checkout (candidate 3): installs all 361 bundled icons (verified against a sandboxed `XDG_DATA_HOME`)
- Simulated release layout — binary copied beside an `icons/` tree (candidate 1): resolves exe-relative and installs
- Real-world validation: manually applying the equivalent copy on an AUR `wayle-bin` 0.7.0 install fixed the mangled-icon rendering described above

## Note for packagers

With candidate 2 in place, distro packages can simply install the release archive's `icons/` directory to `/usr/share/wayle/` and `wayle icons setup` will find it (the AUR `wayle-bin` PKGBUILD currently drops the `icons/` directory entirely — I'll flag that to its maintainer separately).
