### PR TITLE
feat: added support for custom upower devices

### DIFF
--- a/crates/wayle-config/src/schemas/modules/battery/mod.rs
+++ b/crates/wayle-config/src/schemas/modules/battery/mod.rs
@@ -126,6 +126,11 @@ pub struct BatteryConfig {
     #[default(ClickAction::None)]
     pub scroll_down: ConfigProperty<ClickAction>,
 
+    /// Custom UPower device path. Defaults to the display device. Use `upower --dump` to list available devices.
+    #[serde(rename = "custom-upower-device")]
+    #[default(String::from("/org/freedesktop/UPower/devices/DisplayDevice"))]
+    pub custom_upower_device: ConfigProperty<String>,
+
     /// Dynamic color thresholds based on battery percentage.
     ///
     /// Entries are checked in order; the last matching entry wins for each

--- a/crates/wayle-shell/src/bootstrap/mod.rs
+++ b/crates/wayle-shell/src/bootstrap/mod.rs
@@ -29,7 +29,7 @@ use wayle_power_profiles::PowerProfilesService;
 use wayle_sysinfo::SysinfoService;
 use wayle_systray::{SystemTrayService, types::TrayMode};
 use wayle_wallpaper::WallpaperService;
-use zbus::{Connection, fdo::DBusProxy};
+use zbus::{Connection, fdo::DBusProxy, zvariant::OwnedObjectPath};
 
 use crate::{
     services::{IdleInhibitService, ShellIpcService},
@@ -208,7 +208,21 @@ async fn init_core_services(
 
     let startup_duration = modules.idle_inhibit.startup_duration.get();
 
-    let battery_task = tokio::spawn(BatteryService::new());
+    let battery_cfg = config.modules.battery.custom_upower_device.get();
+    let mut battery_builder = BatteryService::builder();
+    if !battery_cfg.is_empty() {
+        match OwnedObjectPath::try_from(battery_cfg.as_str()) {
+            Ok(path) => battery_builder = battery_builder.device_path(path),
+            Err(err) => {
+                warn!(
+                    error = %err,
+                    path = %battery_cfg,
+                    "Invalid UPower device path in config, using DisplayDevice"
+                );
+            }
+        }
+    }
+    let battery_task = tokio::spawn(battery_builder.build());
     let brightness_task = tokio::spawn(BrightnessService::new());
     let network_task = tokio::spawn(NetworkService::new());
     let wallpaper_cfg = config.wallpaper.clone();

--- a/docs/config/modules/battery.md
+++ b/docs/config/modules/battery.md
@@ -36,6 +36,7 @@ right = ["battery"]
 | `format` | string | `"{{ percent }}%"` | Format string for the label. |
 | `label-max-length` | u32 | `0` | Max label characters before truncation with ellipsis. Set to 0 to disable. |
 | `thresholds` | array of [`ThresholdEntry`](/config/types#threshold-entry) | `[]` | Dynamic color thresholds based on battery percentage. |
+| `custom-upower-device` | string | `"/org/freedesktop/UPower/devices/DisplayDevice"` |  Overrides the default DisplayDevice from upower |
 
 ::: details More about `level-icons`
 


### PR DESCRIPTION
Fixes #355 

## Objective
In my system, upower those not expose capacity for the DisplayDevice, so i was not able to see the battery health in the dropdown menu.
## Solution
I added a new config option and updated the BatteryService builder to use the custom device when available
## Test Plan
- cargo fmt --all -- --check
- cargo clippy --workspaces